### PR TITLE
fix: runtime error when OTEL is not enabled

### DIFF
--- a/arcade/arcade/actor/core/base.py
+++ b/arcade/arcade/actor/core/base.py
@@ -55,6 +55,8 @@ class BaseActor(Actor):
 
         self.secret = self._set_secret(secret, disable_auth)
         self.environment = os.environ.get("ARCADE_ENVIRONMENT", "local")
+
+        self.tool_counter = None
         if otel_meter:
             self.tool_counter = otel_meter.create_counter(
                 "tool_call", "requests", "Total number of tools called"

--- a/arcade/pyproject.toml
+++ b/arcade/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "arcade-ai"
-version = "0.1.0"
+version = "0.1.1"
 description = ""
 packages = [
     {include="arcade", from="."}


### PR DESCRIPTION
If an `otel_meter` is not passed when constructing the actor (which is allowed, it's an optional param), the actor would later crash at runtime.