### PR TITLE
Make fastapi a regular dependency

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,24 +2,8 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "Debug examples/fastapi",
-      "type": "python",
-      "request": "launch",
-      "module": "uvicorn",
-      "args": [
-        "main:app",
-        "--app-dir",
-        "${workspaceFolder}/examples/fastapi/arcade_example_fastapi",
-        "--port",
-        "8002"
-      ],
-      "jinja": true,
-      "justMyCode": true,
-      "cwd": "${workspaceFolder}/examples/fastapi/arcade_example_fastapi"
-    },
-    {
       "name": "Debug `arcade workerup --no-auth`",
-      "type": "python",
+      "type": "debugpy",
       "request": "launch",
       "program": "${workspaceFolder}/arcade/run_cli.py",
       "args": ["workerup", "--no-auth"],
@@ -29,8 +13,8 @@
       "cwd": "${workspaceFolder}"
     },
     {
-      "name": "Debug `arcade chat -s -d -h localhost`",
-      "type": "python",
+      "name": "Debug `arcade chat -d -h localhost`",
+      "type": "debugpy",
       "request": "launch",
       "program": "${workspaceFolder}/arcade/run_cli.py",
       "args": ["chat", "-d", "-h", "localhost"],
@@ -41,7 +25,7 @@
     },
     {
       "name": "Debug `arcade dev`",
-      "type": "python",
+      "type": "debugpy",
       "request": "launch",
       "program": "${workspaceFolder}/arcade/run_cli.py",
       "args": ["dev"],
@@ -52,7 +36,7 @@
     },
     {
       "name": "Debug `arcade evals -d` on current file",
-      "type": "python",
+      "type": "debugpy",
       "request": "launch",
       "program": "${workspaceFolder}/arcade/run_cli.py",
       "args": ["evals", "-d", "${fileDirname}", "-h", "localhost"],

--- a/Makefile
+++ b/Makefile
@@ -91,8 +91,8 @@ build-and-publish: build publish ## Build and publish.
 docker: ## Build and run the Docker container
 	@echo "🚀 Building arcade and toolkit wheels..."
 	@make full-dist
-	@echo "Writing extras requirements.txt"
-	@cd arcade && poetry export --extras "fastapi" --output ../dist/requirements.txt
+	@echo "Writing requirements.txt"
+	@cd arcade && poetry export --output ../dist/requirements.txt
 	@echo "🚀 Building Docker image"
 	@cd docker && make docker-build
 	@cd docker && make docker-run
@@ -101,8 +101,8 @@ docker: ## Build and run the Docker container
 docker-base: ## Build and run the Docker container
 	@echo "🚀 Building arcade and toolkit wheels..."
 	@make full-dist
-	@echo "Writing extras requirements.txt"
-	@cd arcade && poetry export --extras "fastapi" --output ../dist/requirements.txt
+	@echo "Writing requirements.txt"
+	@cd arcade && poetry export --output ../dist/requirements.txt
 	@echo "🚀 Building Docker image"
 	@cd docker && INSTALL_TOOLKITS=false make docker-build
 	@cd docker && INSTALL_TOOLKITS=false make docker-run

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ _Pst. hey, you, give us a star if you like it!_
 Install the package:
 
 ```bash
-pip install 'arcade-ai[fastapi]'
+pip install arcade-ai
 ```
 
 Log in to your account via the CLI:

--- a/arcade/arcade/cli/serve.py
+++ b/arcade/arcade/cli/serve.py
@@ -5,24 +5,11 @@ import sys
 from contextlib import asynccontextmanager
 from typing import Any
 
+import fastapi
+import uvicorn
 from loguru import logger
 
 from arcade.core.telemetry import OTELHandler
-
-try:
-    import fastapi
-except ImportError:
-    raise ImportError(
-        "FastAPI is not installed. Please install it using `pip install arcade-ai[fastapi]`."
-    )
-
-try:
-    import uvicorn
-except ImportError:
-    raise ImportError(
-        "Uvicorn is not installed. Please install it using `pip install arcade-ai[fastapi]`."
-    )
-
 from arcade.sdk import Toolkit
 from arcade.worker.fastapi.worker import FastAPIWorker
 

--- a/arcade/arcade/sdk/eval/critic.py
+++ b/arcade/arcade/sdk/eval/critic.py
@@ -214,7 +214,7 @@ class SimilarityCritic(Critic):
                 from sklearn.metrics.pairwise import cosine_similarity
             except ImportError:
                 raise ImportError(
-                    "Use `pip install arcade[evals]` to install the required dependencies for similarity metrics."
+                    "Use `pip install 'arcade-ai[evals]'` to install the required dependencies for similarity metrics."
                 )
             vectorizer = TfidfVectorizer()
             tfidf_matrix = vectorizer.fit_transform([expected, actual])

--- a/arcade/arcade/sdk/eval/eval.py
+++ b/arcade/arcade/sdk/eval/eval.py
@@ -13,7 +13,7 @@ try:
     from scipy.optimize import linear_sum_assignment
 except ImportError:
     raise ImportError(
-        "Use `pip install arcade-ai[evals]` to install the required dependencies for evaluation."
+        "Use `pip install 'arcade-ai[evals]'` to install the required dependencies for evaluation."
     )
 
 from openai import AsyncOpenAI

--- a/arcade/arcade/templates/{{ toolkit_name }}/README.md
+++ b/arcade/arcade/templates/{{ toolkit_name }}/README.md
@@ -53,7 +53,7 @@
 1. [Install the Arcade Engine Locally](https://docs.arcade.dev/home/install/local)
 2. Install extra dependencies needed for evals:
    ```bash
-   pip install 'arcade-ai[fastapi,evals]'
+   pip install 'arcade-ai[evals]'
    ```
 3. Log into Arcade:
    ```bash

--- a/arcade/arcade/worker/fastapi/__init__.py
+++ b/arcade/arcade/worker/fastapi/__init__.py
@@ -1,7 +1,0 @@
-import importlib.util
-
-# FastAPI is an optional dependency, so make sure it's installed
-if importlib.util.find_spec("fastapi") is None:
-    raise ImportError(
-        "FastAPI is not installed. Please install it using `pip install arcade-ai[fastapi]`."
-    )

--- a/arcade/pyproject.toml
+++ b/arcade/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "arcade-ai"
-version = "1.0.1"
+version = "1.1.0"
 description = "Arcade Python SDK and CLI"
 readme = "README.md"
 packages = [
@@ -27,11 +27,11 @@ loguru = "^0.7.0"
 tqdm = "^4.1.0"
 types-python-dateutil = "2.9.0.20241003"
 types-pytz = "2024.2.0.20241003"
-opentelemetry-instrumentation-fastapi = {version = "0.48b0", optional = true}
-opentelemetry-exporter-otlp-proto-http = {version = "1.27.0", optional = true}
-opentelemetry-exporter-otlp-proto-common = {version = "1.27.0", optional = true}
-fastapi = {version = "^0.115.3", optional = true}
-uvicorn = {version = "^0.30.0", optional = true}
+opentelemetry-instrumentation-fastapi = "0.48b0"
+opentelemetry-exporter-otlp-proto-http = "1.27.0"
+opentelemetry-exporter-otlp-proto-common = "1.27.0"
+fastapi = "^0.115.3"
+uvicorn = "^0.30.0"
 scipy = {version = "^1.14.0", optional = true}
 numpy = {version = "^2.0.0", optional = true}
 scikit-learn = {version = "^1.5.0", optional = true}
@@ -40,7 +40,6 @@ python-dateutil = {version = "^2.8.2", optional = true}
 
 pyreadline3 = {version = "^3.5.4", platform = "win32"}
 [tool.poetry.extras]
-fastapi = ["fastapi", "uvicorn", "opentelemetry-instrumentation-fastapi", "opentelemetry-exporter-otlp-proto-http", "opentelemetry-exporter-otlp-proto-common"]
 evals = ["scipy", "numpy", "scikit-learn", "pytz", "python-dateutil"]
 
 [tool.poetry.group.dev.dependencies]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -37,7 +37,7 @@ RUN ls -la /app/arcade/
 # Conditional installation based on version
 RUN if [ ! "$(echo ${VERSION} | grep -E '\.dev0$')" ]; then \
     echo "Installing wheel file" && \
-    python -m pip install ./arcade_ai-${VERSION}-py3-none-any.whl fastapi && \
+    python -m pip install ./arcade_ai-${VERSION}-py3-none-any.whl && \
     python -m pip install -r ./requirements.txt; \
     else \
     echo "Installing from source" && \
@@ -45,7 +45,6 @@ RUN if [ ! "$(echo ${VERSION} | grep -E '\.dev0$')" ]; then \
     pip install poetry && \
     poetry lock && \
     poetry version 0.1.0 && \
-    pip install fastapi && \
     pip install -r requirements.txt && \
     pip install .; \
     fi

--- a/examples/serving-tools/modal/run-arcade-worker.py
+++ b/examples/serving-tools/modal/run-arcade-worker.py
@@ -9,7 +9,7 @@ toolkits = ["arcade-google", "arcade-slack"]
 
 image = (
     Image.debian_slim()
-    .pip_install("arcade-ai[fastapi]")
+    .pip_install("arcade-ai")
     .pip_install(toolkits)
     .pip_install("fastapi>=0.115.3")
     .pip_install("uvicorn>=0.24.0")

--- a/examples/serving-tools/modal/run-arcade-worker.py
+++ b/examples/serving-tools/modal/run-arcade-worker.py
@@ -7,13 +7,7 @@ app = App("arcade-worker")
 
 toolkits = ["arcade-google", "arcade-slack"]
 
-image = (
-    Image.debian_slim()
-    .pip_install("arcade-ai")
-    .pip_install(toolkits)
-    .pip_install("fastapi>=0.115.3")
-    .pip_install("uvicorn>=0.24.0")
-)
+image = Image.debian_slim().pip_install("arcade-ai").pip_install(toolkits)
 
 
 @app.function(image=image)


### PR DESCRIPTION
## PR Description
Changes `pip install 'arcade-ai[fastapi]'` to `pip install arcade-ai`. 
In other words, FastAPI is now a required dependecy of arcade-ai.


Additionally, I snuck in some minor cleanup changes.