### PR TITLE
Fix empty X search result bug

### DIFF
--- a/toolkits/x/arcade_x/tools/utils.py
+++ b/toolkits/x/arcade_x/tools/utils.py
@@ -9,7 +9,7 @@ def get_tweet_url(tweet_id: str) -> str:
 
 def parse_search_recent_tweets_response(response: Response) -> str:
     """
-    Parse the response from the X API search recent tweets endpoint.
+    Parses response from the X API search recent tweets endpoint.
     Returns a JSON string with the tweets data.
 
     Example parsed response:
@@ -27,6 +27,9 @@ def parse_search_recent_tweets_response(response: Response) -> str:
         },
     ]
     """
+    if response.status_code != 200:
+        return json.dumps({"tweets": []})
+
     tweets_data = json.loads(response.text)
 
     if not sanity_check_tweets_data(tweets_data):


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/4419dee1-bbfb-4fc3-a3bd-882e13f12919)


Now:
![image](https://github.com/user-attachments/assets/00cd1fe6-7766-4d51-a328-af2211b9c1ac)
