### PR TITLE
Remove Asana from worker toolkit list

### DIFF
--- a/docker/toolkits.txt
+++ b/docker/toolkits.txt
@@ -1,5 +1,4 @@
 arcade-code-sandbox
-arcade-asana
 arcade-dropbox
 arcade-github
 arcade-google


### PR DESCRIPTION
The Asana toolkit is not published yet, so it cannot be added to the worker's toolkit list. This is causing container build/publish on main branch to fail.