### PR TITLE
Add `arcade --version`

### DIFF
--- a/arcade/arcade/cli/main.py
+++ b/arcade/arcade/cli/main.py
@@ -1,4 +1,5 @@
 import asyncio
+import importlib
 import os
 import threading
 import uuid
@@ -475,3 +476,24 @@ def workerup(
         error_message = f"❌ Failed to start Arcade Worker: {escape(str(e))}"
         console.print(error_message, style="bold red")
         typer.Exit(code=1)
+
+
+def version_callback(value: bool) -> None:
+    if value:
+        version = importlib.import_module("arcade").__version__
+        console.print(f"[bold]Arcade[/bold] (version {version})")
+        exit()
+
+
+@cli.callback(help="Show the current version of Arcade CLI", rich_help_panel="User")
+def version(
+    _: bool = typer.Option(
+        None,
+        "-v",
+        "--version",
+        callback=version_callback,
+        is_eager=True,
+        help="Print version and exit.",
+    ),
+):
+    pass

--- a/arcade/arcade/cli/main.py
+++ b/arcade/arcade/cli/main.py
@@ -478,7 +478,7 @@ def workerup(
         typer.Exit(code=1)
 
 
-@cli.callback(help="Show the current version of Arcade", rich_help_panel="User")
+@cli.callback()
 def version(
     _: bool = typer.Option(
         None,

--- a/arcade/arcade/cli/main.py
+++ b/arcade/arcade/cli/main.py
@@ -488,5 +488,5 @@ def version(
         is_eager=True,
         help="Print version and exit.",
     ),
-):
+) -> None:
     pass

--- a/arcade/arcade/cli/main.py
+++ b/arcade/arcade/cli/main.py
@@ -1,5 +1,4 @@
 import asyncio
-import importlib
 import os
 import threading
 import uuid
@@ -37,6 +36,7 @@ from arcade.cli.utils import (
     load_eval_suites,
     log_engine_health,
     validate_and_get_config,
+    version_callback,
 )
 
 cli = typer.Typer(
@@ -476,13 +476,6 @@ def workerup(
         error_message = f"❌ Failed to start Arcade Worker: {escape(str(e))}"
         console.print(error_message, style="bold red")
         typer.Exit(code=1)
-
-
-def version_callback(value: bool) -> None:
-    if value:
-        version = importlib.import_module("arcade").__version__
-        console.print(f"[bold]Arcade[/bold] (version {version})")
-        exit()
 
 
 @cli.callback(help="Show the current version of Arcade CLI", rich_help_panel="User")

--- a/arcade/arcade/cli/main.py
+++ b/arcade/arcade/cli/main.py
@@ -478,7 +478,7 @@ def workerup(
         typer.Exit(code=1)
 
 
-@cli.callback(help="Show the current version of Arcade CLI", rich_help_panel="User")
+@cli.callback(help="Show the current version of Arcade", rich_help_panel="User")
 def version(
     _: bool = typer.Option(
         None,

--- a/arcade/arcade/cli/utils.py
+++ b/arcade/arcade/cli/utils.py
@@ -667,3 +667,13 @@ def parse_user_command(user_input: str) -> ChatCommand | None:
         return ChatCommand(user_input)
     except ValueError:
         return None
+
+
+def version_callback(value: bool) -> None:
+    """Callback for the --version CLI command.
+    Prints the version of Arcade and exit.
+    """
+    if value:
+        version = importlib.import_module("arcade").__version__
+        console.print(f"[bold]Arcade[/bold] (version {version})")
+        exit()

--- a/arcade/arcade/cli/utils.py
+++ b/arcade/arcade/cli/utils.py
@@ -670,7 +670,7 @@ def parse_user_command(user_input: str) -> ChatCommand | None:
 
 
 def version_callback(value: bool) -> None:
-    """Callback for the --version CLI command.
+    """Callback implementation for the `arcade --version`.
     Prints the version of Arcade and exit.
     """
     if value:


### PR DESCRIPTION
# PR Description
Implements a version callback for the arcade CLI.

### Usage
`arcade --version` OR `arcade -v`

### Example Output
`Arcade (version 0.1.5)`