### PR TITLE
Normalize `arcade show -T` input

### DIFF
--- a/arcade/arcade/cli/utils.py
+++ b/arcade/arcade/cli/utils.py
@@ -55,7 +55,7 @@ def create_cli_catalog(
     Load toolkits from the python environment.
     """
     if toolkit:
-        toolkit = toolkit.lower()
+        toolkit = toolkit.lower().replace("-", "_")
         try:
             prefixed_toolkit = "arcade_" + toolkit
             toolkits = [Toolkit.from_package(prefixed_toolkit)]


### PR DESCRIPTION
Small change that normalizes the toolkit package name to use underscores instead of hyphens. Python packages use underscores, not hyphens

This prevents failures like the following:

<img width="1100" alt="Screenshot 2025-03-17 at 6 17 41 PM" src="https://github.com/user-attachments/assets/980fca9d-122f-468b-92fc-6939e74abaaa" />
