### PR TITLE
Bump Python version for Worker's Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim
+FROM python:3.11-slim
 
 # Define build arguments with default values
 ARG PORT=8001


### PR DESCRIPTION
[build-and-publish](https://github.com/ArcadeAI/arcade-ai/actions/runs/14522118587/job/40745392086) is failing to build the Worker container because the arcade-stripe toolkit requires Python >=3.11. The arcade-stripe toolkit has a dependency that requires >=3.11, so we can't loosen the toolkit's requirement.