### PR TITLE
fix: add missing --model option

### DIFF
--- a/arcade/arcade/cli/main.py
+++ b/arcade/arcade/cli/main.py
@@ -184,7 +184,7 @@ def show(
 
 @cli.command(help="Start Arcade Chat in the terminal", rich_help_panel="Launch")
 def chat(
-    model: str = typer.Option("gpt-4o", "-m", help="The model to use for prediction."),
+    model: str = typer.Option("gpt-4o", "-m", "--model", help="The model to use for prediction."),
     stream: bool = typer.Option(
         False, "-s", "--stream", is_flag=True, help="Stream the tool output."
     ),


### PR DESCRIPTION
Fixes an inconsistency in `arcade chat --help`.

Before:
<img width="590" alt="image" src="https://github.com/user-attachments/assets/bf643e3c-ee12-421a-8cd3-e0d322c0972a" />

After:
<img width="588" alt="image" src="https://github.com/user-attachments/assets/c0a40cdf-3429-468c-9bf1-9e3710907796" />
