### PR TITLE
Slack tools to get user by email / username & performance improvements

### DIFF
--- a/toolkits/slack/arcade_slack/constants.py
+++ b/toolkits/slack/arcade_slack/constants.py
@@ -1,13 +1,18 @@
 import os
 
-from arcade_slack.custom_types import PositiveInt
+from arcade_slack.custom_types import PositiveNonZeroInt
 
 MAX_PAGINATION_SIZE_LIMIT = 200
 
-MAX_PAGINATION_TIMEOUT_SECONDS = PositiveInt(
+MAX_PAGINATION_TIMEOUT_SECONDS = PositiveNonZeroInt(
     os.environ.get(
         "MAX_PAGINATION_TIMEOUT_SECONDS",
         os.environ.get("MAX_SLACK_PAGINATION_TIMEOUT_SECONDS", 30),
     ),
     name="MAX_PAGINATION_TIMEOUT_SECONDS or MAX_SLACK_PAGINATION_TIMEOUT_SECONDS",
+)
+
+MAX_CONCURRENT_REQUESTS = PositiveNonZeroInt(
+    os.environ.get("SLACK_MAX_CONCURRENT_REQUESTS", 3),
+    name="SLACK_MAX_CONCURRENT_REQUESTS",
 )

--- a/toolkits/slack/arcade_slack/custom_types.py
+++ b/toolkits/slack/arcade_slack/custom_types.py
@@ -1,11 +1,11 @@
 from typing import NewType
 
 
-class PositiveInt(int):
-    def __new__(cls, value: str | int, name: str = "value") -> "PositiveInt":
+class PositiveNonZeroInt(int):
+    def __new__(cls, value: str | int, name: str = "value") -> "PositiveNonZeroInt":
         def validate(val: int) -> int:
-            if val <= 0:
-                raise ValueError(f"{name} must be positive, got {val}")
+            if val < 1:
+                raise ValueError(f"{name} must be a positive non-zero integer, got {val}")
             return val
 
         try:

--- a/toolkits/slack/arcade_slack/exceptions.py
+++ b/toolkits/slack/arcade_slack/exceptions.py
@@ -1,3 +1,6 @@
+from arcade_tdk.errors import RetryableToolError
+
+
 class SlackToolkitError(Exception):
     """Base class for all Slack toolkit errors."""
 
@@ -14,17 +17,21 @@ class ItemNotFoundError(SlackToolkitError):
     """Raised when an item is not found."""
 
 
-class UsernameNotFoundError(SlackToolkitError):
-    """Raised when a user is not found by the username searched"""
-
-    def __init__(self, usernames_found: list[str], username_not_found: str) -> None:
-        self.usernames_found = usernames_found
-        self.username_not_found = username_not_found
-
-
 class ConversationNotFoundError(SlackToolkitError):
     """Raised when a conversation is not found"""
 
 
 class DirectMessageConversationNotFoundError(ConversationNotFoundError):
     """Raised when a direct message conversation searched is not found"""
+
+
+class UsernameNotFoundError(RetryableToolError, SlackToolkitError):
+    """Raised when a user is not found by the username searched"""
+
+    def __init__(self, username: str, available_users: list[dict]) -> None:
+        super().__init__(
+            f"Username '{username}' not found",
+            developer_message=f"User with username '{username}' not found.",
+            additional_prompt_content=f"Available users: {available_users}",
+            retry_after_ms=100,
+        )

--- a/toolkits/slack/arcade_slack/tools/users.py
+++ b/toolkits/slack/arcade_slack/tools/users.py
@@ -19,6 +19,7 @@ from arcade_slack.utils import (
     extract_basic_user_info,
     is_user_a_bot,
     is_user_deleted,
+    short_human_users_info,
     short_user_info,
 )
 
@@ -112,7 +113,7 @@ async def get_user_by_username(
 
     raise UsernameNotFoundError(
         username=username,
-        available_users=[short_user_info(user) for user in users],
+        available_users=short_human_users_info(users),
     )
 
 
@@ -147,7 +148,7 @@ async def get_multiple_users_by_username(
         if user["name"].casefold() in usernames_lower:
             users_found.append(extract_basic_user_info(user))
             usernames_pending.remove(user["name"])
-        else:
+        elif not is_user_a_bot(user):
             available_users.append(short_user_info(user))
 
     response = {"users": users_found}

--- a/toolkits/slack/arcade_slack/tools/users.py
+++ b/toolkits/slack/arcade_slack/tools/users.py
@@ -1,12 +1,13 @@
+import asyncio
 from typing import Annotated, Any, cast
 
 from arcade_tdk import ToolContext, tool
 from arcade_tdk.auth import Slack
-from arcade_tdk.errors import RetryableToolError
+from arcade_tdk.errors import RetryableToolError, ToolExecutionError
 from slack_sdk.errors import SlackApiError
 from slack_sdk.web.async_client import AsyncWebClient
 
-from arcade_slack.constants import MAX_PAGINATION_TIMEOUT_SECONDS
+from arcade_slack.constants import MAX_CONCURRENT_REQUESTS, MAX_PAGINATION_TIMEOUT_SECONDS
 from arcade_slack.exceptions import UsernameNotFoundError
 from arcade_slack.models import (
     FindMultipleUsersByUsernameSentinel,
@@ -19,6 +20,7 @@ from arcade_slack.utils import (
     extract_basic_user_info,
     is_user_a_bot,
     is_user_deleted,
+    is_valid_email,
     short_human_users_info,
     short_user_info,
 )
@@ -98,6 +100,9 @@ async def get_user_by_username(
     is reached. If you have a user email, use the `Slack.GetUserByEmail` tool instead, which is
     more efficient.
     """
+    if not username:
+        raise ToolExecutionError("No username provided")
+
     slackClient = AsyncWebClient(token=context.get_auth_token_or_empty())
 
     users, _ = await async_paginate(
@@ -128,6 +133,9 @@ async def get_multiple_users_by_username(
     is reached. If you have the users' email addresses, use the `Slack.GetMultipleUsersByEmail` tool
     instead, which is more efficient.
     """
+    if not usernames:
+        raise ToolExecutionError("No usernames provided")
+
     slackClient = AsyncWebClient(token=context.get_auth_token_or_empty())
 
     users, _ = await async_paginate(
@@ -166,12 +174,15 @@ async def get_user_by_email(
     email: Annotated[str, "The email of the user to get"],
 ) -> Annotated[dict, "The user's info"]:
     """Get a user by their email address."""
+    if not is_valid_email(email):
+        raise ToolExecutionError(f"Invalid email address: {email}")
+
     slackClient = AsyncWebClient(token=context.get_auth_token_or_empty())
 
     try:
         response = await slackClient.users_lookupByEmail(email=email)
     except SlackApiError as e:
-        if e.response.get("error") == "user_not_found":
+        if e.response.get("error") in ["user_not_found", "users_not_found"]:
             users = await list_users(context)
             available_users = [
                 {"name": user["name"], "id": user["id"], "email": user.get("email")}
@@ -185,4 +196,49 @@ async def get_user_by_email(
                 additional_prompt_content=f"Available users: {available_users}",
                 retry_after_ms=500,
             )
-    return {"user": cast(dict, extract_basic_user_info(SlackUser(**response["user"])))}
+        else:
+            raise
+    else:
+        return {"user": cast(dict, extract_basic_user_info(SlackUser(**response["user"])))}
+
+
+@tool(requires_auth=Slack(scopes=["users:read", "users:read.email"]))
+async def get_multiple_users_by_email(
+    context: ToolContext,
+    emails: Annotated[list[str], "The emails of the users to get"],
+) -> Annotated[dict, "The users' info"]:
+    """Get multiple users by their email addresses."""
+    if not emails:
+        raise ToolExecutionError("No emails provided")
+
+    for email in emails:
+        if not is_valid_email(email):
+            raise ToolExecutionError(f"Invalid email address: {email}")
+
+    semaphore = asyncio.Semaphore(MAX_CONCURRENT_REQUESTS)
+
+    async def safe_get_user_by_email(email: str) -> dict[str, Any]:
+        async with semaphore:
+            try:
+                result = await get_user_by_email(context=context, email=email)
+                return {"email": email, "user": result["user"]}
+            except RetryableToolError:
+                return {"email": email, "user": None}
+
+    results = await asyncio.gather(*[safe_get_user_by_email(email) for email in emails if email])
+
+    users = []
+    emails_not_found = []
+
+    for result in results:
+        if result["user"]:
+            users.append(result["user"])
+        else:
+            emails_not_found.append(result["email"])
+
+    response: dict[str, Any] = {"users": users}
+
+    if emails_not_found:
+        response["emails_not_found"] = emails_not_found
+
+    return response

--- a/toolkits/slack/arcade_slack/tools/users.py
+++ b/toolkits/slack/arcade_slack/tools/users.py
@@ -151,7 +151,7 @@ async def get_multiple_users_by_username(
         elif not is_user_a_bot(user):
             available_users.append(short_user_info(user))
 
-    response = {"users": users_found}
+    response: dict[str, Any] = {"users": users_found}
 
     if usernames_pending:
         response["usernames_not_found"] = list(usernames_pending)
@@ -185,5 +185,4 @@ async def get_user_by_email(
                 additional_prompt_content=f"Available users: {available_users}",
                 retry_after_ms=500,
             )
-    user = response.get("user")
-    return {"user": extract_basic_user_info(user)}
+    return {"user": cast(dict, extract_basic_user_info(SlackUser(**response["user"])))}

--- a/toolkits/slack/arcade_slack/utils.py
+++ b/toolkits/slack/arcade_slack/utils.py
@@ -453,3 +453,10 @@ def short_user_info(user: dict) -> dict[str, str | None]:
 
 def short_human_users_info(users: list[dict]) -> list[dict[str, str | None]]:
     return [short_user_info(user) for user in users if not user.get("is_bot")]
+
+
+def is_valid_email(email: str) -> bool:
+    if "@" not in email:
+        return False
+    left, right = email.split("@", 1)
+    return len(left) > 0 and len(right) > 0 and "." in right

--- a/toolkits/slack/arcade_slack/utils.py
+++ b/toolkits/slack/arcade_slack/utils.py
@@ -442,7 +442,7 @@ def convert_relative_datetime_to_unix_timestamp(
     return int(current_unix_timestamp - seconds)
 
 
-def short_user_info(user: SlackUser) -> str:
+def short_user_info(user: dict) -> dict[str, str | None]:
     data = {"id": user.get("id")}
     if user.get("name"):
         data["name"] = user["name"]
@@ -451,5 +451,5 @@ def short_user_info(user: SlackUser) -> str:
     return data
 
 
-def short_human_users_info(users: list[SlackUser]) -> list[str]:
+def short_human_users_info(users: list[dict]) -> list[dict[str, str | None]]:
     return [short_user_info(user) for user in users if not user.get("is_bot")]

--- a/toolkits/slack/arcade_slack/utils.py
+++ b/toolkits/slack/arcade_slack/utils.py
@@ -449,3 +449,7 @@ def short_user_info(user: SlackUser) -> str:
     if isinstance(user.get("profile"), dict) and user["profile"].get("email"):
         data["email"] = user["profile"]["email"]
     return data
+
+
+def short_human_users_info(users: list[SlackUser]) -> list[str]:
+    return [short_user_info(user) for user in users if not user.get("is_bot")]

--- a/toolkits/slack/conftest.py
+++ b/toolkits/slack/conftest.py
@@ -38,6 +38,7 @@ def dummy_user_factory(random_str_factory: Callable[[int], str]):
         id_: str | None = None,
         name: str | None = None,
         email: str | None = None,
+        is_bot: bool = False,
     ):
         return {
             "id": id_ or random_str_factory(),
@@ -45,6 +46,7 @@ def dummy_user_factory(random_str_factory: Callable[[int], str]):
             "profile": {
                 "email": email or f"{random_str_factory()}@{random_str_factory()}.com",
             },
+            "is_bot": is_bot,
         }
 
     return dummy_user_factory

--- a/toolkits/slack/conftest.py
+++ b/toolkits/slack/conftest.py
@@ -1,3 +1,7 @@
+import random
+import string
+from collections.abc import Callable
+
 import pytest
 from arcade_tdk import ToolAuthorizationContext, ToolContext
 
@@ -18,3 +22,29 @@ def mock_chat_slack_client(mocker):
 def mock_users_slack_client(mocker):
     mock_client = mocker.patch("arcade_slack.tools.users.AsyncWebClient", autospec=True)
     return mock_client.return_value
+
+
+@pytest.fixture
+def random_str_factory():
+    def random_str_factory(length: int = 10):
+        return "".join(random.choices(string.ascii_letters + string.digits, k=length))  # noqa: S311
+
+    return random_str_factory
+
+
+@pytest.fixture
+def dummy_user_factory(random_str_factory: Callable[[int], str]):
+    def dummy_user_factory(
+        id_: str | None = None,
+        name: str | None = None,
+        email: str | None = None,
+    ):
+        return {
+            "id": id_ or random_str_factory(),
+            "name": name or random_str_factory(),
+            "profile": {
+                "email": email or f"{random_str_factory()}@{random_str_factory()}.com",
+            },
+        }
+
+    return dummy_user_factory

--- a/toolkits/slack/pyproject.toml
+++ b/toolkits/slack/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "arcade_slack"
-version = "0.4.3"
+version = "0.5.0"
 description = "Arcade.dev LLM tools for Slack"
 requires-python = ">=3.10"
 dependencies = [ "aiodns>=1.0,<2.0.0", "typing; python_version < '3.7'", "aiohttp>=3.7.3,<4.0.0", "arcade-tdk>=2.0.0,<3.0.0", "slack-sdk>=3.31.0,<4.0.0",]

--- a/toolkits/slack/tests/test_models.py
+++ b/toolkits/slack/tests/test_models.py
@@ -1,0 +1,17 @@
+from arcade_slack.models import FindMultipleUsersByUsernameSentinel, FindUserByUsernameSentinel
+
+
+def test_find_user_by_username_sentinel():
+    sentinel = FindUserByUsernameSentinel(username="jenifer")
+    assert sentinel(last_result=[{"name": "jack"}]) is False
+    assert sentinel(last_result=[{"name": "john"}, {"name": "jack"}]) is False
+    assert sentinel(last_result=[{"name": "hello"}, {"name": "jenifer"}]) is True
+    assert sentinel(last_result=[{"name": "JENIFER"}]) is True
+
+
+def test_find_multiple_users_by_username_sentinel():
+    sentinel = FindMultipleUsersByUsernameSentinel(usernames=["jenifer", "jack"])
+    assert sentinel(last_result=[{"name": "jack"}]) is False
+    assert sentinel(last_result=[{"name": "john"}, {"name": "jack"}]) is False
+    assert sentinel(last_result=[{"name": "hello"}, {"name": "JENIFER"}]) is True
+    assert sentinel(last_result=[{"name": "world"}]) is True

--- a/toolkits/slack/tests/test_users.py
+++ b/toolkits/slack/tests/test_users.py
@@ -149,8 +149,9 @@ async def test_get_user_by_username_with_pagination_success(
 async def test_get_user_by_username_not_found(mock_context, mock_slack_client, dummy_user_factory):
     user1 = dummy_user_factory()
     user2 = dummy_user_factory()
+    user3 = dummy_user_factory(is_bot=True)
 
-    mock_slack_client.users_list.return_value = {"ok": True, "members": [user1, user2]}
+    mock_slack_client.users_list.return_value = {"ok": True, "members": [user1, user2, user3]}
 
     with pytest.raises(UsernameNotFoundError) as e:
         await get_user_by_username(mock_context, username=user1["name"] + "not_found")
@@ -158,6 +159,7 @@ async def test_get_user_by_username_not_found(mock_context, mock_slack_client, d
     # Check that the error message contains the available users
     assert str(short_user_info(user1)) in e.value.additional_prompt_content
     assert str(short_user_info(user2)) in e.value.additional_prompt_content
+    assert str(short_user_info(user3)) not in e.value.additional_prompt_content
 
 
 @pytest.mark.asyncio
@@ -207,8 +209,9 @@ async def test_get_multiple_users_by_username_not_found(
 ):
     user1 = dummy_user_factory()
     user2 = dummy_user_factory()
+    user3 = dummy_user_factory(is_bot=True)
 
-    mock_slack_client.users_list.return_value = {"ok": True, "members": [user1, user2]}
+    mock_slack_client.users_list.return_value = {"ok": True, "members": [user1, user2, user3]}
 
     response = await get_multiple_users_by_username(
         mock_context, usernames=[user1["name"], user2["name"] + "not_found"]


### PR DESCRIPTION
Adds four new tools to retrieve a user: by username and email.

- `get_user_by_username`
- `get_multiple_users_by_username`
- `get_user_by_email`
- `get_multiple_users_by_email`

Retrieving by email is the most efficient way. Retrieving by username still requires scanning the list of users, but it does so more efficiently now (especially the `get_multiple_users_by_username` tool is much more efficient than previous implementations).