### PR TITLE
Rename inputs -> input to match Engine

### DIFF
--- a/arcade/arcade/cli/display.py
+++ b/arcade/arcade/cli/display.py
@@ -49,7 +49,7 @@ def display_tool_details(tool: ToolDefinition) -> None:
     )
 
     # Inputs Panel
-    inputs = tool.inputs.parameters
+    inputs = tool.input.parameters
     if inputs:
         inputs_table = Table(show_header=True, header_style="bold green")
         inputs_table.add_column("Name", style="cyan")

--- a/arcade/arcade/core/catalog.py
+++ b/arcade/arcade/core/catalog.py
@@ -34,7 +34,7 @@ from arcade.core.schema import (
     ToolAuthRequirement,
     ToolContext,
     ToolDefinition,
-    ToolInputs,
+    ToolInput,
     ToolkitDefinition,
     ToolOutput,
     ToolRequirements,
@@ -317,7 +317,7 @@ class ToolCatalog(BaseModel):
             fully_qualified_name=str(fully_qualified_name),
             description=tool_description,
             toolkit=toolkit_definition,
-            inputs=create_input_definition(tool),
+            input=create_input_definition(tool),
             output=create_output_definition(tool),
             requirements=ToolRequirements(
                 authorization=auth_requirement,
@@ -325,7 +325,7 @@ class ToolCatalog(BaseModel):
         )
 
 
-def create_input_definition(func: Callable) -> ToolInputs:
+def create_input_definition(func: Callable) -> ToolInput:
     """
     Create an input model for a function based on its parameters.
     """
@@ -363,7 +363,7 @@ def create_input_definition(func: Callable) -> ToolInputs:
             )
         )
 
-    return ToolInputs(
+    return ToolInput(
         parameters=input_parameters, tool_context_parameter_name=tool_context_param_name
     )
 

--- a/arcade/arcade/core/executor.py
+++ b/arcade/arcade/core/executor.py
@@ -37,8 +37,8 @@ class ToolExecutor:
             func_args = inputs.model_dump()
 
             # inject ToolContext, if the target function supports it
-            if definition.inputs.tool_context_parameter_name is not None:
-                func_args[definition.inputs.tool_context_parameter_name] = context
+            if definition.input.tool_context_parameter_name is not None:
+                func_args[definition.input.tool_context_parameter_name] = context
 
             # execute the tool function
             if asyncio.iscoroutinefunction(func):

--- a/arcade/arcade/core/schema.py
+++ b/arcade/arcade/core/schema.py
@@ -42,7 +42,7 @@ class InputParameter(BaseModel):
     )
 
 
-class ToolInputs(BaseModel):
+class ToolInput(BaseModel):
     """The inputs that a tool accepts."""
 
     parameters: list[InputParameter]
@@ -179,7 +179,7 @@ class ToolDefinition(BaseModel):
     toolkit: ToolkitDefinition
     """The toolkit that contains the tool."""
 
-    inputs: ToolInputs
+    input: ToolInput
     """The inputs that the tool accepts."""
 
     output: ToolOutput

