### PR TITLE
fix: Wait for healthy actor in arcade dev

### DIFF
--- a/arcade/arcade/cli/launcher.py
+++ b/arcade/arcade/cli/launcher.py
@@ -277,7 +277,7 @@ def _manage_processes(
             console.print("Starting actor server...", style="bold green")
             actor_process = _start_process("Actor", actor_cmd, debug=debug)
 
-            _wait_for_healthy_actor(actor_host, actor_port)
+            _wait_for_healthy_actor(actor_process, actor_host, actor_port)
 
             # Start the engine
             console.print("Starting engine...", style="bold green")
@@ -359,9 +359,11 @@ def _start_process(
         raise RuntimeError(f"Failed to start {name}")
 
 
-def _wait_for_healthy_actor(actor_host: str, actor_port: int) -> None:
+def _wait_for_healthy_actor(
+    actor_process: subprocess.Popen, actor_host: str, actor_port: int
+) -> None:
     """Wait until an HTTP request to `host:port/actor/health` returns 200"""
-    while True:
+    while not actor_process.poll():
         time.sleep(1)
         try:
             conn = http.client.HTTPConnection(actor_host, actor_port, timeout=1)

--- a/arcade/arcade/cli/launcher.py
+++ b/arcade/arcade/cli/launcher.py
@@ -375,6 +375,7 @@ def _wait_for_healthy_actor(
         except (socket.gaierror, http.client.HTTPException, ConnectionRefusedError, TimeoutError):
             pass  # Handle expected exceptions gracefully
         console.print("Waiting for actor to start...", style="bold yellow")
+    console.print("Actor is healthy", style="bold green")
 
 
 def _stream_output(process: subprocess.Popen, name: str) -> None:

--- a/arcade/arcade/cli/launcher.py
+++ b/arcade/arcade/cli/launcher.py
@@ -375,6 +375,8 @@ def _wait_for_healthy_actor(
         except (socket.gaierror, http.client.HTTPException, ConnectionRefusedError, TimeoutError):
             pass  # Handle expected exceptions gracefully
         console.print("Waiting for actor to start...", style="bold yellow")
+
+    time.sleep(1)
     console.print("Actor is healthy", style="bold green")
 
 

--- a/arcade/arcade/cli/launcher.py
+++ b/arcade/arcade/cli/launcher.py
@@ -363,7 +363,8 @@ def _wait_for_healthy_actor(
     actor_process: subprocess.Popen, actor_host: str, actor_port: int
 ) -> None:
     """Wait until an HTTP request to `host:port/actor/health` returns 200"""
-    while not actor_process.poll():
+
+    while not actor_process.poll():  # Stop waiting if the actor process has exited
         time.sleep(1)
         try:
             conn = http.client.HTTPConnection(actor_host, actor_port, timeout=1)
@@ -376,7 +377,7 @@ def _wait_for_healthy_actor(
             pass  # Handle expected exceptions gracefully
         console.print("Waiting for actor to start...", style="bold yellow")
 
-    time.sleep(1)
+    time.sleep(1)  # Wait just a little longer for everything to settle (discovered experimentally)
     console.print("Actor is healthy", style="bold green")
 
 

--- a/arcade/arcade/core/config_model.py
+++ b/arcade/arcade/core/config_model.py
@@ -123,11 +123,10 @@ class Config(BaseConfig):
                 "Invalid credentials.yaml file. Please ensure it is a valid YAML file."
             )
 
-        if not hasattr(config_data, "cloud"):
+        if "cloud" not in config_data:
             raise ValueError("Invalid credentials.yaml file. Expected a 'cloud' key.")
 
         try:
-            print(config_data)
             return cls(**config_data["cloud"])
         except ValidationError as e:
             # Get only the errors with {type:missing} and combine them

--- a/arcade/arcade/core/config_model.py
+++ b/arcade/arcade/core/config_model.py
@@ -118,7 +118,16 @@ class Config(BaseConfig):
 
         config_data = yaml.safe_load(config_file_path.read_text())
 
+        if config_data is None:
+            raise ValueError(
+                "Invalid credentials.yaml file. Please ensure it is a valid YAML file."
+            )
+
+        if not hasattr(config_data, "cloud"):
+            raise ValueError("Invalid credentials.yaml file. Expected a 'cloud' key.")
+
         try:
+            print(config_data)
             return cls(**config_data["cloud"])
         except ValidationError as e:
             # Get only the errors with {type:missing} and combine them

--- a/arcade/pyproject.toml
+++ b/arcade/pyproject.toml
@@ -38,6 +38,7 @@ pytz = {version = "^2024.1", optional = true}
 python-dateutil = {version = "^2.8.2", optional = true}
 
 pyreadline3 = {version = "^3.5.4", platform = "win32"}
+types-requests = "^2.32.0.20241016"
 [tool.poetry.extras]
 fastapi = ["fastapi", "uvicorn", "opentelemetry-instrumentation-fastapi", "opentelemetry-exporter-otlp-proto-http", "opentelemetry-exporter-otlp-proto-common"]
 evals = ["scipy", "numpy", "scikit-learn", "pytz", "python-dateutil"]

--- a/arcade/pyproject.toml
+++ b/arcade/pyproject.toml
@@ -38,7 +38,6 @@ pytz = {version = "^2024.1", optional = true}
 python-dateutil = {version = "^2.8.2", optional = true}
 
 pyreadline3 = {version = "^3.5.4", platform = "win32"}
-types-requests = "^2.32.0.20241016"
 [tool.poetry.extras]
 fastapi = ["fastapi", "uvicorn", "opentelemetry-instrumentation-fastapi", "opentelemetry-exporter-otlp-proto-http", "opentelemetry-exporter-otlp-proto-common"]
 evals = ["scipy", "numpy", "scikit-learn", "pytz", "python-dateutil"]


### PR DESCRIPTION
Context: Currently, `arcade dev` starts the actor process and then waits a hardcoded amount of time (2sec) for the actor to start up. This isn't enough time on some slower machines, which leads to the engine trying to start but failing.

Fix: Wait until the actor is healthy according to its own `/actor/health` endpoint.