### PR TITLE
Add readme and description to PyPi Project Page

### DIFF
--- a/arcade/pyproject.toml
+++ b/arcade/pyproject.toml
@@ -1,7 +1,8 @@
 [tool.poetry]
 name = "arcade-ai"
 version = "0.1.1"
-description = ""
+description = "Arcade AI Python SDK and CLI"
+readme = "../README.md"
 packages = [
     {include="arcade", from="."}
 ]


### PR DESCRIPTION
# PR Description
Currently the [Arcade AI PyPi Page](https://pypi.org/project/arcade-ai/) doesn't have a description. This PR adds that.