### PR TITLE
fix: No output from arcade login when already logged in

### DIFF
--- a/arcade/arcade/cli/authn.py
+++ b/arcade/arcade/cli/authn.py
@@ -133,14 +133,12 @@ def check_existing_login() -> bool:
         try:
             with open(config_file_path) as f:
                 config: dict[str, Any] = yaml.safe_load(f)
-            api_key = config.get("api", {}).get("key")
-            email = config.get("user", {}).get("email")
+            cloud_config = config.get("cloud", {})
+            api_key = cloud_config.get("api", {}).get("key")
+            email = cloud_config.get("user", {}).get("email")
 
             if api_key and email:
-                console.print(
-                    f"You're already logged in as {email}. "
-                    f"Delete {config_file_path} to log in as a different user."
-                )
+                console.print(f"You're already logged in as {email}. ", style="bold green")
                 return True
         except yaml.YAMLError:
             console.print(

--- a/arcade/arcade/cli/main.py
+++ b/arcade/arcade/cli/main.py
@@ -64,6 +64,7 @@ def login(
     """
 
     if check_existing_login():
+        console.print("Delete ~/.arcade/credentials.yaml to log in as a different user.\n")
         return
 
     # Start the HTTP server in a new thread


### PR DESCRIPTION
I ran into this and was scratching my head why `arcade login` was exiting with no output.

Fix: Get config data from the new top-level object we introduced.