### PR TITLE
fix: readline error on Windows

### DIFF
--- a/arcade/arcade/cli/main.py
+++ b/arcade/arcade/cli/main.py
@@ -1,6 +1,5 @@
 import asyncio
 import os
-import readline
 import threading
 import uuid
 import webbrowser
@@ -234,6 +233,14 @@ def chat(
     """
     Chat with a language model.
     """
+    try:
+        import readline
+    except ImportError:
+        console.print(
+            "Readline is not available on this platform. Command history will be limited.",
+            style="dim",
+        )
+
     config = validate_and_get_config()
     base_url = compute_base_url(force_tls, force_no_tls, host, port)
 

--- a/arcade/pyproject.toml
+++ b/arcade/pyproject.toml
@@ -37,6 +37,7 @@ scikit-learn = {version = "^1.5.0", optional = true}
 pytz = {version = "^2024.1", optional = true}
 python-dateutil = {version = "^2.8.2", optional = true}
 
+pyreadline3 = {version = "^3.5.4", platform = "win32"}
 [tool.poetry.extras]
 fastapi = ["fastapi", "uvicorn", "opentelemetry-instrumentation-fastapi", "opentelemetry-exporter-otlp-proto-http", "opentelemetry-exporter-otlp-proto-common"]
 evals = ["scipy", "numpy", "scikit-learn", "pytz", "python-dateutil"]


### PR DESCRIPTION
With this change, `pyreadline3` is automatically installed on OS `win32` only. Linux/Mac doesn't need it.