### PR TITLE
Minor QOL improvement for arcade chat

### DIFF
--- a/arcade/arcade/cli/main.py
+++ b/arcade/arcade/cli/main.py
@@ -265,6 +265,8 @@ def chat(
 
             # Use input() instead of console.input() to leverage readline history
             user_input = input()
+            while not user_input.strip():
+                user_input = input()
 
             # Add the input to history
             readline.add_history(user_input)


### PR DESCRIPTION
# PR Description
Do not send request if `user_input.strip()` is empty.