### PR TITLE
Update auth `provider_id`

### DIFF
--- a/arcade/arcade/core/auth.py
+++ b/arcade/arcade/core/auth.py
@@ -13,14 +13,14 @@ class ToolAuthorization(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    provider_kind: str
+    provider_id: str
     """The unique provider kind configured in Arcade."""
 
     provider_type: AuthProviderType
     """The type of the authorization provider."""
 
-    provider_id: Optional[str] = None
-    """Optional unique identifier to distinguish between multiple providers of the same kind."""
+    id: Optional[str] = None
+    """Optional unique identifier to distinguish between multiple providers with the same provider_id."""
 
 
 class OAuth2(ToolAuthorization):
@@ -35,58 +35,58 @@ class OAuth2(ToolAuthorization):
 class Atlassian(OAuth2):
     """Marks a tool as requiring Atlassian authorization."""
 
-    provider_kind: str = "atlassian"
+    provider_id: str = "atlassian"
 
 
 class Discord(OAuth2):
     """Marks a tool as requiring Discord authorization."""
 
-    provider_kind: str = "discord"
+    provider_id: str = "discord"
 
 
 class Dropbox(OAuth2):
     """Marks a tool as requiring Dropbox authorization."""
 
-    provider_kind: str = "dropbox"
+    provider_id: str = "dropbox"
 
 
 class Google(OAuth2):
     """Marks a tool as requiring Google authorization."""
 
-    provider_kind: str = "google"
+    provider_id: str = "google"
 
 
 class Slack(OAuth2):
     """Marks a tool as requiring Slack (user token) authorization."""
 
-    provider_kind: str = "slack"
+    provider_id: str = "slack"
 
 
 class GitHub(OAuth2):
     """Marks a tool as requiring GitHub App authorization."""
 
-    provider_kind: str = "github"
+    provider_id: str = "github"
 
 
 class X(OAuth2):
     """Marks a tool as requiring X (Twitter) authorization."""
 
-    provider_kind: str = "x"
+    provider_id: str = "x"
 
 
 class LinkedIn(OAuth2):
     """Marks a tool as requiring LinkedIn authorization."""
 
-    provider_kind: str = "linkedin"
+    provider_id: str = "linkedin"
 
 
 class Spotify(OAuth2):
     """Marks a tool as requiring Spotify authorization."""
 
-    provider_kind: str = "spotify"
+    provider_id: str = "spotify"
 
 
 class Zoom(OAuth2):
     """Marks a tool as requiring Zoom authorization."""
 
-    provider_kind: str = "zoom"
+    provider_id: str = "zoom"

--- a/arcade/arcade/core/auth.py
+++ b/arcade/arcade/core/auth.py
@@ -14,7 +14,7 @@ class ToolAuthorization(BaseModel):
     model_config = ConfigDict(frozen=True)
 
     provider_id: Optional[str] = None
-    """The provider ID configured in Arcade."""
+    """The provider ID configured in Arcade that acts as an alias to well-known configuration."""
 
     provider_type: AuthProviderType
     """The type of the authorization provider."""

--- a/arcade/arcade/core/auth.py
+++ b/arcade/arcade/core/auth.py
@@ -20,7 +20,7 @@ class ToolAuthorization(BaseModel):
     """The type of the authorization provider."""
 
     id: Optional[str] = None
-    """Optional unique identifier to distinguish between multiple providers with the same provider_id."""
+    """A provider's unique identifier, allowing the tool to specify a specific authorization provider. Recommended for private tools only."""
 
     scopes: Optional[list[str]] = None
     """The scope(s) needed for the authorized action."""

--- a/arcade/arcade/core/auth.py
+++ b/arcade/arcade/core/auth.py
@@ -14,10 +14,13 @@ class ToolAuthorization(BaseModel):
     model_config = ConfigDict(frozen=True)
 
     provider_kind: str
-    """The unique provider kind (ID) configured in Arcade."""
+    """The unique provider kind configured in Arcade."""
 
     provider_type: AuthProviderType
     """The type of the authorization provider."""
+
+    provider_id: Optional[str] = None
+    """Optional unique identifier to distinguish between multiple providers of the same kind."""
 
 
 class OAuth2(ToolAuthorization):

--- a/arcade/arcade/core/auth.py
+++ b/arcade/arcade/core/auth.py
@@ -13,8 +13,8 @@ class ToolAuthorization(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    provider_id: str
-    """The unique provider ID configured in Arcade."""
+    provider_kind: str
+    """The unique provider kind (ID) configured in Arcade."""
 
     provider_type: AuthProviderType
     """The type of the authorization provider."""
@@ -32,58 +32,58 @@ class OAuth2(ToolAuthorization):
 class Atlassian(OAuth2):
     """Marks a tool as requiring Atlassian authorization."""
 
-    provider_id: str = "atlassian"
+    provider_kind: str = "atlassian"
 
 
 class Discord(OAuth2):
     """Marks a tool as requiring Discord authorization."""
 
-    provider_id: str = "discord"
+    provider_kind: str = "discord"
 
 
 class Dropbox(OAuth2):
     """Marks a tool as requiring Dropbox authorization."""
 
-    provider_id: str = "dropbox"
+    provider_kind: str = "dropbox"
 
 
 class Google(OAuth2):
     """Marks a tool as requiring Google authorization."""
 
-    provider_id: str = "google"
+    provider_kind: str = "google"
 
 
 class Slack(OAuth2):
     """Marks a tool as requiring Slack (user token) authorization."""
 
-    provider_id: str = "slack"
+    provider_kind: str = "slack"
 
 
 class GitHub(OAuth2):
     """Marks a tool as requiring GitHub App authorization."""
 
-    provider_id: str = "github"
+    provider_kind: str = "github"
 
 
 class X(OAuth2):
     """Marks a tool as requiring X (Twitter) authorization."""
 
-    provider_id: str = "x"
+    provider_kind: str = "x"
 
 
 class LinkedIn(OAuth2):
     """Marks a tool as requiring LinkedIn authorization."""
 
-    provider_id: str = "linkedin"
+    provider_kind: str = "linkedin"
 
 
 class Spotify(OAuth2):
     """Marks a tool as requiring Spotify authorization."""
 
-    provider_id: str = "spotify"
+    provider_kind: str = "spotify"
 
 
 class Zoom(OAuth2):
     """Marks a tool as requiring Zoom authorization."""
 
-    provider_id: str = "zoom"
+    provider_kind: str = "zoom"

--- a/arcade/arcade/core/auth.py
+++ b/arcade/arcade/core/auth.py
@@ -14,7 +14,7 @@ class ToolAuthorization(BaseModel):
     model_config = ConfigDict(frozen=True)
 
     provider_id: str
-    """The unique provider kind configured in Arcade."""
+    """The provider ID configured in Arcade."""
 
     provider_type: AuthProviderType
     """The type of the authorization provider."""

--- a/arcade/arcade/core/auth.py
+++ b/arcade/arcade/core/auth.py
@@ -29,7 +29,7 @@ class ToolAuthorization(BaseModel):
 class OAuth2(ToolAuthorization):
     """Marks a tool as requiring OAuth 2.0 authorization."""
 
-    def __init__(self, *, id: str, scopes: Optional[list[str]] = None):  # noqa: A002
+    def __init__(self, *, id: str | None, scopes: Optional[list[str]] = None):  # noqa: A002
         super().__init__(id=id, scopes=scopes, provider_type=AuthProviderType.oauth2)
 
 
@@ -38,11 +38,17 @@ class Atlassian(OAuth2):
 
     provider_id: str = "atlassian"
 
+    def __init__(self, *, id: Optional[str] = None, scopes: Optional[list[str]] = None):  # noqa: A002
+        super().__init__(id=id, scopes=scopes)
+
 
 class Discord(OAuth2):
     """Marks a tool as requiring Discord authorization."""
 
     provider_id: str = "discord"
+
+    def __init__(self, *, id: Optional[str] = None, scopes: Optional[list[str]] = None):  # noqa: A002
+        super().__init__(id=id, scopes=scopes)
 
 
 class Dropbox(OAuth2):
@@ -50,11 +56,17 @@ class Dropbox(OAuth2):
 
     provider_id: str = "dropbox"
 
+    def __init__(self, *, id: Optional[str] = None, scopes: Optional[list[str]] = None):  # noqa: A002
+        super().__init__(id=id, scopes=scopes)
+
 
 class Google(OAuth2):
     """Marks a tool as requiring Google authorization."""
 
     provider_id: str = "google"
+
+    def __init__(self, *, id: Optional[str] = None, scopes: Optional[list[str]] = None):  # noqa: A002
+        super().__init__(id=id, scopes=scopes)
 
 
 class Slack(OAuth2):
@@ -62,11 +74,17 @@ class Slack(OAuth2):
 
     provider_id: str = "slack"
 
+    def __init__(self, *, id: Optional[str] = None, scopes: Optional[list[str]] = None):  # noqa: A002
+        super().__init__(id=id, scopes=scopes)
+
 
 class GitHub(OAuth2):
     """Marks a tool as requiring GitHub App authorization."""
 
     provider_id: str = "github"
+
+    def __init__(self, *, id: Optional[str] = None, scopes: Optional[list[str]] = None):  # noqa: A002
+        super().__init__(id=id, scopes=scopes)
 
 
 class X(OAuth2):
@@ -74,11 +92,17 @@ class X(OAuth2):
 
     provider_id: str = "x"
 
+    def __init__(self, *, id: Optional[str] = None, scopes: Optional[list[str]] = None):  # noqa: A002
+        super().__init__(id=id, scopes=scopes)
+
 
 class LinkedIn(OAuth2):
     """Marks a tool as requiring LinkedIn authorization."""
 
     provider_id: str = "linkedin"
+
+    def __init__(self, *, id: Optional[str] = None, scopes: Optional[list[str]] = None):  # noqa: A002
+        super().__init__(id=id, scopes=scopes)
 
 
 class Spotify(OAuth2):
@@ -86,8 +110,14 @@ class Spotify(OAuth2):
 
     provider_id: str = "spotify"
 
+    def __init__(self, *, id: Optional[str] = None, scopes: Optional[list[str]] = None):  # noqa: A002
+        super().__init__(id=id, scopes=scopes)
+
 
 class Zoom(OAuth2):
     """Marks a tool as requiring Zoom authorization."""
 
     provider_id: str = "zoom"
+
+    def __init__(self, *, id: Optional[str] = None, scopes: Optional[list[str]] = None):  # noqa: A002
+        super().__init__(id=id, scopes=scopes)

--- a/arcade/arcade/core/auth.py
+++ b/arcade/arcade/core/auth.py
@@ -13,7 +13,7 @@ class ToolAuthorization(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    provider_id: str
+    provider_id: Optional[str] = None
     """The provider ID configured in Arcade."""
 
     provider_type: AuthProviderType
@@ -22,14 +22,15 @@ class ToolAuthorization(BaseModel):
     id: Optional[str] = None
     """Optional unique identifier to distinguish between multiple providers with the same provider_id."""
 
+    scopes: Optional[list[str]] = None
+    """The scope(s) needed for the authorized action."""
+
 
 class OAuth2(ToolAuthorization):
     """Marks a tool as requiring OAuth 2.0 authorization."""
 
-    provider_type: AuthProviderType = AuthProviderType.oauth2
-
-    scopes: Optional[list[str]] = None
-    """The scope(s) needed for the authorized action."""
+    def __init__(self, *, id: str, scopes: Optional[list[str]] = None):  # noqa: A002
+        super().__init__(id=id, scopes=scopes, provider_type=AuthProviderType.oauth2)
 
 
 class Atlassian(OAuth2):

--- a/arcade/arcade/core/catalog.py
+++ b/arcade/arcade/core/catalog.py
@@ -298,6 +298,7 @@ class ToolCatalog(BaseModel):
             new_auth_requirement = ToolAuthRequirement(
                 provider_kind=auth_requirement.provider_kind,
                 provider_type=auth_requirement.provider_type,
+                provider_id=auth_requirement.provider_id,
             )
             if isinstance(auth_requirement, OAuth2):
                 new_auth_requirement.oauth2 = OAuth2Requirement(**auth_requirement.model_dump())

--- a/arcade/arcade/core/catalog.py
+++ b/arcade/arcade/core/catalog.py
@@ -296,9 +296,9 @@ class ToolCatalog(BaseModel):
         auth_requirement = getattr(tool, "__tool_requires_auth__", None)
         if isinstance(auth_requirement, ToolAuthorization):
             new_auth_requirement = ToolAuthRequirement(
-                provider_kind=auth_requirement.provider_kind,
-                provider_type=auth_requirement.provider_type,
                 provider_id=auth_requirement.provider_id,
+                provider_type=auth_requirement.provider_type,
+                id=auth_requirement.id,
             )
             if isinstance(auth_requirement, OAuth2):
                 new_auth_requirement.oauth2 = OAuth2Requirement(**auth_requirement.model_dump())

--- a/arcade/arcade/core/catalog.py
+++ b/arcade/arcade/core/catalog.py
@@ -296,7 +296,7 @@ class ToolCatalog(BaseModel):
         auth_requirement = getattr(tool, "__tool_requires_auth__", None)
         if isinstance(auth_requirement, ToolAuthorization):
             new_auth_requirement = ToolAuthRequirement(
-                provider_id=auth_requirement.provider_id,
+                provider_kind=auth_requirement.provider_kind,
                 provider_type=auth_requirement.provider_type,
             )
             if isinstance(auth_requirement, OAuth2):

--- a/arcade/arcade/core/schema.py
+++ b/arcade/arcade/core/schema.py
@@ -74,7 +74,7 @@ class OAuth2Requirement(BaseModel):
     """Indicates that the tool requires OAuth 2.0 authorization."""
 
     scopes: Optional[list[str]] = None
-    """The scope(s) needed for authorization, if any."""
+    """The scope(s) needed for the authorized action."""
 
 
 class ToolAuthRequirement(BaseModel):
@@ -83,20 +83,20 @@ class ToolAuthRequirement(BaseModel):
     # Provider ID, Type, and ID needed for the Arcade Engine to look up the auth provider.
     # However, the developer generally does not need to set these directly.
     # Instead, they will use:
-    #    @tool(requires_auth=Google(id="my_google_provider123", scopes=["profile", "email"]))
+    #    @tool(requires_auth=Google(scopes=["profile", "email"]))
     # or
-    #    client.auth.authorize(provider=AuthProvider.google, id="my_google_provider123", scopes=["profile", "email"])
+    #    client.auth.authorize(provider=AuthProvider.google, scopes=["profile", "email"])
     #
     # The Arcade SDK translates these into the appropriate provider ID (Google) and type (OAuth2).
     # The only time the developer will set these is if they are using a custom auth provider.
     provider_id: Optional[str] = None
-    """The provider ID."""
+    """The provider ID configured in Arcade that acts as an alias to well-known configuration."""
 
     provider_type: str
-    """The provider type."""
+    """The type of the authorization provider."""
 
     id: Optional[str] = None
-    """Optional unique identifier to distinguish between multiple providers with the same provider_id."""
+    """A provider's unique identifier, allowing the tool to specify a specific authorization provider. Recommended for private tools only."""
 
     oauth2: Optional[OAuth2Requirement] = None
     """The OAuth 2.0 requirement, if any."""

--- a/arcade/arcade/core/schema.py
+++ b/arcade/arcade/core/schema.py
@@ -80,20 +80,23 @@ class OAuth2Requirement(BaseModel):
 class ToolAuthRequirement(BaseModel):
     """A requirement for authorization to use a tool."""
 
-    # Provider Kind and Type needed for the Arcade Engine to look up the auth provider.
+    # Provider Kind, Type, and ID needed for the Arcade Engine to look up the auth provider.
     # However, the developer generally does not need to set these directly.
     # Instead, they will use:
-    #    @tool(requires_auth=Google(scopes=["profile", "email"]))
+    #    @tool(requires_auth=Google(provider_id="my_google_provider123", scopes=["profile", "email"]))
     # or
-    #    client.auth.authorize(provider=AuthProvider.google, scopes=["profile", "email"])
+    #    client.auth.authorize(provider=AuthProvider.google, provider_id="my_google_provider123", scopes=["profile", "email"])
     #
     # The Arcade SDK translates these into the appropriate provider kind and type.
     # The only time the developer will set these is if they are using a custom auth provider.
     provider_kind: Optional[str] = None
-    """A unique provider kind (ID)."""
+    """A unique provider kind"""
 
     provider_type: str
     """The provider type."""
+
+    provider_id: Optional[str] = None
+    """Optional unique identifier to distinguish between multiple providers of the same kind."""
 
     oauth2: Optional[OAuth2Requirement] = None
     """The OAuth 2.0 requirement, if any."""

--- a/arcade/arcade/core/schema.py
+++ b/arcade/arcade/core/schema.py
@@ -80,17 +80,17 @@ class OAuth2Requirement(BaseModel):
 class ToolAuthRequirement(BaseModel):
     """A requirement for authorization to use a tool."""
 
-    # Provider ID and Type needed for the Arcade Engine to look up the auth provider.
+    # Provider Kind and Type needed for the Arcade Engine to look up the auth provider.
     # However, the developer generally does not need to set these directly.
     # Instead, they will use:
     #    @tool(requires_auth=Google(scopes=["profile", "email"]))
     # or
     #    client.auth.authorize(provider=AuthProvider.google, scopes=["profile", "email"])
     #
-    # The Arcade SDK translates these into the appropriate provider ID and type.
+    # The Arcade SDK translates these into the appropriate provider kind and type.
     # The only time the developer will set these is if they are using a custom auth provider.
-    provider_id: Optional[str] = None
-    """A unique provider ID."""
+    provider_kind: Optional[str] = None
+    """A unique provider kind (ID)."""
 
     provider_type: str
     """The provider type."""

--- a/arcade/arcade/core/schema.py
+++ b/arcade/arcade/core/schema.py
@@ -87,7 +87,7 @@ class ToolAuthRequirement(BaseModel):
     # or
     #    client.auth.authorize(provider=AuthProvider.google, id="my_google_provider123", scopes=["profile", "email"])
     #
-    # The Arcade SDK translates these into the appropriate provider id (Google) and type (OAuth2).
+    # The Arcade SDK translates these into the appropriate provider ID (Google) and type (OAuth2).
     # The only time the developer will set these is if they are using a custom auth provider.
     provider_id: Optional[str] = None
     """The provider ID."""

--- a/arcade/arcade/core/schema.py
+++ b/arcade/arcade/core/schema.py
@@ -80,23 +80,23 @@ class OAuth2Requirement(BaseModel):
 class ToolAuthRequirement(BaseModel):
     """A requirement for authorization to use a tool."""
 
-    # Provider Kind, Type, and ID needed for the Arcade Engine to look up the auth provider.
+    # Provider ID, Type, and ID needed for the Arcade Engine to look up the auth provider.
     # However, the developer generally does not need to set these directly.
     # Instead, they will use:
-    #    @tool(requires_auth=Google(provider_id="my_google_provider123", scopes=["profile", "email"]))
+    #    @tool(requires_auth=Google(id="my_google_provider123", scopes=["profile", "email"]))
     # or
-    #    client.auth.authorize(provider=AuthProvider.google, provider_id="my_google_provider123", scopes=["profile", "email"])
+    #    client.auth.authorize(provider=AuthProvider.google, id="my_google_provider123", scopes=["profile", "email"])
     #
     # The Arcade SDK translates these into the appropriate provider kind and type.
     # The only time the developer will set these is if they are using a custom auth provider.
-    provider_kind: Optional[str] = None
+    provider_id: Optional[str] = None
     """A unique provider kind"""
 
     provider_type: str
     """The provider type."""
 
-    provider_id: Optional[str] = None
-    """Optional unique identifier to distinguish between multiple providers of the same kind."""
+    id: Optional[str] = None
+    """Optional unique identifier to distinguish between multiple providers with the same provider_id."""
 
     oauth2: Optional[OAuth2Requirement] = None
     """The OAuth 2.0 requirement, if any."""

--- a/arcade/arcade/core/schema.py
+++ b/arcade/arcade/core/schema.py
@@ -90,7 +90,7 @@ class ToolAuthRequirement(BaseModel):
     # The Arcade SDK translates these into the appropriate provider kind and type.
     # The only time the developer will set these is if they are using a custom auth provider.
     provider_id: Optional[str] = None
-    """A unique provider kind"""
+    """The provider ID."""
 
     provider_type: str
     """The provider type."""

--- a/arcade/arcade/core/schema.py
+++ b/arcade/arcade/core/schema.py
@@ -87,7 +87,7 @@ class ToolAuthRequirement(BaseModel):
     # or
     #    client.auth.authorize(provider=AuthProvider.google, id="my_google_provider123", scopes=["profile", "email"])
     #
-    # The Arcade SDK translates these into the appropriate provider kind and type.
+    # The Arcade SDK translates these into the appropriate provider id (Google) and type (OAuth2).
     # The only time the developer will set these is if they are using a custom auth provider.
     provider_id: Optional[str] = None
     """The provider ID."""

--- a/arcade/tests/sdk/test_tool_decorator.py
+++ b/arcade/tests/sdk/test_tool_decorator.py
@@ -39,7 +39,7 @@ def test_tool_decorator_with_all_options():
         name="TestTool",
         desc="Test description",
         requires_auth=OAuth2(
-            provider_id="example",
+            provider_kind="example",
             scopes=["test_scope", "another.scope"],
         ),
     )

--- a/arcade/tests/sdk/test_tool_decorator.py
+++ b/arcade/tests/sdk/test_tool_decorator.py
@@ -2,7 +2,7 @@ import asyncio
 
 import pytest
 
-from arcade.core.auth import AuthProviderType
+from arcade.core.auth import AuthProviderType, Google
 from arcade.sdk import tool
 from arcade.sdk.auth import OAuth2
 
@@ -35,21 +35,83 @@ async def test_async_function():
     assert result == 3
 
 
-def test_tool_decorator_with_all_options():
+@pytest.mark.parametrize(
+    "auth_class, auth_kwargs, expected_provider_id, expected_id",
+    [
+        (
+            OAuth2,
+            {"id": "my_example_provider123", "scopes": ["test_scope", "another.scope"]},
+            None,
+            "my_example_provider123",
+        ),
+        (Google, {"scopes": ["test_scope", "another.scope"]}, "google", None),
+        (
+            Google,
+            {"id": "my_google_provider123", "scopes": ["test_scope", "another.scope"]},
+            "google",
+            "my_google_provider123",
+        ),
+    ],
+)
+def test_tool_decorator_with_auth_success(
+    auth_class, auth_kwargs, expected_provider_id, expected_id
+):
     @tool(
         name="TestTool",
         desc="Test description",
-        requires_auth=OAuth2(
-            id="my_example_provider123",
-            scopes=["test_scope", "another.scope"],
-        ),
+        requires_auth=auth_class(**auth_kwargs),
     )
     def test_tool(x, y):
         return x + y
 
     assert test_tool.__tool_name__ == "TestTool"
     assert test_tool.__tool_description__ == "Test description"
-    assert test_tool.__tool_requires_auth__.provider_id is None
+    assert test_tool.__tool_requires_auth__.provider_id == expected_provider_id
     assert test_tool.__tool_requires_auth__.provider_type == AuthProviderType.oauth2
-    assert test_tool.__tool_requires_auth__.id == "my_example_provider123"
+    assert test_tool.__tool_requires_auth__.id == expected_id
     assert test_tool.__tool_requires_auth__.scopes == ["test_scope", "another.scope"]
+
+
+@pytest.mark.parametrize(
+    "auth_class, auth_kwargs",
+    [
+        (OAuth2, {"scopes": ["test_scope", "another.scope"]}),
+        (
+            OAuth2,
+            {"provider_id": "my_example_provider123", "scopes": ["test_scope", "another.scope"]},
+        ),
+        (
+            OAuth2,
+            {
+                "provider_id": "my_example_provider_id_123",
+                "id": "my_example_id_123",
+                "scopes": ["test_scope", "another.scope"],
+            },
+        ),
+        (
+            Google,
+            {
+                "provider_id": "my_example_provider_id_123",
+                "scopes": ["test_scope", "another.scope"],
+            },
+        ),
+        (
+            Google,
+            {
+                "provider_id": "my_example_provider_id_123",
+                "id": "my_example_id_123",
+                "scopes": ["test_scope", "another.scope"],
+            },
+        ),
+    ],
+)
+def test_tool_decorator_with_auth_failure(auth_class, auth_kwargs):
+    with pytest.raises(TypeError):
+
+        @tool(
+            name="TestTool",
+            desc="Test description",
+            requires_auth=auth_class(**auth_kwargs),
+        )
+        def test_tool(x, y):
+            return x + y

--- a/arcade/tests/sdk/test_tool_decorator.py
+++ b/arcade/tests/sdk/test_tool_decorator.py
@@ -2,6 +2,7 @@ import asyncio
 
 import pytest
 
+from arcade.core.auth import AuthProviderType
 from arcade.sdk import tool
 from arcade.sdk.auth import OAuth2
 
@@ -39,7 +40,6 @@ def test_tool_decorator_with_all_options():
         name="TestTool",
         desc="Test description",
         requires_auth=OAuth2(
-            provider_id="example",
             id="my_example_provider123",
             scopes=["test_scope", "another.scope"],
         ),
@@ -49,6 +49,7 @@ def test_tool_decorator_with_all_options():
 
     assert test_tool.__tool_name__ == "TestTool"
     assert test_tool.__tool_description__ == "Test description"
-    assert test_tool.__tool_requires_auth__.provider_id == "example"
+    assert test_tool.__tool_requires_auth__.provider_id is None
+    assert test_tool.__tool_requires_auth__.provider_type == AuthProviderType.oauth2
     assert test_tool.__tool_requires_auth__.id == "my_example_provider123"
     assert test_tool.__tool_requires_auth__.scopes == ["test_scope", "another.scope"]

--- a/arcade/tests/sdk/test_tool_decorator.py
+++ b/arcade/tests/sdk/test_tool_decorator.py
@@ -40,6 +40,7 @@ def test_tool_decorator_with_all_options():
         desc="Test description",
         requires_auth=OAuth2(
             provider_kind="example",
+            provider_id="my_example_provider123",
             scopes=["test_scope", "another.scope"],
         ),
     )
@@ -48,4 +49,6 @@ def test_tool_decorator_with_all_options():
 
     assert test_tool.__tool_name__ == "TestTool"
     assert test_tool.__tool_description__ == "Test description"
+    assert test_tool.__tool_requires_auth__.provider_kind == "example"
+    assert test_tool.__tool_requires_auth__.provider_id == "my_example_provider123"
     assert test_tool.__tool_requires_auth__.scopes == ["test_scope", "another.scope"]

--- a/arcade/tests/sdk/test_tool_decorator.py
+++ b/arcade/tests/sdk/test_tool_decorator.py
@@ -39,8 +39,8 @@ def test_tool_decorator_with_all_options():
         name="TestTool",
         desc="Test description",
         requires_auth=OAuth2(
-            provider_kind="example",
-            provider_id="my_example_provider123",
+            provider_id="example",
+            id="my_example_provider123",
             scopes=["test_scope", "another.scope"],
         ),
     )
