### PR TITLE
Fix publish toolkit workflow

### DIFF
--- a/.github/workflows/publish-toolkit.yml
+++ b/.github/workflows/publish-toolkit.yml
@@ -60,11 +60,17 @@ jobs:
         echo "version=$VERSION" >> $GITHUB_OUTPUT
         poetry config pypi-token.pypi ${{ secrets.PYPI_TOKEN }}
         # Attempt to publish the toolkit to PyPI. Skip if the version already exists
-        if poetry publish --skip-existing 2>&1 | grep -q "File exists. Skipping"; then
-          echo "Version already exists on PyPI. Skipping publish."
-          echo "skip_publish=true" >> $GITHUB_OUTPUT
+        if OUTPUT=$(poetry publish --skip-existing 2>&1); then
+          if echo "$OUTPUT" | grep -q "File exists. Skipping"; then
+            echo "Version already exists on PyPI. Skipping publish."
+            echo "skip_publish=true" >> $GITHUB_OUTPUT
+          else
+            echo "skip_publish=false" >> $GITHUB_OUTPUT
+          fi
         else
-          echo "skip_publish=false" >> $GITHUB_OUTPUT
+          echo "Failed to publish package:"
+          echo "$OUTPUT"
+          exit 1
         fi
 
     - name: Send status to Slack

--- a/.github/workflows/publish-toolkit.yml
+++ b/.github/workflows/publish-toolkit.yml
@@ -59,18 +59,21 @@ jobs:
         VERSION=$(poetry version -s)
         echo "version=$VERSION" >> $GITHUB_OUTPUT
         poetry config pypi-token.pypi ${{ secrets.PYPI_TOKEN }}
-        # Attempt to publish the toolkit to PyPI. Skip if the version already exists
-        if OUTPUT=$(poetry publish --skip-existing 2>&1); then
-          if echo "$OUTPUT" | grep -q "File exists. Skipping"; then
-            echo "Version already exists on PyPI. Skipping publish."
-            echo "skip_publish=true" >> $GITHUB_OUTPUT
-          else
-            echo "skip_publish=false" >> $GITHUB_OUTPUT
-          fi
-        else
+        # Attempt to publish the toolkit to PyPI.
+        # If the toolkit version already exists, skip publishing.
+        # If another error occurs, exit with the error code so that the step fails.
+        PUBLISH_OUTPUT=$(poetry publish --skip-existing 2>&1)
+        PUBLISH_STATUS=$?
+        if echo "$PUBLISH_OUTPUT" | grep -q "File exists. Skipping"; then
+          echo "Version already exists on PyPI. Skipping publish."
+          echo "skip_publish=true" >> $GITHUB_OUTPUT
+        elif [ $PUBLISH_STATUS -ne 0 ]; then
           echo "Failed to publish package:"
-          echo "$OUTPUT"
-          exit 1
+          echo "$PUBLISH_OUTPUT"
+          echo "skip_publish=false" >> $GITHUB_OUTPUT
+          exit $PUBLISH_STATUS
+        else
+          echo "skip_publish=false" >> $GITHUB_OUTPUT
         fi
 
     - name: Send status to Slack

--- a/toolkits/notion/pyproject.toml
+++ b/toolkits/notion/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "arcade_notion"
-version = "0.1.0"
+version = "0.0.1"
 description = "LLM tools for essential Notion interactions such as creating, updating, retrieving, and searching pages."
 authors = ["ArcadeAI <dev@arcade.dev>"]
 


### PR DESCRIPTION
There was a bug where if the poetry publish failed, then the slack message would say that it succeeded.

I am setting the notion toolkit version to 0.0.1. This is expected to fail. I'm doing this to ensure the E2E issue is fixed.

The grep'd string comes from https://github.com/python-poetry/poetry/blob/main/src/poetry/publishing/uploader.py#L246-L249 