### PR TITLE
Temp version change for core

### DIFF
--- a/libs/arcade-core/pyproject.toml
+++ b/libs/arcade-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "arcade-core"
-version = "2.0.0"
+version = "1.0.0"
 description = "Arcade Core - Core library for Arcade platform"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
Forgot to set up on the PyPI side. Temporarily changing back to 1.0.0, so that I can trigger a release when going back to 2.0.0