### PR TITLE
Resend Chat request with authentication

### DIFF
--- a/arcade/arcade/cli/main.py
+++ b/arcade/arcade/cli/main.py
@@ -267,7 +267,7 @@ def chat(
                     wait_for_authorization_completion(client, tool_authorization)
                 # re-run the chat request now that authorization is complete
                 try:
-                    history.append(history[-2])
+                    history.pop()
                     chat_result = handle_chat_interaction(
                         client, model, history, user_email, stream
                     )


### PR DESCRIPTION
Currently with arcade chat, when we send a request that requires tool authentication, it sends the message then, waits for authentication, then resends the current chat history. However we resend the authntication link as the latest message instead of resending the message that prompted the authentication link.

OpenAI ignores this and continues, however Anthropic errors because it sees the history as

-User message {Get me sams last 5 tweets}
-Assistant message {Please go to this URL and authorize the action: }

instead of 
-User message {Get me sams last 5 tweets}
-Assistant message {Please go to this URL and authorize the action: }
-User message {Get me sams last 5 tweets}

Having an assistant message as the latest message in a request is invalid for anthropic