### PR TITLE
Tool Metadata

### DIFF
--- a/arcade/arcade/core/schema.py
+++ b/arcade/arcade/core/schema.py
@@ -312,7 +312,9 @@ class ToolContext(BaseModel):
         """Retrieve the metadata for the tool invocation."""
         return self._get_item(key, self.metadata, "metadata")
 
-    def _get_item(self, key: str, items: list, item_name: str) -> str:
+    def _get_item(
+        self, key: str, items: list[ToolMetadataItem] | list[ToolSecretItem] | None, item_name: str
+    ) -> str:
         if not key or not key.strip():
             raise ValueError(
                 f"{item_name.capitalize()} key passed to get_{item_name} cannot be empty."

--- a/arcade/arcade/core/schema.py
+++ b/arcade/arcade/core/schema.py
@@ -1,5 +1,6 @@
 import os
 from dataclasses import dataclass
+from enum import Enum
 from typing import Any, Literal, Optional, Union
 
 from pydantic import BaseModel, Field
@@ -107,6 +108,19 @@ class ToolSecretRequirement(BaseModel):
 
     key: str
     """The ID of the secret."""
+
+
+class ToolMetadataKey(str, Enum):
+    """Convience enum for commonly used metadata keys."""
+
+    CLIENT_ID = "client_id"
+    COORDINATOR_URL = "coordinator_url"
+
+    @staticmethod
+    def requires_auth(key: str) -> bool:
+        """Whether the key depends on the tool having an authorization requirement."""
+        keys_that_require_auth = [ToolMetadataKey.CLIENT_ID]
+        return key.strip().lower() in keys_that_require_auth
 
 
 class ToolMetadataRequirement(BaseModel):

--- a/arcade/arcade/sdk/__init__.py
+++ b/arcade/arcade/sdk/__init__.py
@@ -1,5 +1,5 @@
 from arcade.core.catalog import ToolCatalog
-from arcade.core.schema import ToolAuthorizationContext, ToolContext
+from arcade.core.schema import ToolAuthorizationContext, ToolContext, ToolMetadataKey
 from arcade.core.toolkit import Toolkit
 
 from .tool import tool
@@ -8,6 +8,7 @@ __all__ = [
     "ToolAuthorizationContext",
     "ToolCatalog",
     "ToolContext",
+    "ToolMetadataKey",
     "Toolkit",
     "tool",
 ]

--- a/arcade/arcade/sdk/tool.py
+++ b/arcade/arcade/sdk/tool.py
@@ -15,6 +15,7 @@ def tool(
     name: str | None = None,
     requires_auth: Union[ToolAuthorization, None] = None,
     requires_secrets: Union[list[str], None] = None,
+    requires_metadata: Union[list[str], None] = None,
 ) -> Callable:
     def decorator(func: Callable) -> Callable:
         func_name = str(getattr(func, "__name__", None))
@@ -24,6 +25,7 @@ def tool(
         func.__tool_description__ = desc or inspect.cleandoc(func.__doc__ or "")  # type: ignore[attr-defined]
         func.__tool_requires_auth__ = requires_auth  # type: ignore[attr-defined]
         func.__tool_requires_secrets__ = requires_secrets  # type: ignore[attr-defined]
+        func.__tool_requires_metadata__ = requires_metadata  # type: ignore[attr-defined]
 
         if inspect.iscoroutinefunction(func):
 

--- a/arcade/tests/core/test_schema.py
+++ b/arcade/tests/core/test_schema.py
@@ -1,6 +1,11 @@
 import pytest
 
-from arcade.core.schema import ToolAuthorizationContext, ToolContext, ToolSecretItem
+from arcade.core.schema import (
+    ToolAuthorizationContext,
+    ToolContext,
+    ToolMetadataItem,
+    ToolSecretItem,
+)
 
 
 def test_get_auth_token_or_empty_with_token():
@@ -68,5 +73,47 @@ def test_get_secret_when_secrets_is_none():
 def test_get_secret_with_empty_key():
     tool_context = ToolContext(secrets=[])
 
-    with pytest.raises(ValueError, match="Secret key ID passed to get_secret cannot be empty."):
+    with pytest.raises(ValueError, match="Secret key passed to get_secret cannot be empty."):
         tool_context.get_secret("")
+
+
+def test_get_metadata_valid():
+    key = "my_key"
+    val = "metadata_value"
+    metadata = [ToolMetadataItem(key=key, value=val)]
+    tool_context = ToolContext(metadata=metadata)
+
+    assert tool_context.get_metadata(key) == val
+
+
+def test_get_metadata_with_case_insensitive_key():
+    key = "My_key"
+    val = "metadata_value"
+    metadata = [ToolMetadataItem(key=key, value=val)]
+    tool_context = ToolContext(metadata=metadata)
+
+    assert tool_context.get_metadata(key.upper()) == val
+    assert tool_context.get_metadata(key.lower()) == val
+
+
+def test_get_metadata_key_not_found():
+    key = "nonexistent_key"
+    metadata = [ToolMetadataItem(key="other_key", value="another_metadata")]
+    tool_context = ToolContext(metadata=metadata)
+
+    with pytest.raises(ValueError, match=f"Metadata {key} not found in context."):
+        tool_context.get_metadata(key)
+
+
+def test_get_metadata_when_metadata_is_none():
+    tool_context = ToolContext(metadata=None)
+
+    with pytest.raises(ValueError, match="Metadatas not found in context."):
+        tool_context.get_metadata("missing_key")
+
+
+def test_get_metadata_with_empty_key():
+    tool_context = ToolContext(metadata=[])
+
+    with pytest.raises(ValueError, match="Metadata key passed to get_metadata cannot be empty."):
+        tool_context.get_metadata("")

--- a/arcade/tests/tool/test_create_tool_definition_errors.py
+++ b/arcade/tests/tool/test_create_tool_definition_errors.py
@@ -4,7 +4,7 @@ import pytest
 
 from arcade.core.catalog import ToolCatalog
 from arcade.core.errors import ToolDefinitionError
-from arcade.core.schema import ToolContext
+from arcade.core.schema import ToolContext, ToolMetadataKey
 from arcade.sdk import tool
 
 
@@ -81,6 +81,30 @@ def func_with_secret_requirement_invalid_type():
     pass
 
 
+@tool(
+    desc="A function with a required metadata with a missing key (illegal)",
+    requires_metadata=[""],
+)
+def func_with_missing_metadata_key(context: ToolContext):
+    pass
+
+
+@tool(
+    desc="A function that requires metadata with an invalid type (illegal)",
+    requires_metadata=[True],
+)
+def func_with_metadata_requirement_invalid_type():
+    pass
+
+
+@tool(
+    desc="A function with a required metadata key that depends on the tool having an auth requirement, but the tool does not have an auth requirement (illegal)",
+    requires_metadata=[ToolMetadataKey.CLIENT_ID],
+)
+def func_with_metadata_and_auth_dependency():
+    pass
+
+
 @pytest.mark.parametrize(
     "func_under_test, exception_type",
     [
@@ -138,6 +162,21 @@ def func_with_secret_requirement_invalid_type():
             func_with_secret_requirement_invalid_type,
             ToolDefinitionError,
             id=func_with_secret_requirement_invalid_type.__name__,
+        ),
+        pytest.param(
+            func_with_missing_metadata_key,
+            ToolDefinitionError,
+            id=func_with_missing_metadata_key.__name__,
+        ),
+        pytest.param(
+            func_with_metadata_requirement_invalid_type,
+            ToolDefinitionError,
+            id=func_with_metadata_requirement_invalid_type.__name__,
+        ),
+        pytest.param(
+            func_with_metadata_and_auth_dependency,
+            ToolDefinitionError,
+            id=func_with_metadata_and_auth_dependency.__name__,
         ),
         pytest.param(
             func_with_union_return_type_1,

--- a/schemas/preview/tool_definition.schema.jsonc
+++ b/schemas/preview/tool_definition.schema.jsonc
@@ -159,6 +159,24 @@
             }
           ]
         },
+        "metadata": {
+          "oneOf": [
+            { "type": "null" }, // Can be unset,
+            {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "key": {
+                    "type": "string"
+                  }
+                },
+                "required": ["key"],
+                "additionalProperties": false
+              }
+            }
+          ]
+        },
         "authorization": {
           "oneOf": [
             { "type": "null" }, // Can be unset


### PR DESCRIPTION
Adds the ability to specify required metadata for a tool which is injected into the tool's context before execution.

Example of a tool that requires metadata:
```python
from typing import Annotated

from arcade.sdk import ToolContext, ToolMetadataKey, tool
from arcade.sdk.auth import Google


@tool(
    requires_auth=Google(),
    requires_metadata=[ToolMetadataKey.CLIENT_ID, ToolMetadataKey.COORDINATOR_URL])
def my_metadata_tool(context: ToolContext) -> Annotated[str, "Some metadata"]:
    """Gets some metadata"""
    google_client_id = context.get_metadata(ToolMetadataKey.CLIENT_ID)
    cloud_coordinator_url = context.get_metadata(ToolMetadataKey.COORDINATOR_URL)
    
    return f"My Google Client ID: {google_client_id}, My Cloud Coordinator URL: {cloud_coordinator_url}"