### PR TITLE
Return media attachments metadata when retrieving X tweets

### DIFF
--- a/toolkits/x/arcade_x/tools/tweets.py
+++ b/toolkits/x/arcade_x/tools/tweets.py
@@ -65,9 +65,6 @@ async def delete_tweet_by_id(
 async def search_recent_tweets_by_username(
     context: ToolContext,
     username: Annotated[str, "The username of the X (Twitter) user to look up"],
-    return_attachments_metadata: Annotated[
-        bool, "Whether to return metadata about the media attached to the tweet"
-    ] = True,
     max_results: Annotated[
         int, "The maximum number of results to return. Must be in range [1, 100] inclusive"
     ] = 10,
@@ -89,10 +86,7 @@ async def search_recent_tweets_by_username(
         "user.fields": "id,name,username,entities",
         "tweet.fields": "entities,note_tweet",
     }
-    params = remove_none_values(params)
-
-    if return_attachments_metadata:
-        expand_attached_media(params)
+    params = expand_attached_media(remove_none_values(params))
 
     url = f"{TWEETS_URL}/search/recent"
 
@@ -125,9 +119,6 @@ async def search_recent_tweets_by_keywords(
     phrases: Annotated[
         list[str] | None, "List of phrases that must be present in the tweet"
     ] = None,
-    return_attachments_metadata: Annotated[
-        bool, "Whether to return metadata about the media attached to the tweet"
-    ] = True,
     max_results: Annotated[
         int, "The maximum number of results to return. Must be in range [1, 100] inclusive"
     ] = 10,
@@ -165,10 +156,7 @@ async def search_recent_tweets_by_keywords(
         "user.fields": "id,name,username,entities",
         "tweet.fields": "entities,note_tweet",
     }
-    params = remove_none_values(params)
-
-    if return_attachments_metadata:
-        expand_attached_media(params)
+    params = expand_attached_media(remove_none_values(params))
 
     url = f"{TWEETS_URL}/search/recent"
 
@@ -196,9 +184,6 @@ async def search_recent_tweets_by_keywords(
 async def lookup_tweet_by_id(
     context: ToolContext,
     tweet_id: Annotated[str, "The ID of the tweet you want to look up"],
-    return_attachments_metadata: Annotated[
-        bool, "Whether to return metadata about the media attached to the tweet"
-    ] = True,
 ) -> Annotated[dict[str, Any], "Dictionary containing the tweet data"]:
     """Look up a tweet on X (Twitter) by tweet ID."""
 
@@ -208,9 +193,7 @@ async def lookup_tweet_by_id(
         "user.fields": "id,name,username,entities",
         "tweet.fields": "entities,note_tweet",
     }
-
-    if return_attachments_metadata:
-        expand_attached_media(params)
+    params = expand_attached_media(params)
 
     url = f"{TWEETS_URL}/{tweet_id}"
 

--- a/toolkits/x/arcade_x/tools/utils.py
+++ b/toolkits/x/arcade_x/tools/utils.py
@@ -153,7 +153,6 @@ def expand_attached_media(params: dict) -> dict:
         "duration_ms",
         "height",
         "width",
-        "url",
         "preview_image_url",
         "alt_text",
         "public_metrics",

--- a/toolkits/x/arcade_x/tools/utils.py
+++ b/toolkits/x/arcade_x/tools/utils.py
@@ -137,3 +137,25 @@ def remove_none_values(params: dict) -> dict:
         A new dictionary with None values removed
     """
     return {k: v for k, v in params.items() if v is not None}
+
+
+def expand_attached_media(params: dict) -> dict:
+    """
+    Include attached media metadata in the request parameters.
+    """
+    params["expansions"] += ",attachments.media_keys"
+    params["tweet.fields"] += ",attachments"
+    params["media.fields"] = ",".join([
+        # media_key, url and type are returned by default, added here for clarity
+        "media_key",
+        "url",
+        "type",
+        "duration_ms",
+        "height",
+        "width",
+        "url",
+        "preview_image_url",
+        "alt_text",
+        "public_metrics",
+    ])
+    return params

--- a/toolkits/x/evals/eval_x_tools.py
+++ b/toolkits/x/evals/eval_x_tools.py
@@ -3,7 +3,6 @@ from arcade.sdk.eval import (
     BinaryCritic,
     EvalRubric,
     EvalSuite,
-    ExpectedToolCall,
     tool_eval,
 )
 
@@ -78,9 +77,9 @@ def x_eval_suite() -> EvalSuite:
             "at Arcade AI!'"
         ),
         expected_tool_calls=[
-            ExpectedToolCall(
-                func=post_tweet,
-                args={
+            (
+                post_tweet,
+                {
                     "tweet_text": "Hello World! Exciting stuff is happening over at Arcade AI!",
                 },
             )
@@ -96,12 +95,7 @@ def x_eval_suite() -> EvalSuite:
     suite.add_case(
         name="Delete a tweet by ID",
         user_message="Please delete the tweet with ID '148975632'.",
-        expected_tool_calls=[
-            ExpectedToolCall(
-                func=delete_tweet_by_id,
-                args={"tweet_id": "148975632"},
-            )
-        ],
+        expected_tool_calls=[(delete_tweet_by_id, {"tweet_id": "148975632"})],
         critics=[
             BinaryCritic(
                 critic_field="tweet_id",
@@ -114,9 +108,9 @@ def x_eval_suite() -> EvalSuite:
         name="Search recent tweets by username",
         user_message="Show me the recent tweets from 'elonmusk'.",
         expected_tool_calls=[
-            ExpectedToolCall(
-                func=search_recent_tweets_by_username,
-                args={"username": "elonmusk", "max_results": 10},
+            (
+                search_recent_tweets_by_username,
+                {"username": "elonmusk", "max_results": 10},
             )
         ],
         critics=[
@@ -131,9 +125,9 @@ def x_eval_suite() -> EvalSuite:
         name="Search recent tweets by username without attachments",
         user_message="Show me the recent tweets from 'elonmusk'. Do not include media attachments.",
         expected_tool_calls=[
-            ExpectedToolCall(
-                func=search_recent_tweets_by_username,
-                args={
+            (
+                search_recent_tweets_by_username,
+                {
                     "username": "elonmusk",
                     "max_results": 10,
                     "return_attachments_metadata": False,
@@ -143,11 +137,11 @@ def x_eval_suite() -> EvalSuite:
         critics=[
             BinaryCritic(
                 critic_field="username",
-                weight=1.0,
+                weight=0.5,
             ),
             BinaryCritic(
                 critic_field="return_attachments_metadata",
-                weight=1.0,
+                weight=0.5,
             ),
         ],
     )
@@ -157,9 +151,9 @@ def x_eval_suite() -> EvalSuite:
         user_message="Get the next 42",
         additional_messages=search_recent_tweets_by_username_history,
         expected_tool_calls=[
-            ExpectedToolCall(
-                func=search_recent_tweets_by_username,
-                args={
+            (
+                search_recent_tweets_by_username,
+                {
                     "username": "elonmusk",
                     "max_results": 42,
                     "next_token": "b26v89c19zqg8o3frr3tekall7a7ooom3sctaw30rz62l",
@@ -186,9 +180,9 @@ def x_eval_suite() -> EvalSuite:
         name="Lookup user by username",
         user_message="Can you get information about the user '@jack'?",
         expected_tool_calls=[
-            ExpectedToolCall(
-                func=lookup_single_user_by_username,
-                args={"username": "jack"},
+            (
+                lookup_single_user_by_username,
+                {"username": "jack"},
             )
         ],
         critics=[
@@ -203,19 +197,19 @@ def x_eval_suite() -> EvalSuite:
         name="Lookup user by username without attachments",
         user_message="Can you get information about the user '@jack'. Do not include media attachments.",
         expected_tool_calls=[
-            ExpectedToolCall(
-                func=lookup_single_user_by_username,
-                args={"username": "jack", "return_attachments_metadata": False},
+            (
+                lookup_single_user_by_username,
+                {"username": "jack", "return_attachments_metadata": False},
             )
         ],
         critics=[
             BinaryCritic(
                 critic_field="username",
-                weight=1.0,
+                weight=0.5,
             ),
             BinaryCritic(
                 critic_field="return_attachments_metadata",
-                weight=1.0,
+                weight=0.5,
             ),
         ],
     )
@@ -225,9 +219,9 @@ def x_eval_suite() -> EvalSuite:
         name="Search recent tweets by keywords",
         user_message="Find recent tweets containing 'Arcade AI'.",
         expected_tool_calls=[
-            ExpectedToolCall(
-                func=search_recent_tweets_by_keywords,
-                args={
+            (
+                search_recent_tweets_by_keywords,
+                {
                     "keywords": None,
                     "phrases": ["Arcade AI"],
                     "max_results": 10,
@@ -251,9 +245,9 @@ def x_eval_suite() -> EvalSuite:
         name="Lookup tweet by ID",
         user_message="Can you provide details about the tweet with ID '123456789'?",
         expected_tool_calls=[
-            ExpectedToolCall(
-                func=lookup_tweet_by_id,
-                args={"tweet_id": "123456789"},
+            (
+                lookup_tweet_by_id,
+                {"tweet_id": "123456789"},
             )
         ],
         critics=[
@@ -268,19 +262,19 @@ def x_eval_suite() -> EvalSuite:
         name="Lookup tweet by ID without attachments",
         user_message="Can you provide details about the tweet with ID '123456789'? Do not include media attachments.",
         expected_tool_calls=[
-            ExpectedToolCall(
-                func=lookup_tweet_by_id,
-                args={"tweet_id": "123456789", "return_attachments_metadata": False},
+            (
+                lookup_tweet_by_id,
+                {"tweet_id": "123456789", "return_attachments_metadata": False},
             )
         ],
         critics=[
             BinaryCritic(
                 critic_field="tweet_id",
-                weight=1.0,
+                weight=0.5,
             ),
             BinaryCritic(
                 critic_field="return_attachments_metadata",
-                weight=1.0,
+                weight=0.5,
             ),
         ],
     )

--- a/toolkits/x/evals/eval_x_tools.py
+++ b/toolkits/x/evals/eval_x_tools.py
@@ -128,6 +128,31 @@ def x_eval_suite() -> EvalSuite:
     )
 
     suite.add_case(
+        name="Search recent tweets by username without attachments",
+        user_message="Show me the recent tweets from 'elonmusk'. Do not include media attachments.",
+        expected_tool_calls=[
+            ExpectedToolCall(
+                func=search_recent_tweets_by_username,
+                args={
+                    "username": "elonmusk",
+                    "max_results": 10,
+                    "return_attachments_metadata": False,
+                },
+            )
+        ],
+        critics=[
+            BinaryCritic(
+                critic_field="username",
+                weight=1.0,
+            ),
+            BinaryCritic(
+                critic_field="return_attachments_metadata",
+                weight=1.0,
+            ),
+        ],
+    )
+
+    suite.add_case(
         name="Search recent tweets by username with history",
         user_message="Get the next 42",
         additional_messages=search_recent_tweets_by_username_history,
@@ -174,6 +199,27 @@ def x_eval_suite() -> EvalSuite:
         ],
     )
 
+    suite.add_case(
+        name="Lookup user by username without attachments",
+        user_message="Can you get information about the user '@jack'. Do not include media attachments.",
+        expected_tool_calls=[
+            ExpectedToolCall(
+                func=lookup_single_user_by_username,
+                args={"username": "jack", "return_attachments_metadata": False},
+            )
+        ],
+        critics=[
+            BinaryCritic(
+                critic_field="username",
+                weight=1.0,
+            ),
+            BinaryCritic(
+                critic_field="return_attachments_metadata",
+                weight=1.0,
+            ),
+        ],
+    )
+
     # Add a case for searching recent tweets by keywords
     suite.add_case(
         name="Search recent tweets by keywords",
@@ -213,6 +259,27 @@ def x_eval_suite() -> EvalSuite:
         critics=[
             BinaryCritic(
                 critic_field="tweet_id",
+                weight=1.0,
+            ),
+        ],
+    )
+
+    suite.add_case(
+        name="Lookup tweet by ID without attachments",
+        user_message="Can you provide details about the tweet with ID '123456789'? Do not include media attachments.",
+        expected_tool_calls=[
+            ExpectedToolCall(
+                func=lookup_tweet_by_id,
+                args={"tweet_id": "123456789", "return_attachments_metadata": False},
+            )
+        ],
+        critics=[
+            BinaryCritic(
+                critic_field="tweet_id",
+                weight=1.0,
+            ),
+            BinaryCritic(
+                critic_field="return_attachments_metadata",
                 weight=1.0,
             ),
         ],

--- a/toolkits/x/evals/eval_x_tools.py
+++ b/toolkits/x/evals/eval_x_tools.py
@@ -3,6 +3,7 @@ from arcade.sdk.eval import (
     BinaryCritic,
     EvalRubric,
     EvalSuite,
+    ExpectedToolCall,
     tool_eval,
 )
 
@@ -77,11 +78,9 @@ def x_eval_suite() -> EvalSuite:
             "at Arcade AI!'"
         ),
         expected_tool_calls=[
-            (
-                post_tweet,
-                {
-                    "tweet_text": "Hello World! Exciting stuff is happening over at Arcade AI!",
-                },
+            ExpectedToolCall(
+                func=post_tweet,
+                args={"tweet_text": "Hello World! Exciting stuff is happening over at Arcade AI!"},
             )
         ],
         critics=[
@@ -95,7 +94,12 @@ def x_eval_suite() -> EvalSuite:
     suite.add_case(
         name="Delete a tweet by ID",
         user_message="Please delete the tweet with ID '148975632'.",
-        expected_tool_calls=[(delete_tweet_by_id, {"tweet_id": "148975632"})],
+        expected_tool_calls=[
+            ExpectedToolCall(
+                func=delete_tweet_by_id,
+                args={"tweet_id": "148975632"},
+            )
+        ],
         critics=[
             BinaryCritic(
                 critic_field="tweet_id",
@@ -108,9 +112,9 @@ def x_eval_suite() -> EvalSuite:
         name="Search recent tweets by username",
         user_message="Show me the recent tweets from 'elonmusk'.",
         expected_tool_calls=[
-            (
-                search_recent_tweets_by_username,
-                {"username": "elonmusk", "max_results": 10},
+            ExpectedToolCall(
+                func=search_recent_tweets_by_username,
+                args={"username": "elonmusk", "max_results": 10},
             )
         ],
         critics=[
@@ -122,43 +126,18 @@ def x_eval_suite() -> EvalSuite:
     )
 
     suite.add_case(
-        name="Search recent tweets by username without attachments",
-        user_message="Show me the recent tweets from 'elonmusk'. Do not include media attachments.",
-        expected_tool_calls=[
-            (
-                search_recent_tweets_by_username,
-                {
-                    "username": "elonmusk",
-                    "max_results": 10,
-                    "return_attachments_metadata": False,
-                },
-            )
-        ],
-        critics=[
-            BinaryCritic(
-                critic_field="username",
-                weight=0.5,
-            ),
-            BinaryCritic(
-                critic_field="return_attachments_metadata",
-                weight=0.5,
-            ),
-        ],
-    )
-
-    suite.add_case(
         name="Search recent tweets by username with history",
         user_message="Get the next 42",
         additional_messages=search_recent_tweets_by_username_history,
         expected_tool_calls=[
-            (
-                search_recent_tweets_by_username,
-                {
+            ExpectedToolCall(
+                func=search_recent_tweets_by_username,
+                args={
                     "username": "elonmusk",
                     "max_results": 42,
                     "next_token": "b26v89c19zqg8o3frr3tekall7a7ooom3sctaw30rz62l",
                 },
-            )
+            ),
         ],
         critics=[
             BinaryCritic(
@@ -180,10 +159,10 @@ def x_eval_suite() -> EvalSuite:
         name="Lookup user by username",
         user_message="Can you get information about the user '@jack'?",
         expected_tool_calls=[
-            (
-                lookup_single_user_by_username,
-                {"username": "jack"},
-            )
+            ExpectedToolCall(
+                func=lookup_single_user_by_username,
+                args={"username": "jack"},
+            ),
         ],
         critics=[
             BinaryCritic(
@@ -193,40 +172,19 @@ def x_eval_suite() -> EvalSuite:
         ],
     )
 
-    suite.add_case(
-        name="Lookup user by username without attachments",
-        user_message="Can you get information about the user '@jack'. Do not include media attachments.",
-        expected_tool_calls=[
-            (
-                lookup_single_user_by_username,
-                {"username": "jack", "return_attachments_metadata": False},
-            )
-        ],
-        critics=[
-            BinaryCritic(
-                critic_field="username",
-                weight=0.5,
-            ),
-            BinaryCritic(
-                critic_field="return_attachments_metadata",
-                weight=0.5,
-            ),
-        ],
-    )
-
     # Add a case for searching recent tweets by keywords
     suite.add_case(
         name="Search recent tweets by keywords",
         user_message="Find recent tweets containing 'Arcade AI'.",
         expected_tool_calls=[
-            (
-                search_recent_tweets_by_keywords,
-                {
+            ExpectedToolCall(
+                func=search_recent_tweets_by_keywords,
+                args={
                     "keywords": None,
                     "phrases": ["Arcade AI"],
                     "max_results": 10,
                 },
-            )
+            ),
         ],
         critics=[
             BinaryCritic(
@@ -245,36 +203,15 @@ def x_eval_suite() -> EvalSuite:
         name="Lookup tweet by ID",
         user_message="Can you provide details about the tweet with ID '123456789'?",
         expected_tool_calls=[
-            (
-                lookup_tweet_by_id,
-                {"tweet_id": "123456789"},
-            )
+            ExpectedToolCall(
+                func=lookup_tweet_by_id,
+                args={"tweet_id": "123456789"},
+            ),
         ],
         critics=[
             BinaryCritic(
                 critic_field="tweet_id",
                 weight=1.0,
-            ),
-        ],
-    )
-
-    suite.add_case(
-        name="Lookup tweet by ID without attachments",
-        user_message="Can you provide details about the tweet with ID '123456789'? Do not include media attachments.",
-        expected_tool_calls=[
-            (
-                lookup_tweet_by_id,
-                {"tweet_id": "123456789", "return_attachments_metadata": False},
-            )
-        ],
-        critics=[
-            BinaryCritic(
-                critic_field="tweet_id",
-                weight=0.5,
-            ),
-            BinaryCritic(
-                critic_field="return_attachments_metadata",
-                weight=0.5,
             ),
         ],
     )

--- a/toolkits/x/pyproject.toml
+++ b/toolkits/x/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "arcade_x"
-version = "0.1.8"
+version = "0.1.9"
 description = "LLM tools for interacting with X (Twitter)"
 authors = ["Arcade AI <dev@arcade-ai.com>"]
 

--- a/toolkits/x/pyproject.toml
+++ b/toolkits/x/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "arcade_x"
-version = "0.1.7"
+version = "0.1.8"
 description = "LLM tools for interacting with X (Twitter)"
 authors = ["Arcade AI <dev@arcade-ai.com>"]
 

--- a/toolkits/x/tests/test_tweets.py
+++ b/toolkits/x/tests/test_tweets.py
@@ -117,51 +117,6 @@ async def test_search_recent_tweets_by_username_success(tool_context, mock_httpx
                 },
             }
         ],
-        "includes": {"users": [{"id": "0987654321", "name": "Test User", "username": "testuser"}]},
-    }
-    mock_httpx_client.get.return_value = mock_response
-
-    username = "testuser"
-    result = await search_recent_tweets_by_username(
-        tool_context, username, return_attachments_metadata=False
-    )
-
-    assert "data" in result
-    assert "includes" in result
-    assert len(result["data"]) == 1
-    assert result["data"][0]["text"] == full_tweet_text
-    assert "media" not in result["includes"]
-    mock_httpx_client.get.assert_called_once()
-
-
-@pytest.mark.asyncio
-async def test_search_recent_tweets_by_username_with_attachments_success(
-    tool_context, mock_httpx_client
-):
-    """Test successful search of recent tweets by username with attachments."""
-    # Mock response for a successful tweet search
-    mock_response = MagicMock()
-    mock_response.status_code = 200
-    mock_response.json.return_value = {
-        "data": [
-            {
-                "id": "1234567890",
-                "note_tweet": {
-                    "entities": {
-                        "mentions": [
-                            {"end": 19, "id": "00000000", "start": 4, "username": "aUsername"}
-                        ]
-                    },
-                    "text": full_tweet_text,
-                },
-                "text": truncated_tweet_text,
-                "entities": {
-                    "urls": [
-                        {"url": "https://t.co/short", "expanded_url": "https://example.com/long"}
-                    ]
-                },
-            }
-        ],
         "includes": {
             "users": [{"id": "0987654321", "name": "Test User", "username": "testuser"}],
             "media": [
@@ -172,17 +127,17 @@ async def test_search_recent_tweets_by_username_with_attachments_success(
     mock_httpx_client.get.return_value = mock_response
 
     username = "testuser"
-    result = await search_recent_tweets_by_username(
-        tool_context, username, return_attachments_metadata=True
-    )
+    result = await search_recent_tweets_by_username(tool_context, username)
 
     assert "data" in result
-    assert "includes" in result
     assert len(result["data"]) == 1
     assert result["data"][0]["text"] == full_tweet_text
+
+    assert "includes" in result
     assert "media" in result["includes"]
     assert len(result["includes"]["media"]) == 1
     assert result["includes"]["media"][0]["url"] == "https://example.com/photo.jpg"
+
     mock_httpx_client.get.assert_called_once()
 
 
@@ -224,48 +179,6 @@ async def test_search_recent_tweets_by_keywords_success(tool_context, mock_httpx
                 "entities": {},
             }
         ],
-        "includes": {"users": [{"id": "0987654321", "name": "Test User", "username": "testuser"}]},
-    }
-    mock_httpx_client.get.return_value = mock_response
-
-    keywords = ["test", "keyword"]
-    result = await search_recent_tweets_by_keywords(
-        context=tool_context,
-        keywords=keywords,
-        return_attachments_metadata=False,
-    )
-
-    assert "data" in result
-    assert len(result["data"]) == 1
-    assert result["data"][0]["text"] == full_tweet_text
-    assert "media" not in result.get("includes", {})
-    mock_httpx_client.get.assert_called_once()
-
-
-@pytest.mark.asyncio
-async def test_search_recent_tweets_by_keywords_with_attachments_success(
-    tool_context, mock_httpx_client
-):
-    """Test successful search of recent tweets by keywords with attachments."""
-    # Mock response for a successful keyword search
-    mock_response = MagicMock()
-    mock_response.status_code = 200
-    mock_response.json.return_value = {
-        "data": [
-            {
-                "id": "1234567890",
-                "note_tweet": {
-                    "entities": {
-                        "mentions": [
-                            {"end": 19, "id": "00000000", "start": 4, "username": "aUsername"}
-                        ]
-                    },
-                    "text": full_tweet_text,
-                },
-                "text": truncated_tweet_text,
-                "entities": {},
-            }
-        ],
         "includes": {
             "users": [{"id": "0987654321", "name": "Test User", "username": "testuser"}],
             "media": [
@@ -276,14 +189,17 @@ async def test_search_recent_tweets_by_keywords_with_attachments_success(
     mock_httpx_client.get.return_value = mock_response
 
     keywords = ["test", "keyword"]
-    result = await search_recent_tweets_by_keywords(tool_context, keywords=keywords)
+    result = await search_recent_tweets_by_keywords(context=tool_context, keywords=keywords)
 
     assert "data" in result
     assert len(result["data"]) == 1
     assert result["data"][0]["text"] == full_tweet_text
-    assert "media" in result.get("includes", {})
+
+    assert "includes" in result
+    assert "media" in result["includes"]
     assert len(result["includes"]["media"]) == 1
     assert result["includes"]["media"][0]["url"] == "https://example.com/photo.jpg"
+
     mock_httpx_client.get.assert_called_once()
 
 
@@ -313,36 +229,6 @@ async def test_lookup_tweet_by_id_success(tool_context, mock_httpx_client):
             },
             "text": truncated_tweet_text,
             "entities": {},
-        }
-    }
-    mock_httpx_client.get.return_value = mock_response
-
-    tweet_id = "1234567890"
-    result = await lookup_tweet_by_id(tool_context, tweet_id, return_attachments_metadata=False)
-
-    assert "data" in result
-    assert result["data"]["text"] == full_tweet_text
-    assert "media" not in result.get("includes", {})
-    mock_httpx_client.get.assert_called_once()
-
-
-@pytest.mark.asyncio
-async def test_lookup_tweet_by_id_with_attached_media(tool_context, mock_httpx_client):
-    """Test successful lookup of a tweet by ID with attached media."""
-    # Use MagicMock for the response
-    mock_response = MagicMock()
-    mock_response.status_code = 200
-    mock_response.json.return_value = {
-        "data": {
-            "id": "1234567890",
-            "note_tweet": {
-                "entities": {
-                    "mentions": [{"end": 19, "id": "00000000", "start": 4, "username": "aUsername"}]
-                },
-                "text": full_tweet_text,
-            },
-            "text": truncated_tweet_text,
-            "entities": {},
         },
         "includes": {
             "media": [
@@ -353,14 +239,16 @@ async def test_lookup_tweet_by_id_with_attached_media(tool_context, mock_httpx_c
     mock_httpx_client.get.return_value = mock_response
 
     tweet_id = "1234567890"
-    result = await lookup_tweet_by_id(tool_context, tweet_id, return_attachments_metadata=True)
+    result = await lookup_tweet_by_id(tool_context, tweet_id)
 
     assert "data" in result
-    assert "includes" in result
     assert result["data"]["text"] == full_tweet_text
+
+    assert "includes" in result
     assert "media" in result["includes"]
     assert len(result["includes"]["media"]) == 1
     assert result["includes"]["media"][0]["url"] == "https://example.com/photo.jpg"
+
     mock_httpx_client.get.assert_called_once()
 
 


### PR DESCRIPTION
Modifies X tweet tools to return metadata about media attachments (photo, GIF or video) when retrieving a tweet by ID, username or keywords.

The tool will always return media attachments by default. Since it's only metadata, it shouldn't add significant network overhead to existing implementations of the tool.

My guess is more often than not people will want this info included. When not needed, it doesn't hurt to include by default. It'd be annoying to have to ask the LLM to include it every time they need.