### PR TITLE
fix: Package version in pyproject.toml is wrong

### DIFF
--- a/arcade/pyproject.toml
+++ b/arcade/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "arcade-ai"
-version = "1.2.0"
+version = "1.0.5"
 description = "Arcade Python SDK and CLI"
 readme = "README.md"
 packages = [


### PR DESCRIPTION
Package [1.0.5](https://pypi.org/project/arcade-ai/1.0.5/) is currently the latest on pypi. The version number in pyproject.toml got out of sync.

The next release should be 1.1.0 to take into account these minor version changes that _should_ have bumped the version:
- https://github.com/ArcadeAI/arcade-ai/pull/243
- https://github.com/ArcadeAI/arcade-ai/pull/252