--- a/arcade/tests/tool/test_create_tool_definition.py
+++ b/arcade/tests/tool/test_create_tool_definition.py
@@ -9,7 +9,7 @@ from arcade.core.schema import (
     OAuth2Requirement,
     ToolAuthRequirement,
     ToolContext,
-    ToolInputs,
+    ToolInput,
     ToolOutput,
     ToolRequirements,
     ValueSchema,
@@ -313,7 +313,7 @@ def func_with_complex_return() -> dict[str, str]:
         pytest.param(
             func_with_non_inferrable_param,
             {
-                "inputs": ToolInputs(
+                "inputs": ToolInput(
                     parameters=[
                         InputParameter(
                             name="param1",
@@ -330,7 +330,7 @@ def func_with_complex_return() -> dict[str, str]:
         pytest.param(
             func_with_renamed_param,
             {
-                "inputs": ToolInputs(
+                "inputs": ToolInput(
                     parameters=[
                         InputParameter(
                             name="ParamOne",
@@ -347,7 +347,7 @@ def func_with_complex_return() -> dict[str, str]:
         pytest.param(
             func_with_enum_param,
             {
-                "inputs": ToolInputs(
+                "inputs": ToolInput(
                     parameters=[
                         InputParameter(
                             name="param1",
@@ -364,7 +364,7 @@ def func_with_complex_return() -> dict[str, str]:
         pytest.param(
             func_with_dict_param,
             {
-                "inputs": ToolInputs(
+                "inputs": ToolInput(
                     parameters=[
                         InputParameter(
                             name="param1",
@@ -381,7 +381,7 @@ def func_with_complex_return() -> dict[str, str]:
         pytest.param(
             func_with_string_literal_param,
             {
-                "inputs": ToolInputs(
+                "inputs": ToolInput(
                     parameters=[
                         InputParameter(
                             name="param1",
@@ -398,7 +398,7 @@ def func_with_complex_return() -> dict[str, str]:
         pytest.param(
             func_with_param_with_default,
             {
-                "inputs": ToolInputs(
+                "inputs": ToolInput(
                     parameters=[
                         InputParameter(
                             name="param1",
@@ -418,7 +418,7 @@ def func_with_complex_return() -> dict[str, str]:
         pytest.param(
             func_with_optional_param,
             {
-                "inputs": ToolInputs(
+                "inputs": ToolInput(
                     parameters=[
                         InputParameter(
                             name="param1",
@@ -438,7 +438,7 @@ def func_with_complex_return() -> dict[str, str]:
         pytest.param(
             func_with_optional_param_with_default_None,
             {
-                "inputs": ToolInputs(
+                "inputs": ToolInput(
                     parameters=[
                         InputParameter(
                             name="param1",
@@ -458,7 +458,7 @@ def func_with_complex_return() -> dict[str, str]:
         pytest.param(
             func_with_optional_param_with_default_value,
             {
-                "inputs": ToolInputs(
+                "inputs": ToolInput(
                     parameters=[
                         InputParameter(
                             name="param1",
@@ -478,7 +478,7 @@ def func_with_complex_return() -> dict[str, str]:
         pytest.param(
             func_with_optional_param_with_bar_syntax,
             {
-                "inputs": ToolInputs(
+                "inputs": ToolInput(
                     parameters=[
                         InputParameter(
                             name="param1",
@@ -498,7 +498,7 @@ def func_with_complex_return() -> dict[str, str]:
         pytest.param(
             func_with_mixed_params,
             {
-                "inputs": ToolInputs(
+                "inputs": ToolInput(
                     parameters=[
                         InputParameter(
                             name="param1",
@@ -523,7 +523,7 @@ def func_with_complex_return() -> dict[str, str]:
         pytest.param(
             func_with_list_param,
             {
-                "inputs": ToolInputs(
+                "inputs": ToolInput(
                     parameters=[
                         InputParameter(
                             name="param1",
@@ -542,7 +542,7 @@ def func_with_complex_return() -> dict[str, str]:
         pytest.param(
             func_with_list_float_param,
             {
-                "inputs": ToolInputs(
+                "inputs": ToolInput(
                     parameters=[
                         InputParameter(
                             name="param1",
@@ -561,7 +561,7 @@ def func_with_complex_return() -> dict[str, str]:
         pytest.param(
             func_with_list_of_enums_param,
             {
-                "inputs": ToolInputs(
+                "inputs": ToolInput(
                     parameters=[
                         InputParameter(
                             name="param1",
@@ -580,7 +580,7 @@ def func_with_complex_return() -> dict[str, str]:
         pytest.param(
             func_with_complex_param,
             {
-                "inputs": ToolInputs(
+                "inputs": ToolInput(
                     parameters=[
                         InputParameter(
                             name="param1",
@@ -597,7 +597,7 @@ def func_with_complex_return() -> dict[str, str]:
         pytest.param(
             func_with_context,
             {
-                "inputs": ToolInputs(
+                "inputs": ToolInput(
                     parameters=[], tool_context_parameter_name="my_context"
                 ),  # ToolContext type is not an input param, but it's stored in the inputs field
             },
@@ -607,7 +607,7 @@ def func_with_complex_return() -> dict[str, str]:
         pytest.param(
             func_with_list_return,
             {
-                "inputs": ToolInputs(parameters=[]),
+                "inputs": ToolInput(parameters=[]),
                 "output": ToolOutput(
                     value_schema=ValueSchema(val_type="array", inner_val_type="string", enum=None),
                     available_modes=["value", "error"],
@@ -619,7 +619,7 @@ def func_with_complex_return() -> dict[str, str]:
         pytest.param(
             func_with_known_list_return,
             {
-                "inputs": ToolInputs(parameters=[]),
+                "inputs": ToolInput(parameters=[]),
                 "output": ToolOutput(
                     value_schema=ValueSchema(val_type="string", enum=["value1", "value2"]),
                     available_modes=["value", "error"],
@@ -631,7 +631,7 @@ def func_with_complex_return() -> dict[str, str]:
         pytest.param(
             func_with_enum_return,
             {
-                "inputs": ToolInputs(parameters=[]),
+                "inputs": ToolInput(parameters=[]),
                 "output": ToolOutput(
                     value_schema=ValueSchema(val_type="string", enum=["foo bar", "baz"]),
                     available_modes=["value", "error"],
@@ -643,7 +643,7 @@ def func_with_complex_return() -> dict[str, str]:
         pytest.param(
             func_with_annotated_return,
             {
-                "inputs": ToolInputs(parameters=[]),
+                "inputs": ToolInput(parameters=[]),
                 "output": ToolOutput(
                     value_schema=ValueSchema(val_type="string", enum=None),
                     available_modes=["value", "error"],
@@ -655,7 +655,7 @@ def func_with_complex_return() -> dict[str, str]:
         pytest.param(
             func_with_optional_return,
             {
-                "inputs": ToolInputs(parameters=[]),
+                "inputs": ToolInput(parameters=[]),
                 "output": ToolOutput(
                     value_schema=ValueSchema(val_type="string", enum=None),
                     available_modes=["value", "error", "null"],
@@ -667,7 +667,7 @@ def func_with_complex_return() -> dict[str, str]:
         pytest.param(
             func_with_complex_return,
             {
-                "inputs": ToolInputs(parameters=[]),
+                "inputs": ToolInput(parameters=[]),
                 "output": ToolOutput(
                     value_schema=ValueSchema(val_type="json", enum=None),
                     available_modes=["value", "error"],

--- a/arcade/tests/tool/test_create_tool_definition.py
+++ b/arcade/tests/tool/test_create_tool_definition.py
@@ -313,7 +313,7 @@ def func_with_complex_return() -> dict[str, str]:
         pytest.param(
             func_with_non_inferrable_param,
             {
-                "inputs": ToolInput(
+                "input": ToolInput(
                     parameters=[
                         InputParameter(
                             name="param1",
@@ -330,7 +330,7 @@ def func_with_complex_return() -> dict[str, str]:
         pytest.param(
             func_with_renamed_param,
             {
-                "inputs": ToolInput(
+                "input": ToolInput(
                     parameters=[
                         InputParameter(
                             name="ParamOne",
@@ -347,7 +347,7 @@ def func_with_complex_return() -> dict[str, str]:
         pytest.param(
             func_with_enum_param,
             {
-                "inputs": ToolInput(
+                "input": ToolInput(
                     parameters=[
                         InputParameter(
                             name="param1",
@@ -364,7 +364,7 @@ def func_with_complex_return() -> dict[str, str]:
         pytest.param(
             func_with_dict_param,
             {
-                "inputs": ToolInput(
+                "input": ToolInput(
                     parameters=[
                         InputParameter(
                             name="param1",
@@ -381,7 +381,7 @@ def func_with_complex_return() -> dict[str, str]:
         pytest.param(
             func_with_string_literal_param,
             {
-                "inputs": ToolInput(
+                "input": ToolInput(
                     parameters=[
                         InputParameter(
                             name="param1",
@@ -398,7 +398,7 @@ def func_with_complex_return() -> dict[str, str]:
         pytest.param(
             func_with_param_with_default,
             {
-                "inputs": ToolInput(
+                "input": ToolInput(
                     parameters=[
                         InputParameter(
                             name="param1",
@@ -418,7 +418,7 @@ def func_with_complex_return() -> dict[str, str]:
         pytest.param(
             func_with_optional_param,
             {
-                "inputs": ToolInput(
+                "input": ToolInput(
                     parameters=[
                         InputParameter(
                             name="param1",
@@ -438,7 +438,7 @@ def func_with_complex_return() -> dict[str, str]:
         pytest.param(
             func_with_optional_param_with_default_None,
             {
-                "inputs": ToolInput(
+                "input": ToolInput(
                     parameters=[
                         InputParameter(
                             name="param1",
@@ -458,7 +458,7 @@ def func_with_complex_return() -> dict[str, str]:
         pytest.param(
             func_with_optional_param_with_default_value,
             {
-                "inputs": ToolInput(
+                "input": ToolInput(
                     parameters=[
                         InputParameter(
                             name="param1",
@@ -478,7 +478,7 @@ def func_with_complex_return() -> dict[str, str]:
         pytest.param(
             func_with_optional_param_with_bar_syntax,
             {
-                "inputs": ToolInput(
+                "input": ToolInput(
                     parameters=[
                         InputParameter(
                             name="param1",
@@ -498,7 +498,7 @@ def func_with_complex_return() -> dict[str, str]:
         pytest.param(
             func_with_mixed_params,
             {
-                "inputs": ToolInput(
+                "input": ToolInput(
                     parameters=[
                         InputParameter(
                             name="param1",
@@ -523,7 +523,7 @@ def func_with_complex_return() -> dict[str, str]:
         pytest.param(
             func_with_list_param,
             {
-                "inputs": ToolInput(
+                "input": ToolInput(
                     parameters=[
                         InputParameter(
                             name="param1",
@@ -542,7 +542,7 @@ def func_with_complex_return() -> dict[str, str]:
         pytest.param(
             func_with_list_float_param,
             {
-                "inputs": ToolInput(
+                "input": ToolInput(
                     parameters=[
                         InputParameter(
                             name="param1",
@@ -561,7 +561,7 @@ def func_with_complex_return() -> dict[str, str]:
         pytest.param(
             func_with_list_of_enums_param,
             {
-                "inputs": ToolInput(
+                "input": ToolInput(
                     parameters=[
                         InputParameter(
                             name="param1",
@@ -580,7 +580,7 @@ def func_with_complex_return() -> dict[str, str]:
         pytest.param(
             func_with_complex_param,
             {
-                "inputs": ToolInput(
+                "input": ToolInput(
                     parameters=[
                         InputParameter(
                             name="param1",
@@ -597,9 +597,9 @@ def func_with_complex_return() -> dict[str, str]:
         pytest.param(
             func_with_context,
             {
-                "inputs": ToolInput(
+                "input": ToolInput(
                     parameters=[], tool_context_parameter_name="my_context"
-                ),  # ToolContext type is not an input param, but it's stored in the inputs field
+                ),  # ToolContext type is not an input param, but it's stored in the input field
             },
             id="func_with_context",
         ),
@@ -607,7 +607,7 @@ def func_with_complex_return() -> dict[str, str]:
         pytest.param(
             func_with_list_return,
             {
-                "inputs": ToolInput(parameters=[]),
+                "input": ToolInput(parameters=[]),
                 "output": ToolOutput(
                     value_schema=ValueSchema(val_type="array", inner_val_type="string", enum=None),
                     available_modes=["value", "error"],
@@ -619,7 +619,7 @@ def func_with_complex_return() -> dict[str, str]:
         pytest.param(
             func_with_known_list_return,
             {
-                "inputs": ToolInput(parameters=[]),
+                "input": ToolInput(parameters=[]),
                 "output": ToolOutput(
                     value_schema=ValueSchema(val_type="string", enum=["value1", "value2"]),
                     available_modes=["value", "error"],
@@ -631,7 +631,7 @@ def func_with_complex_return() -> dict[str, str]:
         pytest.param(
             func_with_enum_return,
             {
-                "inputs": ToolInput(parameters=[]),
+                "input": ToolInput(parameters=[]),
                 "output": ToolOutput(
                     value_schema=ValueSchema(val_type="string", enum=["foo bar", "baz"]),
                     available_modes=["value", "error"],
@@ -643,7 +643,7 @@ def func_with_complex_return() -> dict[str, str]:
         pytest.param(
             func_with_annotated_return,
             {
-                "inputs": ToolInput(parameters=[]),
+                "input": ToolInput(parameters=[]),
                 "output": ToolOutput(
                     value_schema=ValueSchema(val_type="string", enum=None),
                     available_modes=["value", "error"],
@@ -655,7 +655,7 @@ def func_with_complex_return() -> dict[str, str]:
         pytest.param(
             func_with_optional_return,
             {
-                "inputs": ToolInput(parameters=[]),
+                "input": ToolInput(parameters=[]),
                 "output": ToolOutput(
                     value_schema=ValueSchema(val_type="string", enum=None),
                     available_modes=["value", "error", "null"],
@@ -667,7 +667,7 @@ def func_with_complex_return() -> dict[str, str]:
         pytest.param(
             func_with_complex_return,
             {
-                "inputs": ToolInput(parameters=[]),
+                "input": ToolInput(parameters=[]),
                 "output": ToolOutput(
                     value_schema=ValueSchema(val_type="json", enum=None),
                     available_modes=["value", "error"],

--- a/arcade/tests/tool/test_create_tool_definition_new.py
+++ b/arcade/tests/tool/test_create_tool_definition_new.py
@@ -64,7 +64,7 @@ def test_create_tool_def2(test_case):
     tool_def = ToolCatalog.create_tool_definition(generated_func, "1.0")
 
     for i, input_type in enumerate(input_types):
-        param = tool_def.inputs.parameters[i]
+        param = tool_def.input.parameters[i]
         assert (
             param.value_schema.val_type == get_wire_type(input_type)
         ), f"Parameter {param.name} has value type {param.value_schema.val_type} but {input_type} was expected at index {i}"

--- a/arcade/tests/tool/test_create_tool_definition_pydantic.py
+++ b/arcade/tests/tool/test_create_tool_definition_pydantic.py
@@ -143,7 +143,7 @@ def read_products(
         pytest.param(
             func_takes_pydantic_field_with_description,
             {
-                "inputs": ToolInput(
+                "input": ToolInput(
                     parameters=[
                         InputParameter(
                             name="product_name",
@@ -160,7 +160,7 @@ def read_products(
         pytest.param(
             func_takes_pydantic_field_optional,
             {
-                "inputs": ToolInput(
+                "input": ToolInput(
                     parameters=[
                         InputParameter(
                             name="product_name",
@@ -177,7 +177,7 @@ def read_products(
         pytest.param(
             func_takes_pydantic_field_annotated_description,
             {
-                "inputs": ToolInput(
+                "input": ToolInput(
                     parameters=[
                         InputParameter(
                             name="product_name",
@@ -194,7 +194,7 @@ def read_products(
         pytest.param(
             func_takes_pydantic_field_annotated_name_and_description,
             {
-                "inputs": ToolInput(
+                "input": ToolInput(
                     parameters=[
                         InputParameter(
                             name="ProductName",
@@ -211,7 +211,7 @@ def read_products(
         pytest.param(
             func_takes_pydantic_field_default,
             {
-                "inputs": ToolInput(
+                "input": ToolInput(
                     parameters=[
                         InputParameter(
                             name="product_name",
@@ -228,7 +228,7 @@ def read_products(
         pytest.param(
             func_takes_pydantic_field_default_factory,
             {
-                "inputs": ToolInput(
+                "input": ToolInput(
                     parameters=[
                         InputParameter(
                             name="product_name",
@@ -245,7 +245,7 @@ def read_products(
         pytest.param(
             read_products,
             {
-                "inputs": ToolInput(
+                "input": ToolInput(
                     parameters=[
                         InputParameter(
                             name="action",

--- a/arcade/tests/tool/test_create_tool_definition_pydantic.py
+++ b/arcade/tests/tool/test_create_tool_definition_pydantic.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel, Field
 from arcade.core.catalog import ToolCatalog
 from arcade.core.schema import (
     InputParameter,
-    ToolInputs,
+    ToolInput,
     ToolOutput,
     ValueSchema,
 )
@@ -143,7 +143,7 @@ def read_products(
         pytest.param(
             func_takes_pydantic_field_with_description,
             {
-                "inputs": ToolInputs(
+                "inputs": ToolInput(
                     parameters=[
                         InputParameter(
                             name="product_name",
@@ -160,7 +160,7 @@ def read_products(
         pytest.param(
             func_takes_pydantic_field_optional,
             {
-                "inputs": ToolInputs(
+                "inputs": ToolInput(
                     parameters=[
                         InputParameter(
                             name="product_name",
@@ -177,7 +177,7 @@ def read_products(
         pytest.param(
             func_takes_pydantic_field_annotated_description,
             {
-                "inputs": ToolInputs(
+                "inputs": ToolInput(
                     parameters=[
                         InputParameter(
                             name="product_name",
@@ -194,7 +194,7 @@ def read_products(
         pytest.param(
             func_takes_pydantic_field_annotated_name_and_description,
             {
-                "inputs": ToolInputs(
+                "inputs": ToolInput(
                     parameters=[
                         InputParameter(
                             name="ProductName",
@@ -211,7 +211,7 @@ def read_products(
         pytest.param(
             func_takes_pydantic_field_default,
             {
-                "inputs": ToolInputs(
+                "inputs": ToolInput(
                     parameters=[
                         InputParameter(
                             name="product_name",
@@ -228,7 +228,7 @@ def read_products(
         pytest.param(
             func_takes_pydantic_field_default_factory,
             {
-                "inputs": ToolInputs(
+                "inputs": ToolInput(
                     parameters=[
                         InputParameter(
                             name="product_name",
@@ -245,7 +245,7 @@ def read_products(
         pytest.param(
             read_products,
             {
-                "inputs": ToolInputs(
+                "inputs": ToolInput(
                     parameters=[
                         InputParameter(
                             name="action",

--- a/schemas/preview/tool_definition.schema.jsonc
+++ b/schemas/preview/tool_definition.schema.jsonc
@@ -78,7 +78,7 @@
       "required": ["name", "version"],
       "additionalProperties": false
     },
-    "inputs": {
+    "input": {
       "type": "object",
       "properties": {
         "parameters": {
@@ -181,6 +181,6 @@
       "additionalProperties": false
     }
   },
-  "required": ["name", "fully_qualified_name", "toolkit", "inputs", "output"],
+  "required": ["name", "fully_qualified_name", "toolkit", "input", "output"],
   "additionalProperties": false
 }


### PR DESCRIPTION
Tool definitions in the Engine were missing `input` because the field was renamed.