### PR TITLE
Make starred = True by default in Github tool

### DIFF
--- a/toolkits/github/arcade_github/tools/activity.py
+++ b/toolkits/github/arcade_github/tools/activity.py
@@ -14,7 +14,7 @@ async def set_starred(
     context: ToolContext,
     owner: Annotated[str, "The owner of the repository"],
     name: Annotated[str, "The name of the repository"],
-    starred: Annotated[bool, "Whether to star the repository or not"],
+    starred: Annotated[bool, "Whether to star the repository or not"] = True,
 ) -> Annotated[
     str, "A message indicating whether the repository was successfully starred or unstarred"
 ]:


### PR DESCRIPTION
`starred` is a required argument of the `arcade_github.activity.set_starred` tool, but when it is not provided in the tool call, the engine is somehow passing it with a falsy value, instead of raising an error. the falsy value makes the tool unstar a repo by default, which is not the desired behavior.

we're setting the `starred` arg to True in the tool interface to prevent that.