### PR TITLE
In arcade chat, ground the LLM with today's date for better accuracy

### DIFF
--- a/arcade/arcade/cli/main.py
+++ b/arcade/arcade/cli/main.py
@@ -36,6 +36,7 @@ from arcade.cli.utils import (
     compute_base_url,
     compute_login_url,
     get_eval_files,
+    get_today_context,
     get_user_input,
     handle_chat_interaction,
     handle_tool_authorization,
@@ -242,7 +243,15 @@ def chat(
         # start messages conversation
         history: list[dict[str, Any]] = []
 
+        # Ground the LLM with today's date and day of the week to help when calling date-related tools
+        # in case the user refers to relative dates (e.g. next Monday, last month, etc)
+        today_context = get_today_context()
+
         if prompt:
+            prompt = f"{today_context} {prompt}"
+        else:
+            prompt = today_context
+
             history.append({"role": "system", "content": prompt})
 
         display_arcade_chat_header(base_url, stream)

--- a/arcade/arcade/cli/utils.py
+++ b/arcade/arcade/cli/utils.py
@@ -2,6 +2,7 @@ import importlib.util
 import ipaddress
 import webbrowser
 from dataclasses import dataclass
+from datetime import datetime
 from enum import Enum
 from pathlib import Path
 from textwrap import dedent
@@ -658,3 +659,9 @@ def version_callback(value: bool) -> None:
         version = importlib.import_module("arcade").__version__
         console.print(f"[bold]Arcade[/bold] (version {version})")
         exit()
+
+
+def get_today_context() -> str:
+    today = datetime.now().strftime("%Y-%m-%d")
+    day_of_week = datetime.now().strftime("%A")
+    return f"Today is {today}, {day_of_week}."


### PR DESCRIPTION
Some tools have date-related arguments where LLMs fail to provide the correct values if the user asks in a relative way (e.g. next Monday, last month, etc). By including today's date and day of the week in the `arcade chat` system prompt, we avoid that issue.