### PR TITLE
Generate poetry.lock before caching

### DIFF
--- a/.github/actions/setup-poetry-env/action.yml
+++ b/.github/actions/setup-poetry-env/action.yml
@@ -20,6 +20,10 @@ runs:
       with:
         virtualenvs-in-project: true
 
+    - name: Generate poetry.lock
+      run: cd arcade && poetry lock --no-update
+      shell: bash
+
     - name: Load cached venv
       id: cached-poetry-dependencies
       uses: actions/cache@v4


### PR DESCRIPTION
Our Github Actions build cache step is subtly broken. (see comment below)