### PR TITLE
Bump notion version

### DIFF
--- a/toolkits/notion/pyproject.toml
+++ b/toolkits/notion/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "arcade_notion_toolkit"
-version = "0.1.0"
+version = "0.1.1"
 description = "LLM tools for essential Notion interactions such as creating, updating, retrieving, and searching pages."
 authors = ["ArcadeAI <dev@arcade.dev>"]
 


### PR DESCRIPTION
when testing earlier, 0.1.0 was used for a failed pypi upload. I'm assuming this is why `This filename has already been used, use a different version` is occuring