### PR TITLE
Fix `/show` for Cloud Engine

### DIFF
--- a/arcade/arcade/cli/show.py
+++ b/arcade/arcade/cli/show.py
@@ -1,0 +1,54 @@
+import typer
+from rich.console import Console
+from rich.markup import escape
+
+from arcade.cli.display import display_tool_details, display_tools_table
+from arcade.cli.utils import create_cli_catalog, get_tools_from_engine
+
+
+def show_logic(
+    toolkit: str | None,
+    tool: str | None,
+    host: str,
+    local: bool,
+    port: int | None,
+    force_tls: bool,
+    force_no_tls: bool,
+    debug: bool,
+) -> None:
+    """Wrapper function for the `arcade show` CLI command
+    Handles the logic for showing tools/toolkits.
+    """
+    console = Console()
+    try:
+        if local:
+            catalog = create_cli_catalog(toolkit=toolkit)
+            tools = [t.definition for t in list(catalog)]
+        else:
+            tools = get_tools_from_engine(host, port, force_tls, force_no_tls, toolkit)
+
+        if tool:
+            # Display detailed information for the specified tool
+            tool_def = next(
+                (
+                    t
+                    for t in tools
+                    if t.get_fully_qualified_name().name.lower() == tool.lower()
+                    or str(t.get_fully_qualified_name()).lower() == tool.lower()
+                ),
+                None,
+            )
+            if not tool_def:
+                console.print(f"❌ Tool '{tool}' not found.", style="bold red")
+                typer.Exit(code=1)
+            else:
+                display_tool_details(tool_def)
+        else:
+            # Display the list of tools as a table
+            display_tools_table(tools)
+
+    except Exception as e:
+        if debug:
+            raise
+        error_message = f"❌ Failed to list tools: {escape(str(e))}"
+        console.print(error_message, style="bold red")

--- a/arcade/arcade/cli/utils.py
+++ b/arcade/arcade/cli/utils.py
@@ -671,6 +671,7 @@ def handle_user_command(
             toolkit=None,
             tool=None,
             host=host,
+            local=False,
             port=port,
             force_tls=force_tls,
             force_no_tls=force_no_tls,

--- a/arcade/tests/cli/test_show.py
+++ b/arcade/tests/cli/test_show.py
@@ -1,0 +1,40 @@
+from unittest.mock import patch
+
+from arcade.cli.show import show_logic
+
+
+def test_show_logic_local_false():
+    with patch("arcade.cli.show.get_tools_from_engine") as mock_get_tools:
+        mock_get_tools.return_value = []
+        show_logic(
+            toolkit=None,
+            tool=None,
+            host="localhost",
+            local=False,
+            port=None,
+            force_tls=False,
+            force_no_tls=False,
+            debug=False,
+        )
+
+        # get_tools_from_engine should be called when local=False
+        mock_get_tools.assert_called_once()
+
+
+def test_show_logic_local_true():
+    with patch("arcade.cli.show.create_cli_catalog") as mock_create_catalog:
+        mock_create_catalog.return_value = []
+
+        show_logic(
+            toolkit=None,
+            tool=None,
+            host="localhost",
+            local=True,
+            port=None,
+            force_tls=False,
+            force_no_tls=False,
+            debug=False,
+        )
+
+        # create_cli_catalog should be called when local=True
+        mock_create_catalog.assert_called_once()


### PR DESCRIPTION
# PR Description
### The following bug was observed: 
* When connected to the cloud engine for `arcade chat`, and the user types `/show`, then the local environment tools are displayed. Instead, the cloud engine's tools should be displayed.

### Why was this bug happening?:
* When a user entered the `/show` command, the CLI Command `show` was being called directly. Since the function was a CLI command, the `local` parameter was not being processed and resolved to its intended value because the Typer CLI interface was being bypassed. So, the conditional `if local:` would always evaluate to `True`.

### How this was fixed:
* I created a wrapper function for the `show` CLI Command. Now, when the user types `/show`, then the wrapper function is called instead of the `show` CLI command. This ensures that all input parameters are resolved to their intended values.