### PR TITLE
Update arcade version in web toolkit toml

### DIFF
--- a/toolkits/web/pyproject.toml
+++ b/toolkits/web/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Arcade AI <dev@arcade-ai.com>"]
 
 [tool.poetry.dependencies]
 python = "^3.10"
-arcade-ai = "^0.1.0"
+arcade-ai = "0.1.*"
 firecrawl-py = "^1.3.1"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
When #110 was merged the build failed with:
```
9.372 Installing toolkit ./toolkits/arcade_web-2024.10.17.dev0-py3-none-any.whl
9.687 Processing ./toolkits/arcade_web-2024.10.17.dev0-py3-none-any.whl
9.749 Collecting firecrawl-py<2.0.0,>=1.3.1
9.872   Downloading firecrawl_py-1.3.1-py3-none-any.whl (15 kB)
9.911 ERROR: Could not find a version that satisfies the requirement arcade-ai<0.2.0,>=0.1.0 (from arcade-web) (from versions: 0.0.1, 0.0.13)
9.911 ERROR: No matching distribution found for arcade-ai<0.2.0,>=0.1.0
```

and I believe this fixes the issue