### PR TITLE
Add Ability to Disable Tools 

### DIFF
--- a/arcade/arcade/core/catalog.py
+++ b/arcade/arcade/core/catalog.py
@@ -116,11 +116,11 @@ class ToolCatalog(BaseModel):
 
     _disabled_tools: set[str] = set()
 
-    def __init__(self, **data):
+    def __init__(self, **data) -> None:
         super().__init__(**data)
         self._load_disabled_tools()
 
-    def _load_disabled_tools(self):
+    def _load_disabled_tools(self) -> None:
         """Load disabled tools from the environment variable.
 
         The ARCADE_DISABLED_TOOLS environment variable should contain a

--- a/arcade/arcade/core/catalog.py
+++ b/arcade/arcade/core/catalog.py
@@ -116,7 +116,7 @@ class ToolCatalog(BaseModel):
 
     _disabled_tools: set[str] = set()
 
-    def __init__(self, **data) -> None:
+    def __init__(self, **data) -> None:  # type: ignore[no-untyped-def]
         super().__init__(**data)
         self._load_disabled_tools()
 

--- a/arcade/arcade/core/catalog.py
+++ b/arcade/arcade/core/catalog.py
@@ -1,5 +1,6 @@
 import asyncio
 import inspect
+import logging
 import os
 import re
 import typing
@@ -50,6 +51,8 @@ from arcade.core.utils import (
     is_union,
     snake_to_pascal_case,
 )
+
+logger = logging.getLogger(__name__)
 
 InnerWireType = Literal["string", "integer", "number", "boolean", "json"]
 WireType = Union[InnerWireType, Literal["array"]]
@@ -177,6 +180,7 @@ class ToolCatalog(BaseModel):
             raise KeyError(f"Tool '{definition.name}' already exists in the catalog.")
 
         if str(fully_qualified_name).lower() in self._disabled_tools:
+            logger.info(f"Tool '{fully_qualified_name!s}' is disabled and will not be cataloged.")
             return
 
         self._tools[fully_qualified_name] = MaterializedTool(
@@ -303,6 +307,12 @@ class ToolCatalog(BaseModel):
                 return tool
 
         raise ValueError(f"Tool {name} not found.")
+
+    def get_tool_count(self) -> int:
+        """
+        Get the number of tools in the catalog.
+        """
+        return len(self._tools)
 
     @staticmethod
     def create_tool_definition(

--- a/arcade/tests/core/test_catalog.py
+++ b/arcade/tests/core/test_catalog.py
@@ -166,3 +166,17 @@ def test_add_tool_with_disabled_tool(monkeypatch):
 
     catalog.add_tool(sample_tool, "SampleToolkitOne")
     assert len(catalog._tools) == 0
+
+
+def test_add_tool_with_empty_string_disabled_tools(monkeypatch):
+    monkeypatch.setenv("ARCADE_DISABLED_TOOLS", "")
+    catalog = ToolCatalog()
+    catalog.add_tool(sample_tool, "SampleToolkitOne")
+    assert len(catalog._tools) == 1
+
+
+def test_add_tool_with_whitespace_disabled_tools(monkeypatch):
+    monkeypatch.setenv("ARCADE_DISABLED_TOOLS", "        SampleToolkitOne.SampleTool    ")
+    catalog = ToolCatalog()
+    catalog.add_tool(sample_tool, "SampleToolkitOne")
+    assert len(catalog._tools) == 0

--- a/arcade/tests/core/test_catalog.py
+++ b/arcade/tests/core/test_catalog.py
@@ -136,3 +136,33 @@ def test_get_tool_by_name_with_invalid_version():
 
     with pytest.raises(ValueError):
         catalog.get_tool_by_name("SampleToolkit.SampleTool", version="2.0.0")
+
+
+def test_load_disabled_tools(monkeypatch):
+    disabled_tools = (
+        "SampleToolkitOne.SampleToolOne,"  # valid
+        + "SampleToolkitOne_SampleToolTwo,"  # invalid
+        + "SampleToolkitTwo.SampleToolThree,"  # valid
+        + "SampleToolkitTwo.SampleToolFour@0.0.1,"  # invalid
+        + "SampleToolkitThree_SampleToolFive@0.0.1,"  # invalid
+        + "SampleToolkitFour.sample_tool_six,"  # invalid
+        + "sample_toolkit5.SampleTool7,"  # invalid
+        + "sample_toolkit6.sample_tool_8"  # invalid
+    )
+    expected_disabled_tools = {
+        "SampleToolkitOne.SampleToolOne",
+        "SampleToolkitTwo.SampleToolThree",
+    }
+
+    monkeypatch.setenv("ARCADE_DISABLED_TOOLS", disabled_tools)
+    catalog = ToolCatalog()
+
+    assert catalog._disabled_tools == expected_disabled_tools
+
+
+def test_add_tool_with_disabled_tool(monkeypatch):
+    monkeypatch.setenv("ARCADE_DISABLED_TOOLS", "SampleToolkitOne.SampleTool")
+    catalog = ToolCatalog()
+
+    catalog.add_tool(sample_tool, "SampleToolkitOne")
+    assert len(catalog._tools) == 0

--- a/arcade/tests/core/test_catalog.py
+++ b/arcade/tests/core/test_catalog.py
@@ -176,7 +176,7 @@ def test_add_tool_with_empty_string_disabled_tools(monkeypatch):
 
 
 def test_add_tool_with_whitespace_disabled_tools(monkeypatch):
-    monkeypatch.setenv("ARCADE_DISABLED_TOOLS", "        SampleToolkitOne.SampleTool    ")
+    monkeypatch.setenv("ARCADE_DISABLED_TOOLS", "            ")
     catalog = ToolCatalog()
     catalog.add_tool(sample_tool, "SampleToolkitOne")
-    assert len(catalog._tools) == 0
+    assert len(catalog._tools) == 1

--- a/arcade/tests/core/test_catalog.py
+++ b/arcade/tests/core/test_catalog.py
@@ -150,8 +150,8 @@ def test_load_disabled_tools(monkeypatch):
         + "sample_toolkit6.sample_tool_8"  # invalid
     )
     expected_disabled_tools = {
-        "SampleToolkitOne.SampleToolOne",
-        "SampleToolkitTwo.SampleToolThree",
+        "sampletoolkitone.sampletoolone",
+        "sampletoolkittwo.sampletoolthree",
     }
 
     monkeypatch.setenv("ARCADE_DISABLED_TOOLS", disabled_tools)


### PR DESCRIPTION
# PR Description
This PR introduces a new environment variable `ARCADE_DISABLED_TOOLS`. Tools that are added to this env var are not added to the worker's `ToolCatalog`. In effect, they are disabled for the worker.

## How to use the `ARCADE_DISABLED_TOOLS` environment variable
* Each tool is separated by a comma.
* For each tool, specify the toolkit name in camel case and the tool name in camel case.
* Do not include versions. (This is a simple implementation. We can add disabling specific versions in the future if needed)
* Separate the toolkit name and the tool name with your environment's tool name separator. By default, the tool name separator is `.`, but you can override this with the `ARCADE_TOOL_NAME_SEPARATOR` environment variable.

Correct: `export ARCADE_DISABLED_TOOLS="Math.Add,Spotify.GetAvailableDevices,Math.Sqrt"`
Incorrect: `export ARCADE_DISABLED_TOOLS="Math.Add@0.1.0,Spotify.get_available_devices,Sqrt`
