### PR TITLE
Decorator to warn the deprecation of an Arcade tool

### DIFF
--- a/arcade/arcade/sdk/warns.py
+++ b/arcade/arcade/sdk/warns.py
@@ -1,11 +1,12 @@
 import warnings
 from functools import wraps
+from typing import Any, Callable
 
 
-def deprecated(reason: str, stacklevel: int = 3):
-    def decorator(func):
+def deprecated(reason: str, stacklevel: int = 3) -> Callable:
+    def decorator(func: Callable) -> Callable:
         @wraps(func)
-        async def wrapper(*args, **kwargs):
+        async def wrapper(*args: Any, **kwargs: Any) -> Any:
             warnings.warn(
                 f"{func.__name__} is deprecated: {reason}",
                 DeprecationWarning,

--- a/arcade/arcade/sdk/warns.py
+++ b/arcade/arcade/sdk/warns.py
@@ -1,0 +1,18 @@
+import warnings
+from functools import wraps
+
+
+def deprecated(reason: str, stacklevel: int = 3):
+    def decorator(func):
+        @wraps(func)
+        async def wrapper(*args, **kwargs):
+            warnings.warn(
+                f"{func.__name__} is deprecated: {reason}",
+                DeprecationWarning,
+                stacklevel=stacklevel,
+            )
+            return await func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/arcade/pyproject.toml
+++ b/arcade/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "arcade-ai"
-version = "1.0.1"
+version = "1.0.2"
 description = "Arcade Python SDK and CLI"
 readme = "README.md"
 packages = [

--- a/arcade/tests/sdk/test_warns.py
+++ b/arcade/tests/sdk/test_warns.py
@@ -1,0 +1,33 @@
+import warnings
+
+import pytest
+
+from arcade.sdk.warns import deprecated
+
+
+@deprecated("please use new_function", stacklevel=3)
+async def add(a, b):
+    """A simple async function that adds two numbers."""
+    return a + b
+
+
+@pytest.mark.asyncio
+async def test_deprecated_warning_is_emitted():
+    # The context manager pytest.warns() will catch a warning matching the given criteria.
+    with pytest.warns(DeprecationWarning, match="add is deprecated: please use new_function"):
+        result = await add(2, 3)
+        assert result == 5
+
+
+@pytest.mark.asyncio
+async def test_deprecated_warning_multiple_calls():
+    # Make sure all DeprecationWarnings are caught, even if they are normally suppressed.
+    warnings.simplefilter("always", DeprecationWarning)
+    with pytest.warns(DeprecationWarning) as record:
+        results = []
+        for i in range(3):
+            results.append(await add(i, i))
+        # Check that the function returns the expected values.
+        assert results == [0, 2, 4]
+    # Ensure that a warning was raised for each call.
+    assert len(record) == 3


### PR DESCRIPTION
Implements a `deprecated` decorator to simplify raising a warning when a tool is set for deprecation.