### PR TITLE
Recursively search for evaluation files

### DIFF
--- a/arcade/arcade/cli/utils.py
+++ b/arcade/arcade/cli/utils.py
@@ -493,11 +493,7 @@ def get_eval_files(directory: str) -> list[Path]:
     directory_path = Path(directory).resolve()
 
     if directory_path.is_dir():
-        eval_files = [
-            f
-            for f in directory_path.iterdir()
-            if f.is_file() and f.name.startswith("eval_") and f.name.endswith(".py")
-        ]
+        eval_files = [f for f in directory_path.rglob("eval_*.py") if f.is_file()]
     elif directory_path.is_file():
         eval_files = (
             [directory_path]


### PR DESCRIPTION
Minor QOL improvemnt

Previously, `arcade evals <your-eval-directory>` would only find evaluations at the top level of the directory. This PR adds recursively searching through your-eval-directory. This is especially useful for larger toolkits that benefit from file structure organization.

The following file structure is now possible:
```
evals/
├── docs/
│   ├── eval_create_document.py
│   └── eval_delete_document.py
├── drive/
│   ├── eval_search_files.py
│   └── eval_get_content_of_file.py
├── contacts/
│   ├── eval_list_contacts.py
│   └── eval_update_contact.py
└── sheets/
    ├── eval_create_sheet.py
    └── eval_read_sheet.py
```