### PR TITLE
Check if toolkit version changed before attempting publish

### DIFF
--- a/.github/workflows/publish-toolkit.yml
+++ b/.github/workflows/publish-toolkit.yml
@@ -49,19 +49,33 @@ jobs:
         make check
         make test
 
+    - name: Check Version
+      id: Check_Version
+      working-directory: toolkits/${{ steps.set-toolkit.outputs.toolkit }}
+      run: |
+        VERSION=$(poetry version -s)
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+        PACKAGE=$(poetry version | cut -d' ' -f1)
+
+        if pip index versions $PACKAGE | grep -q "^$VERSION$"; then
+          echo "Version $PACKAGE == $VERSION already exists on PyPI. Skipping publish."
+          echo "skip_publish=true" >> $GITHUB_OUTPUT
+        else
+          echo "skip_publish=false" >> $GITHUB_OUTPUT
+        fi
+
     - name: Publish Toolkit
       id: Publish_Toolkit
+      if: steps.Check_Version.outputs.skip_publish != 'true'
       working-directory: toolkits/${{ steps.set-toolkit.outputs.toolkit }}
       run: |
         poetry build
-        # Extract version from pyproject.toml using poetry and save it
-        VERSION=$(poetry version -s)
-        echo "version=$VERSION" >> $GITHUB_OUTPUT
         poetry config pypi-token.pypi ${{ secrets.PYPI_TOKEN }}
         poetry publish
 
     - name: Send status to Slack
-      if: always()
+      if: steps.Check_Version.outputs.skip_publish != 'true'
       uses: slackapi/slack-github-action@v2.0.0
       with:
         webhook: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/publish-toolkit.yml
+++ b/.github/workflows/publish-toolkit.yml
@@ -49,33 +49,22 @@ jobs:
         make check
         make test
 
-    - name: Check Version
-      id: Check_Version
+    - name: Publish Toolkit
+      # Publish the toolkit to PyPI if the version is not already published
+      id: Publish_Toolkit
       working-directory: toolkits/${{ steps.set-toolkit.outputs.toolkit }}
       run: |
-        VERSION=$(poetry version -s)
-        echo "version=$VERSION" >> $GITHUB_OUTPUT
-
-        PACKAGE=$(poetry version | cut -d' ' -f1)
-
-        if pip index versions $PACKAGE | grep -q "^$VERSION$"; then
-          echo "Version $PACKAGE == $VERSION already exists on PyPI. Skipping publish."
+        poetry build
+        poetry config pypi-token.pypi ${{ secrets.PYPI_TOKEN }}
+        if poetry publish --skip-existing 2>&1 | grep -q "File exists. Skipping"; then
+          echo "Version already exists on PyPI. Skipping publish."
           echo "skip_publish=true" >> $GITHUB_OUTPUT
         else
           echo "skip_publish=false" >> $GITHUB_OUTPUT
         fi
 
-    - name: Publish Toolkit
-      id: Publish_Toolkit
-      if: steps.Check_Version.outputs.skip_publish != 'true'
-      working-directory: toolkits/${{ steps.set-toolkit.outputs.toolkit }}
-      run: |
-        poetry build
-        poetry config pypi-token.pypi ${{ secrets.PYPI_TOKEN }}
-        poetry publish
-
     - name: Send status to Slack
-      if: steps.Check_Version.outputs.skip_publish != 'true'
+      if: steps.Publish_Toolkit.outputs.skip_publish != 'true'
       uses: slackapi/slack-github-action@v2.0.0
       with:
         webhook: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/publish-toolkit.yml
+++ b/.github/workflows/publish-toolkit.yml
@@ -55,7 +55,11 @@ jobs:
       working-directory: toolkits/${{ steps.set-toolkit.outputs.toolkit }}
       run: |
         poetry build
+        # Extract version from pyproject.toml using poetry and save it
+        VERSION=$(poetry version -s)
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
         poetry config pypi-token.pypi ${{ secrets.PYPI_TOKEN }}
+        # Attempt to publish the toolkit to PyPI. Skip if the version already exists
         if poetry publish --skip-existing 2>&1 | grep -q "File exists. Skipping"; then
           echo "Version already exists on PyPI. Skipping publish."
           echo "skip_publish=true" >> $GITHUB_OUTPUT

--- a/toolkits/math/evals/eval_math_tools.py
+++ b/toolkits/math/evals/eval_math_tools.py
@@ -25,7 +25,7 @@ catalog.add_module(arcade_math)
 def math_eval_suite():
     suite = EvalSuite(
         name="Math Tools Evaluation",
-        system_message="You are an AI assistant with access to math tools. Use them to help the user with their math-related tasks.",
+        system_message="You're an AI assistant with access to math tools. Use them to help the user with their math-related tasks.",
         catalog=catalog,
         rubric=rubric,
     )


### PR DESCRIPTION
# PR Description
Changes to a toolkit without changes to the toolkit's version fail the 'Publish Toolkit' workflow with `HTTP Error 400: File already exists ('arcade_zoom-0.1.7.tar.gz', with blake2_256 hash '02183cda607f06616e7edb17e3d22bc11d1d83b074b3e44066b78ec72602fb37'). See https://pypi.org/help/#file-name-reuse for more information.`, for example.

This PR adds the `--skip-existing` flag to `poetry publish` to avoid attempting to publish an existing version. Skips slack notification if publish is skipped.


The `grep`'d string comes from https://github.com/python-poetry/poetry/blob/main/src/poetry/publishing/uploader.py#L246-L249