### PR TITLE
Add `local` flag to `arcade show`

### DIFF
--- a/arcade/arcade/cli/main.py
+++ b/arcade/arcade/cli/main.py
@@ -142,7 +142,13 @@ def show(
         DEFAULT_ENGINE_HOST,
         "-h",
         "--host",
-        help="The Arcade Engine address to send chat requests to.",
+        help="The Arcade Engine address to show the tools/toolkits of.",
+    ),
+    local: bool = typer.Option(
+        False,
+        "--local",
+        "-l",
+        help="Show the local environment's catalog instead of an Arcade Engine's catalog.",
     ),
     port: Optional[int] = typer.Option(
         None,
@@ -165,9 +171,8 @@ def show(
     """
     Show the available toolkits or detailed information about a specific tool.
     """
-    local_hosts = ["localhost", "127.0.0.1", "0.0.0.0"]  # noqa: S104
     try:
-        if host in local_hosts:
+        if local:
             catalog = create_cli_catalog(toolkit=toolkit)
             tools = [t.definition for t in list(catalog)]
         else:

--- a/arcade/arcade/cli/utils.py
+++ b/arcade/arcade/cli/utils.py
@@ -78,6 +78,8 @@ def compute_base_url(
     """
     Compute the base URL for the Arcade Engine from the provided overrides.
 
+    Treats 127.0.0.1 and 0.0.0.0 as aliases for localhost.
+
     force_no_tls takes precedence over force_tls. For example, if both are set to True,
     the resulting URL will use http.
 
@@ -102,6 +104,9 @@ def compute_base_url(
     Returns:
         str: The fully constructed URL for the Arcade Engine.
     """
+    # "Use 127.0.0.1" and "0.0.0.0" as aliases for "localhost"
+    host = "localhost" if host in ["127.0.0.1", "0.0.0.0"] else host  # noqa: S104
+
     # Determine TLS setting based on input flags
     if force_no_tls:
         is_tls = False


### PR DESCRIPTION
* `-h localhost`, `-h 127.0.0.1`, and `-h 0.0.0.0` shows the tools that are in the local engine's catalog
* `--local` show the tools that are in the local environment.