### PR TITLE
Removed unused param

### DIFF
--- a/toolkits/google/arcade_google/tools/gmail.py
+++ b/toolkits/google/arcade_google/tools/gmail.py
@@ -497,16 +497,12 @@ async def list_threads(
 async def get_thread(
     context: ToolContext,
     thread_id: Annotated[str, "The ID of the thread to retrieve"],
-    metadata_headers: Annotated[
-        Optional[list[str]], "When given and format is METADATA, only include headers specified."
-    ] = None,
 ) -> Annotated[dict, "A dictionary containing the thread details"]:
     """Get the specified thread by ID."""
     params = {
         "userId": "me",
         "id": thread_id,
         "format": "full",
-        "metadataHeaders": metadata_headers,
     }
     params = remove_none_values(params)
 


### PR DESCRIPTION
# PR Description
For the `Google.GetThread` tool, we had a parameter named `metadata_headers`. This parameter only makes a difference if the format is "metadata", but the tool will never have the format "metadata". So, the input parameter is useless. This parameter should have never been added to the tool and we should remove it before public beta.