### PR TITLE
Support Discord as an Auth provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ This connects to the Arcade Cloud Engine (`api.arcade-ai.com`) with all pre-buil
 
 For example, try:
 
-```
+```text
 User (dev@arcade-ai.com):
 > star the ArcadeAI/arcade-ai repo on Github
 ```
@@ -96,7 +96,7 @@ Arcade AI will prompt you to authorize with GitHub and will star the [ArcadeAI/a
 
 You'll see:
 
-```
+```text
 Assistant (gpt-4o):
 I starred the ArcadeAI/arcade-ai repo on Github for you!
 ```

--- a/arcade/arcade/core/auth.py
+++ b/arcade/arcade/core/auth.py
@@ -29,6 +29,12 @@ class OAuth2(ToolAuthorization):
     """The scope(s) needed for the authorized action."""
 
 
+class Discord(OAuth2):
+    """Marks a tool as requiring Discord authorization."""
+
+    provider_id: str = "discord"
+
+
 class Google(OAuth2):
     """Marks a tool as requiring Google authorization."""
 

--- a/arcade/arcade/sdk/auth/__init__.py
+++ b/arcade/arcade/sdk/auth/__init__.py
@@ -1,4 +1,5 @@
 from arcade.core.auth import (
+    Discord,
     GitHub,
     Google,
     LinkedIn,
@@ -11,6 +12,7 @@ from arcade.core.auth import (
 )
 
 __all__ = [
+    "Discord",
     "GitHub",
     "Google",
     "LinkedIn",


### PR DESCRIPTION
This supports Discord as an auth provider. It depends on the next release of the Arcade Engine to work, so ~we'll hold off on merging for now.~ we'll do it live!