### PR TITLE
Update Salesforce provider id

### DIFF
--- a/toolkits/salesforce/arcade_salesforce/models.py
+++ b/toolkits/salesforce/arcade_salesforce/models.py
@@ -30,7 +30,7 @@ from arcade_salesforce.utils import (
 @dataclass
 class SalesforceClient:
     auth_token: str
-    org_domain: str | None = None
+    org_subdomain: str | None = None
     api_version: str = SALESFORCE_API_VERSION
     max_concurrent_requests: int = MAX_CONCURRENT_REQUESTS
 
@@ -40,11 +40,11 @@ class SalesforceClient:
     _semaphore: asyncio.Semaphore | None = None
 
     def __post_init__(self) -> None:
-        if self.org_domain is None:
-            self.org_domain = os.getenv("SALESFORCE_ORG_DOMAIN")
-        if self.org_domain is None:
+        if self.org_subdomain is None:
+            self.org_subdomain = os.getenv("SALESFORCE_ORG_SUBDOMAIN")
+        if self.org_subdomain is None:
             raise ValueError(
-                "Either `org_domain` argument or `SALESFORCE_ORG_DOMAIN` env var must be set"
+                "Either `org_subdomain` argument or `SALESFORCE_ORG_SUBDOMAIN` env var must be set"
             )
 
         if self._state_object_fields is None:
@@ -55,7 +55,7 @@ class SalesforceClient:
 
     @property
     def _base_url(self) -> str:
-        return f"https://{self.org_domain}.my.salesforce.com/services/data/{self.api_version}"
+        return f"https://{self.org_subdomain}.my.salesforce.com/services/data/{self.api_version}"
 
     @property
     def object_fields(self) -> dict[SalesforceObject, list[str]]:

--- a/toolkits/salesforce/arcade_salesforce/tools/crm/account.py
+++ b/toolkits/salesforce/arcade_salesforce/tools/crm/account.py
@@ -14,7 +14,7 @@ from arcade_salesforce.utils import clean_account_data
 # separate tools for each related object, so that we can return more items, when needed.
 @tool(
     requires_auth=OAuth2(
-        id="arcade-salesforce",
+        id="salesforce",
         scopes=[
             "read_account",
             "read_contact",
@@ -85,7 +85,7 @@ async def get_account_data_by_keywords(
 
 @tool(
     requires_auth=OAuth2(
-        id="arcade-salesforce",
+        id="salesforce",
         scopes=[
             "read_account",
             "read_contact",

--- a/toolkits/salesforce/arcade_salesforce/tools/crm/contact.py
+++ b/toolkits/salesforce/arcade_salesforce/tools/crm/contact.py
@@ -13,7 +13,7 @@ from arcade_salesforce.models import SalesforceClient
 # raise a RetryableToolError providing the matches for the user to choose.
 @tool(
     requires_auth=OAuth2(
-        id="arcade-salesforce",
+        id="salesforce",
         scopes=["write_contact"],
     )
 )

--- a/toolkits/salesforce/tests/test_salesforce_client.py
+++ b/toolkits/salesforce/tests/test_salesforce_client.py
@@ -27,7 +27,7 @@ async def test_get_account_success(mock_context, mock_httpx_client):
 
     client = SalesforceClient(
         auth_token=mock_context.authorization.token,
-        org_domain="org_domain",
+        org_subdomain="org_domain",
     )
     response = await client.get_account(account_id)
 
@@ -51,7 +51,7 @@ async def test_get_account_not_found_error(mock_context, mock_httpx_client):
 
     client = SalesforceClient(
         auth_token=mock_context.authorization.token,
-        org_domain="org_domain",
+        org_subdomain="org_domain",
     )
     response = await client.get_account(account_id)
     assert response is None
@@ -69,7 +69,7 @@ async def test_get_account_bad_request_error(mock_context, mock_httpx_client):
 
     client = SalesforceClient(
         auth_token=mock_context.authorization.token,
-        org_domain="org_domain",
+        org_subdomain="org_domain",
     )
     with pytest.raises(SalesforceToolExecutionError) as exc_info:
         await client.get_account(account_id)
@@ -88,7 +88,7 @@ async def test_get_account_internal_server_error(mock_context, mock_httpx_client
 
     client = SalesforceClient(
         auth_token=mock_context.authorization.token,
-        org_domain="org_domain",
+        org_subdomain="org_domain",
     )
     with pytest.raises(SalesforceToolExecutionError) as exc_info:
         await client.get_account(account_id)
@@ -101,7 +101,7 @@ async def test_create_contact(mock_context, mock_httpx_client):
 
     client = SalesforceClient(
         auth_token=mock_context.authorization.token,
-        org_domain="org_domain",
+        org_subdomain="org_domain",
     )
 
     mock_response = MagicMock(spec=httpx.Response)
@@ -133,7 +133,7 @@ async def test_create_contact(mock_context, mock_httpx_client):
 async def test_get_related_objects_success(mock_context, mock_httpx_client):
     client = SalesforceClient(
         auth_token=mock_context.authorization.token,
-        org_domain="org_domain",
+        org_subdomain="org_domain",
     )
 
     parent_object_id = "001gK000003DIn0QAG"
@@ -170,7 +170,7 @@ async def test_get_related_objects_not_found_error(mock_context, mock_httpx_clie
 
     client = SalesforceClient(
         auth_token=mock_context.authorization.token,
-        org_domain="org_domain",
+        org_subdomain="org_domain",
     )
 
     parent_object_id = "001gK000003DIn0QAG"
@@ -203,7 +203,7 @@ async def test_get_related_objects_not_found_error(mock_context, mock_httpx_clie
 async def test_get_notes_success(mock_build_soql_query, mock_context, mock_httpx_client):
     client = SalesforceClient(
         auth_token=mock_context.authorization.token,
-        org_domain="org_domain",
+        org_subdomain="org_domain",
     )
 
     note_data = {
@@ -256,7 +256,7 @@ async def test_get_notes_success(mock_build_soql_query, mock_context, mock_httpx
 async def test_get_notes_not_found_error(mock_build_soql_query, mock_context, mock_httpx_client):
     client = SalesforceClient(
         auth_token=mock_context.authorization.token,
-        org_domain="org_domain",
+        org_subdomain="org_domain",
     )
 
     mock_response = MagicMock(spec=httpx.Response)


### PR DESCRIPTION
Updating the auth provider's `id` to simply `salesforce`. We don't want it to be confused with a future well-known `provider_id` of `arcade-salesforce`.

Also, what the toolkit was referring to as `org_domain` is actually the organization's SUBdomain. We changed all references to "subdomain" to be more precise. The documentation has been updated accordingly.