### PR TITLE
Fix 'Check Toolkits' Workflow

### DIFF
--- a/.github/workflows/check-toolkits.yml
+++ b/.github/workflows/check-toolkits.yml
@@ -34,7 +34,7 @@ jobs:
         dirs=$(echo "${CHANGED_FILES}" | tr ' ' '\n' | grep "toolkits/" | cut -d'/' -f2 | sort -u)
         if [ -n "$dirs" ]; then
           echo "$dirs" | while read -r dir; do
-            echo "Processing toolkit: $dir"
+            echo "$dir"
             gh workflow -R ArcadeAI/arcade-ai run "Publish Toolkit" -f toolkit=${dir}
           done
         else

--- a/.github/workflows/check-toolkits.yml
+++ b/.github/workflows/check-toolkits.yml
@@ -32,7 +32,11 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.PAT }}
       run: |
         dirs=$(echo "${CHANGED_FILES}" | tr ' ' '\n' | grep "toolkits/" | cut -d'/' -f2 | sort -u)
-        echo "$dirs" | while read -r dir; do
-          echo "$dir"
-          gh workflow -R ArcadeAI/arcade-ai run "Publish Toolkit" -f toolkit=${dir}
-        done
+        if [ -n "$dirs" ]; then
+          echo "$dirs" | while read -r dir; do
+            echo "Processing toolkit: $dir"
+            gh workflow -R ArcadeAI/arcade-ai run "Publish Toolkit" -f toolkit=${dir}
+          done
+        else
+          echo "No toolkit directories were changed"
+        fi


### PR DESCRIPTION
# PR Description
The 'Check Toolkits' workflow was failing if no toolkits were changed. This PR gracefully exits the workflow for this case.