### PR TITLE
Fix langchain-arcade `SyncOffsetPage` iteration

### DIFF
--- a/contrib/langchain/README.md
+++ b/contrib/langchain/README.md
@@ -18,7 +18,6 @@
 <p align="center">
     <a href="https://docs.arcade-ai.com" target="_blank">Docs</a> •
     <a href="https://docs.arcade-ai.com/integrations" target="_blank">Integrations</a> •
-    <a href="https://github.com/ArcadeAI/cookbook" target="_blank">Cookbook</a> •
     <a href="https://github.com/ArcadeAI/arcade-py" target="_blank">Python Client</a> •
     <a href="https://github.com/ArcadeAI/arcade-js" target="_blank">JavaScript Client</a>
 </p>

--- a/contrib/langchain/langchain_arcade/manager.py
+++ b/contrib/langchain/langchain_arcade/manager.py
@@ -200,14 +200,14 @@ class ArcadeToolManager:
         if toolkits:
             for tk in toolkits:
                 # tools.list(...) returns a paginated response (SyncOffsetPage),
-                # so we iterate over its items to accumulate tool definitions.
+                # which has an __iter__ method that automatically iterates over all pages.
                 paginated_tools = self.client.tools.list(toolkit=tk)
-                all_tools.extend(paginated_tools.items)
+                all_tools.extend(paginated_tools)
 
         # If no specific tools or toolkits were requested, retrieve *all* tools.
         if not tools and not toolkits:
             paginated_all_tools = self.client.tools.list()
-            all_tools.extend(paginated_all_tools.items)
+            all_tools.extend(paginated_all_tools)
         # Build a dictionary that maps the "full_tool_name" to the tool definition.
         tool_definitions: dict[str, ToolDefinition] = {}
         for tool in all_tools:

--- a/contrib/langchain/pyproject.toml
+++ b/contrib/langchain/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "langchain-arcade"
-version = "1.0.0"
+version = "1.0.1"
 description = "An integration package connecting Arcade and LangChain/LangGraph"
 authors = ["Arcade <dev@arcade.dev>"]
 readme = "README.md"


### PR DESCRIPTION
## PR Description
The `ArcadeToolManager` was retrieving tools from the Arcade client incorrectly as it was only returning the first page of results.

This PR removes the use of `SyncOffsetPage`'s `.items` attribute since `.items` only contains the tools in the **current page**. Since `SyncOffsetPage` implements an `__iter__` that iterates over all pages, we can simply drop the `.items`.

## Try it for yourself
Run the following code without the changes in this PR and notice that only 25 tools are in the internal tool list, which also happens to be the size of a page. Now run again, but with the changes in this PR and notice that all tools hosted by Arcade are in the internal tool list.
```python
import os

from langchain_arcade import ArcadeToolManager

arcade_api_key = os.environ.get("ARCADE_API_KEY")
manager = ArcadeToolManager(api_key=arcade_api_key)

tools = manager.init_tools()
print(len(manager.tools))
```