### PR TITLE
fix: arcade dev waits forever if no toolkits are installed

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -40,6 +40,17 @@
       "cwd": "${workspaceFolder}"
     },
     {
+      "name": "Debug `arcade dev`",
+      "type": "python",
+      "request": "launch",
+      "program": "${workspaceFolder}/arcade/run_cli.py",
+      "args": ["dev", "-c", "~/Team/Engine/config.dev.yaml", "-e", "~/Team/Engine/.env"],
+      "console": "integratedTerminal",
+      "jinja": true,
+      "justMyCode": true,
+      "cwd": "${workspaceFolder}"
+    },
+    {
       "name": "Debug `arcade evals -d` on current file",
       "type": "python",
       "request": "launch",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -44,7 +44,7 @@
       "type": "python",
       "request": "launch",
       "program": "${workspaceFolder}/arcade/run_cli.py",
-      "args": ["dev", "-c", "~/Team/Engine/config.dev.yaml", "-e", "~/Team/Engine/.env"],
+      "args": ["dev"],
       "console": "integratedTerminal",
       "jinja": true,
       "justMyCode": true,

--- a/arcade/arcade/cli/launcher.py
+++ b/arcade/arcade/cli/launcher.py
@@ -364,7 +364,7 @@ def _wait_for_healthy_actor(
 ) -> None:
     """Wait until an HTTP request to `host:port/actor/health` returns 200"""
 
-    while not actor_process.poll():  # Stop waiting if the actor process has exited
+    while actor_process.poll() is None:  # Continue waiting UNLESS the actor process has exited
         time.sleep(1)
         try:
             conn = http.client.HTTPConnection(actor_host, actor_port, timeout=1)

--- a/arcade/arcade/cli/serve.py
+++ b/arcade/arcade/cli/serve.py
@@ -98,13 +98,12 @@ def serve_default_actor(
 
     toolkits = Toolkit.find_all_arcade_toolkits()
     if not toolkits:
-        logger.error("No toolkits found in Python environment. Exiting...")
-        return
-    else:
-        logger.info("Serving the following toolkits:")
-        for toolkit in toolkits:
-            num_tools = sum(len(tools) for tools in toolkit.tools.values())
-            logger.info(f"  - {toolkit.name} ({toolkit.package_name}): {num_tools} tools")
+        raise RuntimeError("No toolkits found in Python environment.")
+
+    logger.info("Serving the following toolkits:")
+    for toolkit in toolkits:
+        num_tools = sum(len(tools) for tools in toolkit.tools.values())
+        logger.info(f"  - {toolkit.name} ({toolkit.package_name}): {num_tools} tools")
 
     actor_secret = os.environ.get("ARCADE_ACTOR_SECRET")
     if not disable_auth and not actor_secret:


### PR DESCRIPTION
Fixes an edge case where the actor doesn't start because no toolkits are installed in the local environment, but `arcade dev` keeps waiting for a healthy actor.