### PR TITLE
Fix dashboard redirect in docker compose

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.10-slim
 # Define build arguments with default values
 ARG PORT=8001
 ARG HOST=0.0.0.0
-ARG VERSION=${VERSION:-0.1.0}
+ARG VERSION=${VERSION:-1.0.1}
 ARG INSTALL_TOOLKITS=true
 
 # Set environment variables using the build arguments

--- a/docker/README.md
+++ b/docker/README.md
@@ -69,7 +69,7 @@ You should receive a response indicating that the engine is healthy:
 { "status": "healthy" }
 ```
 
-You can also view the swagger docs at `http://localhost:9099/swagger/index.html`
+Open a browser and navigate to http://localhost:9099/dashboard to view the Arcade dashboard.
 
 ## Adding Authentication Providers
 

--- a/docker/docker.engine.yaml
+++ b/docker/docker.engine.yaml
@@ -171,3 +171,6 @@ auth:
       provider_id: zoom
       client_id: ${env:ZOOM_CLIENT_ID}
       client_secret: ${env:ZOOM_CLIENT_SECRET}
+
+dashboard:
+  redirect_uri: "http://localhost:9099/dashboard"


### PR DESCRIPTION
When the Engine is running via `docker compose`, the login redirect for the Dashboard was ending up at `0.0.0.0` instead of `localhost`. 