### PR TITLE
Improve error message when an exception is raised at toolkit import time upon Worker startup

### DIFF
--- a/arcade/arcade/core/catalog.py
+++ b/arcade/arcade/core/catalog.py
@@ -243,9 +243,9 @@ class ToolCatalog(BaseModel):
                     tool_func = getattr(module, tool_name)
                     self.add_tool(tool_func, toolkit, module)
 
-                except AttributeError:
+                except AttributeError as e:
                     raise ToolDefinitionError(
-                        f"Could not find tool {tool_name} in module {module_name}"
+                        f"Could not import tool {tool_name} in module {module_name}. Reason: {e}"
                     )
                 except ImportError as e:
                     raise ToolDefinitionError(f"Could not import module {module_name}. Reason: {e}")


### PR DESCRIPTION
Upon Worker startup, when an exception raised in a toolkit at import time, the worker logged output will not display the cause of the exception, or even that there was an exception raised in the toolkit.

Instead, the worker logs only a not very useful message:

```
❌ Failed to start Arcade Worker: Could not find tool {tool_name} in module {toolkit_name}.tools.{module_name}
```

This PR improves the logged message by adding the cause of the error.