@@ -49,6 +49,6 @@ def test_tool_decorator_with_all_options():
 
     assert test_tool.__tool_name__ == "TestTool"
     assert test_tool.__tool_description__ == "Test description"
-    assert test_tool.__tool_requires_auth__.provider_kind == "example"
-    assert test_tool.__tool_requires_auth__.provider_id == "my_example_provider123"
+    assert test_tool.__tool_requires_auth__.provider_id == "example"
+    assert test_tool.__tool_requires_auth__.id == "my_example_provider123"
     assert test_tool.__tool_requires_auth__.scopes == ["test_scope", "another.scope"]

--- a/arcade/tests/tool/test_create_tool_definition.py
+++ b/arcade/tests/tool/test_create_tool_definition.py
@@ -49,9 +49,8 @@ def func_with_name_and_description():
 @tool(
     desc="A function that requires authentication",
     requires_auth=OAuth2(
-        provider_id="example",
-        scopes=["scope1", "scope2"],
         id="my_example_provider123",
+        scopes=["scope1", "scope2"],
     ),
 )
 def func_with_auth_requirement():
@@ -269,7 +268,6 @@ def func_with_complex_return() -> dict[str, str]:
             {
                 "requirements": ToolRequirements(
                     authorization=ToolAuthRequirement(
-                        provider_id="example",
                         provider_type="oauth2",
                         id="my_example_provider123",
                         oauth2=OAuth2Requirement(

--- a/arcade/tests/tool/test_create_tool_definition.py
+++ b/arcade/tests/tool/test_create_tool_definition.py
@@ -81,7 +81,6 @@ def func_with_github_auth_requirement():
 @tool(
     desc="A function that requires Slack user authorization",
     requires_auth=Slack(
-        id="my_slack_provider123",
         scopes=["chat:write", "channels:history"],
     ),
 )
@@ -92,7 +91,6 @@ def func_with_slack_user_auth_requirement():
 @tool(
     desc="A function that requires X (Twitter) authorization",
     requires_auth=X(
-        id="my_x_provider123",
         scopes=["tweet.write"],
     ),
 )
@@ -316,7 +314,6 @@ def func_with_complex_return() -> dict[str, str]:
                     authorization=ToolAuthRequirement(
                         provider_id="slack",
                         provider_type="oauth2",
-                        id="my_slack_provider123",
                         oauth2=OAuth2Requirement(
                             scopes=["chat:write", "channels:history"],
                         ),
@@ -324,6 +321,20 @@ def func_with_complex_return() -> dict[str, str]:
                 )
             },
             id="func_with_slack_user_auth_requirement",
+        ),
+        pytest.param(
+            func_with_x_requirement,
+            {
+                "requirements": ToolRequirements(
+                    authorization=ToolAuthRequirement(
+                        provider_id="x",
+                        provider_type="oauth2",
+                        oauth2=OAuth2Requirement(
+                            scopes=["tweet.write"],
+                        ),
+                    )
+                )
+            },
         ),
         # Tests on input params
         pytest.param(

--- a/arcade/tests/tool/test_create_tool_definition.py
+++ b/arcade/tests/tool/test_create_tool_definition.py
@@ -51,6 +51,7 @@ def func_with_name_and_description():
     requires_auth=OAuth2(
         provider_kind="example",
         scopes=["scope1", "scope2"],
+        provider_id="my_example_provider123",
     ),
 )
 def func_with_auth_requirement():
@@ -59,7 +60,10 @@ def func_with_auth_requirement():
 
 @tool(
     desc="A function that requires Google authorization",
-    requires_auth=Google(scopes=["https://www.googleapis.com/auth/gmail.readonly"]),
+    requires_auth=Google(
+        provider_id="my_google_provider123",
+        scopes=["https://www.googleapis.com/auth/gmail.readonly"],
+    ),
 )
 def func_with_google_auth_requirement():
     pass
@@ -67,7 +71,9 @@ def func_with_google_auth_requirement():
 
 @tool(
     desc="A function that requires GitHub authorization",
-    requires_auth=GitHub(),
+    requires_auth=GitHub(
+        provider_id="my_github_provider123",
+    ),
 )
 def func_with_github_auth_requirement():
     pass
@@ -75,7 +81,10 @@ def func_with_github_auth_requirement():
 
 @tool(
     desc="A function that requires Slack user authorization",
-    requires_auth=Slack(scopes=["chat:write", "channels:history"]),
+    requires_auth=Slack(
+        provider_id="my_slack_provider123",
+        scopes=["chat:write", "channels:history"],
+    ),
 )
 def func_with_slack_user_auth_requirement():
     pass
@@ -83,7 +92,10 @@ def func_with_slack_user_auth_requirement():
 
 @tool(
     desc="A function that requires X (Twitter) authorization",
-    requires_auth=X(scopes=["tweet.write"]),
+    requires_auth=X(
+        provider_id="my_x_provider123",
+        scopes=["tweet.write"],
+    ),
 )
 def func_with_x_requirement():
     pass
@@ -259,6 +271,7 @@ def func_with_complex_return() -> dict[str, str]:
                     authorization=ToolAuthRequirement(
                         provider_kind="example",
                         provider_type="oauth2",
+                        provider_id="my_example_provider123",
                         oauth2=OAuth2Requirement(
                             authority="https://example.com/oauth2/auth",
                             scopes=["scope1", "scope2"],
@@ -275,6 +288,7 @@ def func_with_complex_return() -> dict[str, str]:
                     authorization=ToolAuthRequirement(
                         provider_kind="google",
                         provider_type="oauth2",
+                        provider_id="my_google_provider123",
                         oauth2=OAuth2Requirement(
                             scopes=["https://www.googleapis.com/auth/gmail.readonly"],
                         ),
@@ -288,7 +302,10 @@ def func_with_complex_return() -> dict[str, str]:
             {
                 "requirements": ToolRequirements(
                     authorization=ToolAuthRequirement(
-                        provider_kind="github", provider_type="oauth2", oauth2=OAuth2Requirement()
+                        provider_kind="github",
+                        provider_type="oauth2",
+                        provider_id="my_github_provider123",
+                        oauth2=OAuth2Requirement(),
                     )
                 )
             },
@@ -301,6 +318,7 @@ def func_with_complex_return() -> dict[str, str]:
                     authorization=ToolAuthRequirement(
                         provider_kind="slack",
                         provider_type="oauth2",
+                        provider_id="my_slack_provider123",
                         oauth2=OAuth2Requirement(
                             scopes=["chat:write", "channels:history"],
                         ),

--- a/arcade/tests/tool/test_create_tool_definition.py
+++ b/arcade/tests/tool/test_create_tool_definition.py
@@ -49,9 +49,9 @@ def func_with_name_and_description():
 @tool(
     desc="A function that requires authentication",
     requires_auth=OAuth2(
-        provider_kind="example",
+        provider_id="example",
         scopes=["scope1", "scope2"],
-        provider_id="my_example_provider123",
+        id="my_example_provider123",
     ),
 )
 def func_with_auth_requirement():
@@ -61,7 +61,7 @@ def func_with_auth_requirement():
 @tool(
     desc="A function that requires Google authorization",
     requires_auth=Google(
-        provider_id="my_google_provider123",
+        id="my_google_provider123",
         scopes=["https://www.googleapis.com/auth/gmail.readonly"],
     ),
 )
@@ -72,7 +72,7 @@ def func_with_google_auth_requirement():
 @tool(
     desc="A function that requires GitHub authorization",
     requires_auth=GitHub(
-        provider_id="my_github_provider123",
+        id="my_github_provider123",
     ),
 )
 def func_with_github_auth_requirement():
@@ -82,7 +82,7 @@ def func_with_github_auth_requirement():
 @tool(
     desc="A function that requires Slack user authorization",
     requires_auth=Slack(
-        provider_id="my_slack_provider123",
+        id="my_slack_provider123",
         scopes=["chat:write", "channels:history"],
     ),
 )
@@ -93,7 +93,7 @@ def func_with_slack_user_auth_requirement():
 @tool(
     desc="A function that requires X (Twitter) authorization",
     requires_auth=X(
-        provider_id="my_x_provider123",
+        id="my_x_provider123",
         scopes=["tweet.write"],
     ),
 )
@@ -269,9 +269,9 @@ def func_with_complex_return() -> dict[str, str]:
             {
                 "requirements": ToolRequirements(
                     authorization=ToolAuthRequirement(
-                        provider_kind="example",
+                        provider_id="example",
                         provider_type="oauth2",
-                        provider_id="my_example_provider123",
+                        id="my_example_provider123",
                         oauth2=OAuth2Requirement(
                             authority="https://example.com/oauth2/auth",
                             scopes=["scope1", "scope2"],
@@ -286,9 +286,9 @@ def func_with_complex_return() -> dict[str, str]:
             {
                 "requirements": ToolRequirements(
                     authorization=ToolAuthRequirement(
-                        provider_kind="google",
+                        provider_id="google",
                         provider_type="oauth2",
-                        provider_id="my_google_provider123",
+                        id="my_google_provider123",
                         oauth2=OAuth2Requirement(
                             scopes=["https://www.googleapis.com/auth/gmail.readonly"],
                         ),
@@ -302,9 +302,9 @@ def func_with_complex_return() -> dict[str, str]:
             {
                 "requirements": ToolRequirements(
                     authorization=ToolAuthRequirement(
-                        provider_kind="github",
+                        provider_id="github",
                         provider_type="oauth2",
-                        provider_id="my_github_provider123",
+                        id="my_github_provider123",
                         oauth2=OAuth2Requirement(),
                     )
                 )
@@ -316,9 +316,9 @@ def func_with_complex_return() -> dict[str, str]:
             {
                 "requirements": ToolRequirements(
                     authorization=ToolAuthRequirement(
-                        provider_kind="slack",
+                        provider_id="slack",
                         provider_type="oauth2",
-                        provider_id="my_slack_provider123",
+                        id="my_slack_provider123",
                         oauth2=OAuth2Requirement(
                             scopes=["chat:write", "channels:history"],
                         ),

--- a/arcade/tests/tool/test_create_tool_definition.py
+++ b/arcade/tests/tool/test_create_tool_definition.py
@@ -49,7 +49,7 @@ def func_with_name_and_description():
 @tool(
     desc="A function that requires authentication",
     requires_auth=OAuth2(
-        provider_id="example",
+        provider_kind="example",
         scopes=["scope1", "scope2"],
     ),
 )
@@ -257,7 +257,7 @@ def func_with_complex_return() -> dict[str, str]:
             {
                 "requirements": ToolRequirements(
                     authorization=ToolAuthRequirement(
-                        provider_id="example",
+                        provider_kind="example",
                         provider_type="oauth2",
                         oauth2=OAuth2Requirement(
                             authority="https://example.com/oauth2/auth",
@@ -273,7 +273,7 @@ def func_with_complex_return() -> dict[str, str]:
             {
                 "requirements": ToolRequirements(
                     authorization=ToolAuthRequirement(
-                        provider_id="google",
+                        provider_kind="google",
                         provider_type="oauth2",
                         oauth2=OAuth2Requirement(
                             scopes=["https://www.googleapis.com/auth/gmail.readonly"],
@@ -288,7 +288,7 @@ def func_with_complex_return() -> dict[str, str]:
             {
                 "requirements": ToolRequirements(
                     authorization=ToolAuthRequirement(
-                        provider_id="github", provider_type="oauth2", oauth2=OAuth2Requirement()
+                        provider_kind="github", provider_type="oauth2", oauth2=OAuth2Requirement()
                     )
                 )
             },
@@ -299,7 +299,7 @@ def func_with_complex_return() -> dict[str, str]:
             {
                 "requirements": ToolRequirements(
                     authorization=ToolAuthRequirement(
-                        provider_id="slack",
+                        provider_kind="slack",
                         provider_type="oauth2",
                         oauth2=OAuth2Requirement(
                             scopes=["chat:write", "channels:history"],

--- a/schemas/preview/tool_definition.schema.jsonc
+++ b/schemas/preview/tool_definition.schema.jsonc
@@ -153,15 +153,15 @@
               "properties": {
                 "provider_id": {
                   "type": "string",
-                  "description": "The provider ID."
+                  "description": "The provider ID configured in Arcade that acts as an alias to well-known configuration."
                 },
                 "provider_type": {
                   "type": "string",
-                  "description": "The provider type."
+                  "description": "The type of the authorization provider."
                 },
                 "id": {
                   "type": "string",
-                  "description": "Optional unique identifier to distinguish between multiple providers with the same provider_id."
+                  "description": "A provider's unique identifier, allowing the tool to specify a specific authorization provider. Recommended for private tools only."
                 },
                 "oauth2": {
                   "type": "object",

--- a/schemas/preview/tool_definition.schema.jsonc
+++ b/schemas/preview/tool_definition.schema.jsonc
@@ -151,9 +151,9 @@
             {
               "type": "object",
               "properties": {
-                "provider_id": {
+                "provider_kind": {
                   "type": "string",
-                  "description": "A unique provider ID."
+                  "description": "A unique provider kind (ID)."
                 },
                 "provider_type": {
                   "type": "string",
@@ -172,7 +172,7 @@
                   "additionalProperties": false
                 }
               },
-              "required": ["provider_id", "provider_type"],
+              "required": ["provider_kind", "provider_type"],
               "additionalProperties": false
             }
           ]

--- a/schemas/preview/tool_definition.schema.jsonc
+++ b/schemas/preview/tool_definition.schema.jsonc
@@ -151,7 +151,7 @@
             {
               "type": "object",
               "properties": {
-                "provider_kind": {
+                "provider_id": {
                   "type": "string",
                   "description": "A unique provider kind."
                 },
@@ -159,7 +159,7 @@
                   "type": "string",
                   "description": "The provider type."
                 },
-                "provider_id": {
+                "id": {
                   "type": "string",
                   "description": "Optional unique identifier to distinguish between multiple providers of the same kind."
                 },
@@ -176,7 +176,7 @@
                   "additionalProperties": false
                 }
               },
-              "required": ["provider_kind", "provider_type"],
+              "required": ["provider_id", "provider_type"],
               "additionalProperties": false
             }
           ]

--- a/schemas/preview/tool_definition.schema.jsonc
+++ b/schemas/preview/tool_definition.schema.jsonc
@@ -176,7 +176,7 @@
                   "additionalProperties": false
                 }
               },
-              "required": ["provider_id", "provider_type"],
+              "required": ["provider_type"],
               "additionalProperties": false
             }
           ]

--- a/schemas/preview/tool_definition.schema.jsonc
+++ b/schemas/preview/tool_definition.schema.jsonc
@@ -153,11 +153,15 @@
               "properties": {
                 "provider_kind": {
                   "type": "string",
-                  "description": "A unique provider kind (ID)."
+                  "description": "A unique provider kind."
                 },
                 "provider_type": {
                   "type": "string",
                   "description": "The provider type."
+                },
+                "provider_id": {
+                  "type": "string",
+                  "description": "Optional unique identifier to distinguish between multiple providers of the same kind."
                 },
                 "oauth2": {
                   "type": "object",

--- a/schemas/preview/tool_definition.schema.jsonc
+++ b/schemas/preview/tool_definition.schema.jsonc
@@ -153,7 +153,7 @@
               "properties": {
                 "provider_id": {
                   "type": "string",
-                  "description": "A unique provider kind."
+                  "description": "The provider ID."
                 },
                 "provider_type": {
                   "type": "string",
@@ -161,7 +161,7 @@
                 },
                 "id": {
                   "type": "string",
-                  "description": "Optional unique identifier to distinguish between multiple providers of the same kind."
+                  "description": "Optional unique identifier to distinguish between multiple providers with the same provider_id."
                 },
                 "oauth2": {
                   "type": "object",


### PR DESCRIPTION
# PR Description
Well known providers (Google, X, Dropbox, etc.) can optionally have an `id` in addition to their hardcoded `provider_id`. For non well known providers, they must provide an `id`, and the `provider_id` is hardcoded as `None`.

```python
OAuth2() # INVALID
OAuth2(provider_id="abc") # INVALID
OAuth2(id="abc") # VALID
OAuth2(provider_id="abc", id="def") # INVALID
```
```python
Google() # VALID
Google(provider_id="abc") # INVALID
Google(id="abc") # VALID
Google(provider_id="abc", id="def") # INVALID
```
  