### PR TITLE
Fix examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,7 +435,7 @@ auth_response = client.tools.authorize(
 # If the tool is not already authorized, prompt the user to authenticate
 if auth_response.status != "completed":
     print("Please authorize by visiting:")
-    print(auth_response.authorization_url)
+    print(auth_response.url)
     client.auth.wait_for_completion(auth_response)
 
 # Execute the tool to send a Slack message after authorization

--- a/examples/call_a_tool_directly_with_auth.py
+++ b/examples/call_a_tool_directly_with_auth.py
@@ -23,7 +23,7 @@ def call_auth_tool(client: Arcade, user_id: str) -> None:
 
     # If not already authorized, then wait for the user to authorize the permissions required by the tool
     if auth_response.status != "completed":
-        print(f"Click this link to authorize: {auth_response.authorization_url}")
+        print(f"Click this link to authorize: {auth_response.url}")
 
     # Wait for the user to complete the auth flow, if necessary
     client.auth.wait_for_completion(auth_response)


### PR DESCRIPTION
Somehow these have slipped through the cracks. It hasn't been `authorization_url` for some time.