### PR TITLE
Update arcade up to use arcade-engine

### DIFF
--- a/arcade/arcade/cli/launcher.py
+++ b/arcade/arcade/cli/launcher.py
@@ -160,7 +160,7 @@ def _build_engine_command(engine_config: str) -> list[str]:
     Returns:
         The command as a list.
     """
-    engine_bin = shutil.which("engine")
+    engine_bin = shutil.which("arcade-engine")
     if not engine_bin:
         console.print(
             "❌ Engine binary not found, refer to the installation guide at "


### PR DESCRIPTION
Fixes the binary name from `engine` to `arcade-engine`