### PR TITLE
CLI Improvements

### DIFF
--- a/arcade/arcade/cli/utils.py
+++ b/arcade/arcade/cli/utils.py
@@ -6,7 +6,6 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Union, cast
 from urllib.parse import urlencode, urlparse
-from uuid import UUID
 
 import idna
 import typer
@@ -156,7 +155,7 @@ def compute_engine_base_url(
         return f"{protocol}://{encoded_host}"
 
 
-def compute_login_url(host: str, state: UUID, port: int | None) -> str:
+def compute_login_url(host: str, state: str, port: int | None) -> str:
     """
     Compute the full URL for the CLI login endpoint.
     """

--- a/arcade/arcade/cli/utils.py
+++ b/arcade/arcade/cli/utils.py
@@ -162,7 +162,7 @@ def compute_login_url(host: str, state: str, port: int | None) -> str:
     callback_uri = "http://localhost:9905/callback"
     params = urlencode({"callback_uri": callback_uri, "state": state})
 
-    port = port if port else "8000"
+    port = port if port else 8000
 
     login_base_url = (
         f"http://localhost:{port}"

--- a/arcade/tests/cli/test_utils.py
+++ b/arcade/tests/cli/test_utils.py
@@ -1,8 +1,9 @@
 import pytest
 
-from arcade.cli.utils import compute_engine_base_url
+from arcade.cli.utils import compute_engine_base_url, compute_login_url
 
-DEFAULT_HOST = "api.arcade-ai.com"
+DEFAULT_CLOUD_HOST = "cloud.arcade-ai.com"
+DEFAULT_ENGINE_HOST = "api.arcade-ai.com"
 LOCALHOST = "localhost"
 DEFAULT_PORT = None
 DEFAULT_FORCE_TLS = False
@@ -14,7 +15,7 @@ DEFAULT_FORCE_NO_TLS = False
     [
         pytest.param(
             {
-                "host_input": DEFAULT_HOST,
+                "host_input": DEFAULT_ENGINE_HOST,
                 "port_input": DEFAULT_PORT,
                 "force_tls": DEFAULT_FORCE_TLS,
                 "force_no_tls": DEFAULT_FORCE_NO_TLS,
@@ -34,7 +35,7 @@ DEFAULT_FORCE_NO_TLS = False
         ),
         pytest.param(
             {
-                "host_input": DEFAULT_HOST,
+                "host_input": DEFAULT_ENGINE_HOST,
                 "port_input": 9099,
                 "force_tls": DEFAULT_FORCE_TLS,
                 "force_no_tls": DEFAULT_FORCE_NO_TLS,
@@ -54,7 +55,7 @@ DEFAULT_FORCE_NO_TLS = False
         ),
         pytest.param(
             {
-                "host_input": DEFAULT_HOST,
+                "host_input": DEFAULT_ENGINE_HOST,
                 "port_input": DEFAULT_PORT,
                 "force_tls": True,
                 "force_no_tls": DEFAULT_FORCE_NO_TLS,
@@ -74,7 +75,7 @@ DEFAULT_FORCE_NO_TLS = False
         ),
         pytest.param(
             {
-                "host_input": DEFAULT_HOST,
+                "host_input": DEFAULT_ENGINE_HOST,
                 "port_input": 9099,
                 "force_tls": True,
                 "force_no_tls": DEFAULT_FORCE_NO_TLS,
@@ -94,7 +95,7 @@ DEFAULT_FORCE_NO_TLS = False
         ),
         pytest.param(
             {
-                "host_input": DEFAULT_HOST,
+                "host_input": DEFAULT_ENGINE_HOST,
                 "port_input": DEFAULT_PORT,
                 "force_tls": DEFAULT_FORCE_TLS,
                 "force_no_tls": True,
@@ -114,7 +115,7 @@ DEFAULT_FORCE_NO_TLS = False
         ),
         pytest.param(
             {
-                "host_input": DEFAULT_HOST,
+                "host_input": DEFAULT_ENGINE_HOST,
                 "port_input": 9099,
                 "force_tls": DEFAULT_FORCE_TLS,
                 "force_no_tls": True,
@@ -134,7 +135,7 @@ DEFAULT_FORCE_NO_TLS = False
         ),
         pytest.param(
             {
-                "host_input": DEFAULT_HOST,
+                "host_input": DEFAULT_ENGINE_HOST,
                 "port_input": DEFAULT_PORT,
                 "force_tls": True,
                 "force_no_tls": True,
@@ -154,7 +155,7 @@ DEFAULT_FORCE_NO_TLS = False
         ),
         pytest.param(
             {
-                "host_input": DEFAULT_HOST,
+                "host_input": DEFAULT_ENGINE_HOST,
                 "port_input": 9099,
                 "force_tls": True,
                 "force_no_tls": True,
@@ -193,3 +194,34 @@ def test_compute_base_url(inputs: dict, expected_output: str):
     )
 
     assert base_url == expected_output
+
+
+@pytest.mark.parametrize(
+    "inputs, expected_output",
+    [
+        pytest.param(
+            {"host_input": DEFAULT_CLOUD_HOST, "port_input": DEFAULT_PORT, "state": "123"},
+            "https://cloud.arcade-ai.com/api/v1/auth/cli_login?callback_uri=http%3A%2F%2Flocalhost%3A9905%2Fcallback&state=123",
+            id="default",
+        ),
+        pytest.param(
+            {"host_input": "localhost", "port_input": 9099, "state": "123"},
+            "http://localhost:9099/api/v1/auth/cli_login?callback_uri=http%3A%2F%2Flocalhost%3A9905%2Fcallback&state=123",
+            id="localhost with custom port",
+        ),
+        pytest.param(
+            {"host_input": "localhost", "port_input": DEFAULT_PORT, "state": "123"},
+            "http://localhost:8000/api/v1/auth/cli_login?callback_uri=http%3A%2F%2Flocalhost%3A9905%2Fcallback&state=123",
+            id="localhost",
+        ),
+        pytest.param(
+            {"host_input": DEFAULT_CLOUD_HOST, "port_input": 8000, "state": "123"},
+            "https://cloud.arcade-ai.com/api/v1/auth/cli_login?callback_uri=http%3A%2F%2Flocalhost%3A9905%2Fcallback&state=123",
+            id="cloud host with an ignored custom port",
+        ),
+    ],
+)
+def test_compute_login_url(inputs: dict, expected_output: str):
+    login_url = compute_login_url(inputs["host_input"], inputs["state"], inputs["port_input"])
+
+    assert login_url == expected_output

--- a/arcade/tests/cli/test_utils.py
+++ b/arcade/tests/cli/test_utils.py
@@ -1,6 +1,6 @@
 import pytest
 
-from arcade.cli.utils import compute_base_url
+from arcade.cli.utils import compute_engine_base_url
 
 DEFAULT_HOST = "api.arcade-ai.com"
 LOCALHOST = "localhost"
@@ -185,7 +185,7 @@ DEFAULT_FORCE_NO_TLS = False
     ],
 )
 def test_compute_base_url(inputs: dict, expected_output: str):
-    base_url = compute_base_url(
+    base_url = compute_engine_base_url(
         inputs["force_tls"],
         inputs["force_no_tls"],
         inputs["host_input"],


### PR DESCRIPTION
1. Fixes bug where arcade login doesn't work for localhost
    - `arcade login -h localhost` will open login page at `http://localhost:8000/...`
    - Optionally specify the port: `arcade login -h localhost -p 8000`


3. Adds `local` flag to `arcade show`
    - `-h localhost`, `-h 127.0.0.1`, and `-h 0.0.0.0` shows the tools that are in the local engine's catalog
    - `--local` show the tools that are in the local environment.