### PR TITLE
Fix Search.SearchJobs for Anthropic Models

### DIFF
--- a/toolkits/search/arcade_search/tools/google_jobs.py
+++ b/toolkits/search/arcade_search/tools/google_jobs.py
@@ -23,7 +23,7 @@ async def search_jobs(
     ] = None,
     language: Annotated[
         str,
-        "2-character language code to use in the Google Jobs search. ",
+        "2-character language code to use in the Google Jobs search. "
         f"E.g. 'en' for English. Defaults to '{DEFAULT_GOOGLE_JOBS_LANGUAGE}'.",
     ] = DEFAULT_GOOGLE_JOBS_LANGUAGE,
     limit: Annotated[

--- a/toolkits/search/pyproject.toml
+++ b/toolkits/search/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "arcade_search"
-version = "1.2.0"
+version = "1.2.1"
 description = "Tools for searching the web"
 authors = ["Arcade <dev@arcade.dev>"]
 


### PR DESCRIPTION
Fixes this error:

```bash
openai.InternalServerError: Error code: 503 - {'name': 'all_models_unavailable', 'message': "failed to chat with models; Attempt 0: anthropic - anthropic (type = error, message = tools.75.custom.input_schema.properties: Property keys should match pattern '^[a-zA-Z0-9_-]{1,64}$'); Attempt 1: anthropic - anthropic (type = error, message = tools.75.custom.input_schema.properties: Property keys should match pattern '^[a-zA-Z0-9_-]{1,64}$'); Attempt 2: anthropic - anthropic (type = error, message = tools.75.custom.input_schema.properties: Property keys should match pattern '^[a-zA-Z0-9_-]{1,64}$')"}
```