### PR TITLE
Poll for auth completion in `arcade chat`

### DIFF
--- a/arcade/arcade/cli/main.py
+++ b/arcade/arcade/cli/main.py
@@ -244,17 +244,19 @@ def chat(
 
             history.append({"role": "user", "content": user_input})
 
-            history, tool_messages, tool_authorization = handle_chat_interaction(
-                client, model, history, user_email, stream
-            )
+            chat_result = handle_chat_interaction(client, model, history, user_email, stream)
+            history = chat_result.history
+            tool_messages = chat_result.tool_messages
+            tool_authorization = chat_result.tool_authorization
 
             # wait for tool authorizations to complete, if any
             if is_authorization_pending(tool_authorization):
-                wait_for_authorization_completion(client, tool_authorization)
+                with console.status("Waiting for you to authorize the action...", spinner="dots"):
+                    wait_for_authorization_completion(client, tool_authorization)
                 # re-run the chat request now that authorization is complete
-                history, tool_messages, _ = handle_chat_interaction(
-                    client, model, history, user_email, stream
-                )
+                chat_result = handle_chat_interaction(client, model, history, user_email, stream)
+                history = chat_result.history
+                tool_messages = chat_result.tool_messages
 
             if debug:
                 display_tool_messages(tool_messages)

--- a/toolkits/google/arcade_google/tools/utils.py
+++ b/toolkits/google/arcade_google/tools/utils.py
@@ -2,7 +2,7 @@ import datetime
 import re
 from base64 import urlsafe_b64decode
 from enum import Enum
-from typing import Any, Optional, dict
+from typing import Any, Optional
 
 from bs4 import BeautifulSoup
 


### PR DESCRIPTION
This PR re-organizes arcade chat implementation and also adds polling for auth response to complete (if any)


### arcade chat streaming with auth:
![Screenshot 2024-09-25 at 11 28 45 AM](https://github.com/user-attachments/assets/c351fce7-060a-4060-b215-6b5d05028216)  

### arcade chat without streaming with auth:
![Screenshot 2024-09-25 at 11 33 08 AM](https://github.com/user-attachments/assets/29a6c5ad-857c-47e6-92d9-52ec87ff88c9)
