### PR TITLE
QOL improvements for `arcade chat`

### DIFF
--- a/arcade/arcade/cli/main.py
+++ b/arcade/arcade/cli/main.py
@@ -13,7 +13,7 @@ from rich.markup import escape
 from rich.table import Table
 from rich.text import Text
 
-from arcade.cli.authn import check_existing_login, LocalAuthCallbackServer
+from arcade.cli.authn import LocalAuthCallbackServer, check_existing_login
 from arcade.cli.utils import (
     OrderCommands,
     create_cli_catalog,
@@ -158,12 +158,13 @@ def chat(
         console.print(chat_header)
 
         while True:
-            user_input = console.print(
-                f"\n[magenta][bold]User[/bold] {user_attribution}:[/magenta] "
-            )
+            console.print(f"\n[magenta][bold]User[/bold] {user_attribution}:[/magenta] ")
+
             # Use input() instead of console.input() to leverage readline history
             user_input = input()
-            readline.add_history(user_input)  # Add the input to history
+
+            # Add the input to history
+            readline.add_history(user_input)
 
             messages.append({"role": "user", "content": user_input})
 

--- a/arcade/arcade/cli/utils.py
+++ b/arcade/arcade/cli/utils.py
@@ -3,7 +3,6 @@ from typing import TYPE_CHECKING
 import typer
 from openai.resources.chat.completions import ChatCompletionChunk, Stream
 from rich.console import Console
-from rich.live import Live
 from rich.markdown import Markdown
 from typer.core import TyperGroup
 from typer.models import Context


### PR DESCRIPTION
Includes these improvements:
- Up-arrow loads your previous message history in the session (if available)
- Shows the target engine URL when the chat starts
- Shows the model name in the chat: e.g. `Assistant (gpt-4o-mini): `
- URLs are re-written as clickable markdown links in the chat output
- mypy cleanup