### PR TITLE
Fix log that stated the number of tools found in toolkit

### DIFF
--- a/arcade/arcade/cli/serve.py
+++ b/arcade/arcade/cli/serve.py
@@ -103,7 +103,8 @@ def serve_default_actor(
     else:
         logger.info("Serving the following toolkits:")
         for toolkit in toolkits:
-            logger.info(f"  - {toolkit.name} ({toolkit.package_name}): {len(toolkit.tools)} tools")
+            num_tools = sum(len(tools) for tools in toolkit.tools.values())
+            logger.info(f"  - {toolkit.name} ({toolkit.package_name}): {num_tools} tools")
 
     actor_secret = os.environ.get("ARCADE_ACTOR_SECRET")
     if not disable_auth and not actor_secret:


### PR DESCRIPTION
The original log was counting the number of files in the toolkit module. This PR fixes this such that it counts the number of tools in the toolkit.