### PR TITLE
chore: apt-get ugprade in dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,7 +13,7 @@ ENV OTEL_ENABLE=false
 ENV ARCADE_WORK_DIR=/app
 
 # Install system dependencies
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get upgrade && apt-get install -y \
     libssl-dev \
     python3-dev \
     curl \


### PR DESCRIPTION
Adds `apt-get upgrade` to ensure that system packages are up to date in the image