### PR TITLE
fix: update typer dependency to ^0.10.0 to fix Python 3.13 compatibility

### DIFF
--- a/arcade/pyproject.toml
+++ b/arcade/pyproject.toml
@@ -16,7 +16,7 @@ build-backend = "poetry.core.masonry.api"
 [tool.poetry.dependencies]
 python = ">=3.10,<4.0"
 pydantic = "^2.7.0"
-typer = "^0.9.0"
+typer = "^0.10.0"
 rich = "^13.7.1"
 Jinja2 = ">=3.1.5,<4.0.0"
 pyyaml = "^6.0"


### PR DESCRIPTION
## Description
Updates the typer dependency from ^0.9.0 to ^0.10.0 to fix compatibility issues with Python 3.13, specifically addressing the error:
```TypeError: Parameter.make_metavar() missing 1 required positional argument: 'ctx'```

## Changes
- Updated typer dependency in pyproject.toml from ^0.9.0 to ^0.10.0

## Testing
The change has been tested locally and resolves the TypeError when running the arcade CLI with Python 3.13.
```