### PR TITLE
Fix issues in arcade show

### DIFF
--- a/arcade/arcade/cli/main.py
+++ b/arcade/arcade/cli/main.py
@@ -130,10 +130,10 @@ def new(
 )
 def show(
     toolkit: Optional[str] = typer.Option(
-        None, "-t", "--toolkit", help="The toolkit to show the tools of"
+        None, "-T", "--toolkit", help="The toolkit to show the tools of"
     ),
     tool: Optional[str] = typer.Option(
-        None, "-T", "--tool", help="The specific tool to show details for"
+        None, "-t", "--tool", help="The specific tool to show details for"
     ),
     host: Optional[str] = typer.Option(
         None,
@@ -176,8 +176,8 @@ def show(
                 (
                     t
                     for t in tools
-                    if t.get_fully_qualified_name().name == tool
-                    or str(t.get_fully_qualified_name()) == tool
+                    if t.get_fully_qualified_name().name.lower() == tool.lower()
+                    or str(t.get_fully_qualified_name()).lower() == tool.lower()
                 ),
                 None,
             )

--- a/arcade/arcade/cli/utils.py
+++ b/arcade/arcade/cli/utils.py
@@ -42,6 +42,7 @@ def create_cli_catalog(
     Load toolkits from the python environment.
     """
     if toolkit:
+        toolkit = toolkit.lower()
         try:
             prefixed_toolkit = "arcade_" + toolkit
             toolkits = [Toolkit.from_package(prefixed_toolkit)]


### PR DESCRIPTION
# PR Description
1. `arcade show` only supported lowercase args for toolkit and tools. This PR allows the user to use capitalization and the tool/toolkit will still be displayed.
2. `arcade show -T` is now for showing a toolkit and `arcade show -t` is now for showing a tool.