### PR TITLE
patching toolkit template generator for outside the main repo

### DIFF
--- a/libs/arcade-cli/arcade_cli/new.py
+++ b/libs/arcade-cli/arcade_cli/new.py
@@ -173,6 +173,14 @@ def create_new_toolkit(output_directory: str, toolkit_name: str) -> None:
     include_evals = ask_yes_no_question(
         "Do you want an evals directory created for you?", default=True
     )
+    cwd = Path.cwd()
+    # TODO: this detection mechanism works only for people that didn't change the
+    # name of the repo, a better detection method is required here
+    community_toolkit = False
+    if cwd.name == "toolkits" and cwd.parent.name == "arcade-ai":
+        community_toolkit = ask_yes_no_question(
+            "Is your toolkit a community contribution?", default=False
+        )
 
     context = {
         "package_name": package_name,
@@ -187,6 +195,7 @@ def create_new_toolkit(output_directory: str, toolkit_name: str) -> None:
         "arcade_ai_min_version": ARCADE_AI_MIN_VERSION,
         "arcade_ai_max_version": ARCADE_AI_MAX_VERSION,
         "creation_year": datetime.now().year,
+        "community_toolkit": community_toolkit,
     }
     template_directory = Path(__file__).parent / "templates" / "{{ toolkit_name }}"
 

--- a/libs/arcade-cli/arcade_cli/new.py
+++ b/libs/arcade-cli/arcade_cli/new.py
@@ -173,14 +173,6 @@ def create_new_toolkit(output_directory: str, toolkit_name: str) -> None:
     include_evals = ask_yes_no_question(
         "Do you want an evals directory created for you?", default=True
     )
-    cwd = Path.cwd()
-    # TODO: this detection mechanism works only for people that didn't change the
-    # name of the repo, a better detection method is required here
-    community_toolkit = False
-    if cwd.name == "toolkits" and cwd.parent.name == "arcade-ai":
-        community_toolkit = ask_yes_no_question(
-            "Is your toolkit a community contribution?", default=False
-        )
 
     context = {
         "package_name": package_name,
@@ -195,7 +187,6 @@ def create_new_toolkit(output_directory: str, toolkit_name: str) -> None:
         "arcade_ai_min_version": ARCADE_AI_MIN_VERSION,
         "arcade_ai_max_version": ARCADE_AI_MAX_VERSION,
         "creation_year": datetime.now().year,
-        "community_toolkit": community_toolkit,
     }
     template_directory = Path(__file__).parent / "templates" / "{{ toolkit_name }}"
 

--- a/libs/arcade-cli/arcade_cli/templates/{{ toolkit_name }}/Makefile
+++ b/libs/arcade-cli/arcade_cli/templates/{{ toolkit_name }}/Makefile
@@ -8,14 +8,14 @@ help:
 install: ## Install the uv environment and install all packages with dependencies
 	@echo "🚀 Creating virtual environment and installing all packages using uv"
 	@uv sync --active --all-extras --no-sources
-	@uv run pre-commit install
+	@if [ -f .pre-commit-config.yaml ]; then uv run pre-commit install; fi
 	@echo "✅ All packages and dependencies installed via uv"
 
 .PHONY: install-local
 install-local: ## Install the uv environment and install all packages with dependencies with local Arcade sources
 	@echo "🚀 Creating virtual environment and installing all packages using uv"
 	@uv sync --active --all-extras
-	@uv run pre-commit install
+	@if [ -f .pre-commit-config.yaml ]; then uv run pre-commit install; fi
 	@echo "✅ All packages and dependencies installed via uv"
 
 .PHONY: build
@@ -47,7 +47,9 @@ bump-version: ## Bump the version in the pyproject.toml file by a patch version
 
 .PHONY: check
 check: ## Run code quality tools.
-	@echo "🚀 Linting code: Running pre-commit"
-	@uv run pre-commit run -a
+	@if [ -f .pre-commit-config.yaml ]; then\
+		echo "🚀 Linting code: Running pre-commit";\
+		uv run pre-commit run -a;\
+	fi
 	@echo "🚀 Static type checking: Running mypy"
 	@uv run mypy --config-file=pyproject.toml

--- a/libs/arcade-cli/arcade_cli/templates/{{ toolkit_name }}/Makefile
+++ b/libs/arcade-cli/arcade_cli/templates/{{ toolkit_name }}/Makefile
@@ -49,7 +49,7 @@ bump-version: ## Bump the version in the pyproject.toml file by a patch version
 check: ## Run code quality tools.
 	@if [ -f .pre-commit-config.yaml ]; then\
 		echo "🚀 Linting code: Running pre-commit";\
-		uv run pre-commit run -a;\
+		uv run --no-sources pre-commit run -a;\
 	fi
 	@echo "🚀 Static type checking: Running mypy"
 	@uv run mypy --config-file=pyproject.toml

--- a/libs/arcade-cli/arcade_cli/templates/{{ toolkit_name }}/Makefile
+++ b/libs/arcade-cli/arcade_cli/templates/{{ toolkit_name }}/Makefile
@@ -8,7 +8,7 @@ help:
 install: ## Install the uv environment and install all packages with dependencies
 	@echo "🚀 Creating virtual environment and installing all packages using uv"
 	@uv sync --active --all-extras --no-sources
-	@if [ -f .pre-commit-config.yaml ]; then uv run pre-commit install; fi
+	@if [ -f .pre-commit-config.yaml ]; then uv run --no-sources pre-commit install; fi
 	@echo "✅ All packages and dependencies installed via uv"
 
 .PHONY: install-local

--- a/libs/arcade-cli/arcade_cli/templates/{{ toolkit_name }}/pyproject.toml
+++ b/libs/arcade-cli/arcade_cli/templates/{{ toolkit_name }}/pyproject.toml
@@ -36,13 +36,11 @@ dev = [
     "ruff>=0.7.4,<0.8.0",
 ]
 
-{% if community_toolkit %}
 # Use local path sources for arcade libs when working locally
 [tool.uv.sources]
 arcade-ai = { path = "../../", editable = true }
 arcade-serve = { path = "../../libs/arcade-serve/", editable = true }
 arcade-tdk = { path = "../../libs/arcade-tdk/", editable = true }
-{% endif -%}
 
 [tool.mypy]
 files = [ "{{ package_name }}/**/*.py",]

--- a/libs/arcade-cli/arcade_cli/templates/{{ toolkit_name }}/pyproject.toml
+++ b/libs/arcade-cli/arcade_cli/templates/{{ toolkit_name }}/pyproject.toml
@@ -36,12 +36,13 @@ dev = [
     "ruff>=0.7.4,<0.8.0",
 ]
 
+{% if community_toolkit %}
 # Use local path sources for arcade libs when working locally
 [tool.uv.sources]
 arcade-ai = { path = "../../", editable = true }
 arcade-serve = { path = "../../libs/arcade-serve/", editable = true }
 arcade-tdk = { path = "../../libs/arcade-tdk/", editable = true }
-
+{% endif -%}
 
 [tool.mypy]
 files = [ "{{ package_name }}/**/*.py",]

--- a/toolkits/asana/Makefile
+++ b/toolkits/asana/Makefile
@@ -8,7 +8,7 @@ help:
 install: ## Install the uv environment and install all packages with dependencies
 	@echo "🚀 Creating virtual environment and installing all packages using uv"
 	@uv sync --active --all-extras --no-sources
-	@if [ -f .pre-commit-config.yaml ]; then uv run pre-commit install; fi
+	@if [ -f .pre-commit-config.yaml ]; then uv run --no-sources pre-commit install; fi
 	@echo "✅ All packages and dependencies installed via uv"
 
 .PHONY: install-local

--- a/toolkits/asana/Makefile
+++ b/toolkits/asana/Makefile
@@ -8,14 +8,14 @@ help:
 install: ## Install the uv environment and install all packages with dependencies
 	@echo "🚀 Creating virtual environment and installing all packages using uv"
 	@uv sync --active --all-extras --no-sources
-	@uv run pre-commit install
+	@if [ -f .pre-commit-config.yaml ]; then uv run pre-commit install; fi
 	@echo "✅ All packages and dependencies installed via uv"
 
 .PHONY: install-local
 install-local: ## Install the uv environment and install all packages with dependencies with local Arcade sources
 	@echo "🚀 Creating virtual environment and installing all packages using uv"
 	@uv sync --active --all-extras
-	@uv run pre-commit install
+	@if [ -f .pre-commit-config.yaml ]; then uv run pre-commit install; fi
 	@echo "✅ All packages and dependencies installed via uv"
 
 .PHONY: build
@@ -47,7 +47,9 @@ bump-version: ## Bump the version in the pyproject.toml file by a patch version
 
 .PHONY: check
 check: ## Run code quality tools.
-	@echo "🚀 Linting code: Running pre-commit"
-	@uv run pre-commit run -a
+	@if [ -f .pre-commit-config.yaml ]; then\
+		echo "🚀 Linting code: Running pre-commit";\
+		uv run --no-sources pre-commit run -a;\
+	fi
 	@echo "🚀 Static type checking: Running mypy"
 	@uv run mypy --config-file=pyproject.toml

--- a/toolkits/code_sandbox/Makefile
+++ b/toolkits/code_sandbox/Makefile
@@ -8,7 +8,7 @@ help:
 install: ## Install the uv environment and install all packages with dependencies
 	@echo "🚀 Creating virtual environment and installing all packages using uv"
 	@uv sync --active --all-extras --no-sources
-	@if [ -f .pre-commit-config.yaml ]; then uv run pre-commit install; fi
+	@if [ -f .pre-commit-config.yaml ]; then uv run --no-sources pre-commit install; fi
 	@echo "✅ All packages and dependencies installed via uv"
 
 .PHONY: install-local

--- a/toolkits/code_sandbox/Makefile
+++ b/toolkits/code_sandbox/Makefile
@@ -8,14 +8,14 @@ help:
 install: ## Install the uv environment and install all packages with dependencies
 	@echo "🚀 Creating virtual environment and installing all packages using uv"
 	@uv sync --active --all-extras --no-sources
-	@uv run pre-commit install
+	@if [ -f .pre-commit-config.yaml ]; then uv run pre-commit install; fi
 	@echo "✅ All packages and dependencies installed via uv"
 
 .PHONY: install-local
 install-local: ## Install the uv environment and install all packages with dependencies with local Arcade sources
 	@echo "🚀 Creating virtual environment and installing all packages using uv"
 	@uv sync --active --all-extras
-	@uv run pre-commit install
+	@if [ -f .pre-commit-config.yaml ]; then uv run pre-commit install; fi
 	@echo "✅ All packages and dependencies installed via uv"
 
 .PHONY: build
@@ -47,7 +47,9 @@ bump-version: ## Bump the version in the pyproject.toml file by a patch version
 
 .PHONY: check
 check: ## Run code quality tools.
-	@echo "🚀 Linting code: Running pre-commit"
-	@uv run pre-commit run -a
+	@if [ -f .pre-commit-config.yaml ]; then\
+		echo "🚀 Linting code: Running pre-commit";\
+		uv run --no-sources pre-commit run -a;\
+	fi
 	@echo "🚀 Static type checking: Running mypy"
 	@uv run mypy --config-file=pyproject.toml

--- a/toolkits/confluence/Makefile
+++ b/toolkits/confluence/Makefile
@@ -8,7 +8,7 @@ help:
 install: ## Install the uv environment and install all packages with dependencies
 	@echo "🚀 Creating virtual environment and installing all packages using uv"
 	@uv sync --active --all-extras --no-sources
-	@if [ -f .pre-commit-config.yaml ]; then uv run pre-commit install; fi
+	@if [ -f .pre-commit-config.yaml ]; then uv run --no-sources pre-commit install; fi
 	@echo "✅ All packages and dependencies installed via uv"
 
 .PHONY: install-local

--- a/toolkits/confluence/Makefile
+++ b/toolkits/confluence/Makefile
@@ -8,14 +8,14 @@ help:
 install: ## Install the uv environment and install all packages with dependencies
 	@echo "🚀 Creating virtual environment and installing all packages using uv"
 	@uv sync --active --all-extras --no-sources
-	@uv run pre-commit install
+	@if [ -f .pre-commit-config.yaml ]; then uv run pre-commit install; fi
 	@echo "✅ All packages and dependencies installed via uv"
 
 .PHONY: install-local
 install-local: ## Install the uv environment and install all packages with dependencies with local Arcade sources
 	@echo "🚀 Creating virtual environment and installing all packages using uv"
 	@uv sync --active --all-extras
-	@uv run pre-commit install
+	@if [ -f .pre-commit-config.yaml ]; then uv run pre-commit install; fi
 	@echo "✅ All packages and dependencies installed via uv"
 
 .PHONY: build
@@ -47,7 +47,9 @@ bump-version: ## Bump the version in the pyproject.toml file by a patch version
 
 .PHONY: check
 check: ## Run code quality tools.
-	@echo "🚀 Linting code: Running pre-commit"
-	@uv run pre-commit run -a
+	@if [ -f .pre-commit-config.yaml ]; then\
+		echo "🚀 Linting code: Running pre-commit";\
+		uv run --no-sources pre-commit run -a;\
+	fi
 	@echo "🚀 Static type checking: Running mypy"
 	@uv run mypy --config-file=pyproject.toml

--- a/toolkits/dropbox/Makefile
+++ b/toolkits/dropbox/Makefile
@@ -8,7 +8,7 @@ help:
 install: ## Install the uv environment and install all packages with dependencies
 	@echo "🚀 Creating virtual environment and installing all packages using uv"
 	@uv sync --active --all-extras --no-sources
-	@if [ -f .pre-commit-config.yaml ]; then uv run pre-commit install; fi
+	@if [ -f .pre-commit-config.yaml ]; then uv run --no-sources pre-commit install; fi
 	@echo "✅ All packages and dependencies installed via uv"
 
 .PHONY: install-local

--- a/toolkits/dropbox/Makefile
+++ b/toolkits/dropbox/Makefile
@@ -8,14 +8,14 @@ help:
 install: ## Install the uv environment and install all packages with dependencies
 	@echo "🚀 Creating virtual environment and installing all packages using uv"
 	@uv sync --active --all-extras --no-sources
-	@uv run pre-commit install
+	@if [ -f .pre-commit-config.yaml ]; then uv run pre-commit install; fi
 	@echo "✅ All packages and dependencies installed via uv"
 
 .PHONY: install-local
 install-local: ## Install the uv environment and install all packages with dependencies with local Arcade sources
 	@echo "🚀 Creating virtual environment and installing all packages using uv"
 	@uv sync --active --all-extras
-	@uv run pre-commit install
+	@if [ -f .pre-commit-config.yaml ]; then uv run pre-commit install; fi
 	@echo "✅ All packages and dependencies installed via uv"
 
 .PHONY: build
@@ -47,7 +47,9 @@ bump-version: ## Bump the version in the pyproject.toml file by a patch version
 
 .PHONY: check
 check: ## Run code quality tools.
-	@echo "🚀 Linting code: Running pre-commit"
-	@uv run pre-commit run -a
+	@if [ -f .pre-commit-config.yaml ]; then\
+		echo "🚀 Linting code: Running pre-commit";\
+		uv run --no-sources pre-commit run -a;\
+	fi
 	@echo "🚀 Static type checking: Running mypy"
 	@uv run mypy --config-file=pyproject.toml

--- a/toolkits/github/Makefile
+++ b/toolkits/github/Makefile
@@ -8,7 +8,7 @@ help:
 install: ## Install the uv environment and install all packages with dependencies
 	@echo "🚀 Creating virtual environment and installing all packages using uv"
 	@uv sync --active --all-extras --no-sources
-	@if [ -f .pre-commit-config.yaml ]; then uv run pre-commit install; fi
+	@if [ -f .pre-commit-config.yaml ]; then uv run --no-sources pre-commit install; fi
 	@echo "✅ All packages and dependencies installed via uv"
 
 .PHONY: install-local

--- a/toolkits/github/Makefile
+++ b/toolkits/github/Makefile
@@ -8,14 +8,14 @@ help:
 install: ## Install the uv environment and install all packages with dependencies
 	@echo "🚀 Creating virtual environment and installing all packages using uv"
 	@uv sync --active --all-extras --no-sources
-	@uv run pre-commit install
+	@if [ -f .pre-commit-config.yaml ]; then uv run pre-commit install; fi
 	@echo "✅ All packages and dependencies installed via uv"
 
 .PHONY: install-local
 install-local: ## Install the uv environment and install all packages with dependencies with local Arcade sources
 	@echo "🚀 Creating virtual environment and installing all packages using uv"
 	@uv sync --active --all-extras
-	@uv run pre-commit install
+	@if [ -f .pre-commit-config.yaml ]; then uv run pre-commit install; fi
 	@echo "✅ All packages and dependencies installed via uv"
 
 .PHONY: build
@@ -47,7 +47,9 @@ bump-version: ## Bump the version in the pyproject.toml file by a patch version
 
 .PHONY: check
 check: ## Run code quality tools.
-	@echo "🚀 Linting code: Running pre-commit"
-	@uv run pre-commit run -a
+	@if [ -f .pre-commit-config.yaml ]; then\
+		echo "🚀 Linting code: Running pre-commit";\
+		uv run --no-sources pre-commit run -a;\
+	fi
 	@echo "🚀 Static type checking: Running mypy"
 	@uv run mypy --config-file=pyproject.toml

--- a/toolkits/google/Makefile
+++ b/toolkits/google/Makefile
@@ -8,7 +8,7 @@ help:
 install: ## Install the uv environment and install all packages with dependencies
 	@echo "🚀 Creating virtual environment and installing all packages using uv"
 	@uv sync --active --all-extras --no-sources
-	@if [ -f .pre-commit-config.yaml ]; then uv run pre-commit install; fi
+	@if [ -f .pre-commit-config.yaml ]; then uv run --no-sources pre-commit install; fi
 	@echo "✅ All packages and dependencies installed via uv"
 
 .PHONY: install-local

--- a/toolkits/google/Makefile
+++ b/toolkits/google/Makefile
@@ -8,14 +8,14 @@ help:
 install: ## Install the uv environment and install all packages with dependencies
 	@echo "🚀 Creating virtual environment and installing all packages using uv"
 	@uv sync --active --all-extras --no-sources
-	@uv run pre-commit install
+	@if [ -f .pre-commit-config.yaml ]; then uv run pre-commit install; fi
 	@echo "✅ All packages and dependencies installed via uv"
 
 .PHONY: install-local
 install-local: ## Install the uv environment and install all packages with dependencies with local Arcade sources
 	@echo "🚀 Creating virtual environment and installing all packages using uv"
 	@uv sync --active --all-extras
-	@uv run pre-commit install
+	@if [ -f .pre-commit-config.yaml ]; then uv run pre-commit install; fi
 	@echo "✅ All packages and dependencies installed via uv"
 
 .PHONY: build
@@ -47,7 +47,9 @@ bump-version: ## Bump the version in the pyproject.toml file by a patch version
 
 .PHONY: check
 check: ## Run code quality tools.
-	@echo "🚀 Linting code: Running pre-commit"
-	@uv run pre-commit run -a
+	@if [ -f .pre-commit-config.yaml ]; then\
+		echo "🚀 Linting code: Running pre-commit";\
+		uv run --no-sources pre-commit run -a;\
+	fi
 	@echo "🚀 Static type checking: Running mypy"
 	@uv run mypy --config-file=pyproject.toml

--- a/toolkits/hubspot/Makefile
+++ b/toolkits/hubspot/Makefile
@@ -8,7 +8,7 @@ help:
 install: ## Install the uv environment and install all packages with dependencies
 	@echo "🚀 Creating virtual environment and installing all packages using uv"
 	@uv sync --active --all-extras --no-sources
-	@if [ -f .pre-commit-config.yaml ]; then uv run pre-commit install; fi
+	@if [ -f .pre-commit-config.yaml ]; then uv run --no-sources pre-commit install; fi
 	@echo "✅ All packages and dependencies installed via uv"
 
 .PHONY: install-local

--- a/toolkits/hubspot/Makefile
+++ b/toolkits/hubspot/Makefile
@@ -8,14 +8,14 @@ help:
 install: ## Install the uv environment and install all packages with dependencies
 	@echo "🚀 Creating virtual environment and installing all packages using uv"
 	@uv sync --active --all-extras --no-sources
-	@uv run pre-commit install
+	@if [ -f .pre-commit-config.yaml ]; then uv run pre-commit install; fi
 	@echo "✅ All packages and dependencies installed via uv"
 
 .PHONY: install-local
 install-local: ## Install the uv environment and install all packages with dependencies with local Arcade sources
 	@echo "🚀 Creating virtual environment and installing all packages using uv"
 	@uv sync --active --all-extras
-	@uv run pre-commit install
+	@if [ -f .pre-commit-config.yaml ]; then uv run pre-commit install; fi
 	@echo "✅ All packages and dependencies installed via uv"
 
 .PHONY: build
@@ -47,7 +47,9 @@ bump-version: ## Bump the version in the pyproject.toml file by a patch version
 
 .PHONY: check
 check: ## Run code quality tools.
-	@echo "🚀 Linting code: Running pre-commit"
-	@uv run pre-commit run -a
+	@if [ -f .pre-commit-config.yaml ]; then\
+		echo "🚀 Linting code: Running pre-commit";\
+		uv run --no-sources pre-commit run -a;\
+	fi
 	@echo "🚀 Static type checking: Running mypy"
 	@uv run mypy --config-file=pyproject.toml

--- a/toolkits/jira/Makefile
+++ b/toolkits/jira/Makefile
@@ -8,7 +8,7 @@ help:
 install: ## Install the uv environment and install all packages with dependencies
 	@echo "🚀 Creating virtual environment and installing all packages using uv"
 	@uv sync --active --all-extras --no-sources
-	@if [ -f .pre-commit-config.yaml ]; then uv run pre-commit install; fi
+	@if [ -f .pre-commit-config.yaml ]; then uv run --no-sources pre-commit install; fi
 	@echo "✅ All packages and dependencies installed via uv"
 
 .PHONY: install-local

--- a/toolkits/jira/Makefile
+++ b/toolkits/jira/Makefile
@@ -8,14 +8,14 @@ help:
 install: ## Install the uv environment and install all packages with dependencies
 	@echo "🚀 Creating virtual environment and installing all packages using uv"
 	@uv sync --active --all-extras --no-sources
-	@uv run pre-commit install
+	@if [ -f .pre-commit-config.yaml ]; then uv run pre-commit install; fi
 	@echo "✅ All packages and dependencies installed via uv"
 
 .PHONY: install-local
 install-local: ## Install the uv environment and install all packages with dependencies with local Arcade sources
 	@echo "🚀 Creating virtual environment and installing all packages using uv"
 	@uv sync --active --all-extras
-	@uv run pre-commit install
+	@if [ -f .pre-commit-config.yaml ]; then uv run pre-commit install; fi
 	@echo "✅ All packages and dependencies installed via uv"
 
 .PHONY: build
@@ -47,7 +47,9 @@ bump-version: ## Bump the version in the pyproject.toml file by a patch version
 
 .PHONY: check
 check: ## Run code quality tools.
-	@echo "🚀 Linting code: Running pre-commit"
-	@uv run pre-commit run -a
+	@if [ -f .pre-commit-config.yaml ]; then\
+		echo "🚀 Linting code: Running pre-commit";\
+		uv run --no-sources pre-commit run -a;\
+	fi
 	@echo "🚀 Static type checking: Running mypy"
 	@uv run mypy --config-file=pyproject.toml

--- a/toolkits/linkedin/Makefile
+++ b/toolkits/linkedin/Makefile
@@ -8,7 +8,7 @@ help:
 install: ## Install the uv environment and install all packages with dependencies
 	@echo "🚀 Creating virtual environment and installing all packages using uv"
 	@uv sync --active --all-extras --no-sources
-	@if [ -f .pre-commit-config.yaml ]; then uv run pre-commit install; fi
+	@if [ -f .pre-commit-config.yaml ]; then uv run --no-sources pre-commit install; fi
 	@echo "✅ All packages and dependencies installed via uv"
 
 .PHONY: install-local

--- a/toolkits/linkedin/Makefile
+++ b/toolkits/linkedin/Makefile
@@ -8,14 +8,14 @@ help:
 install: ## Install the uv environment and install all packages with dependencies
 	@echo "🚀 Creating virtual environment and installing all packages using uv"
 	@uv sync --active --all-extras --no-sources
-	@uv run pre-commit install
+	@if [ -f .pre-commit-config.yaml ]; then uv run pre-commit install; fi
 	@echo "✅ All packages and dependencies installed via uv"
 
 .PHONY: install-local
 install-local: ## Install the uv environment and install all packages with dependencies with local Arcade sources
 	@echo "🚀 Creating virtual environment and installing all packages using uv"
 	@uv sync --active --all-extras
-	@uv run pre-commit install
+	@if [ -f .pre-commit-config.yaml ]; then uv run pre-commit install; fi
 	@echo "✅ All packages and dependencies installed via uv"
 
 .PHONY: build
@@ -47,7 +47,9 @@ bump-version: ## Bump the version in the pyproject.toml file by a patch version
 
 .PHONY: check
 check: ## Run code quality tools.
-	@echo "🚀 Linting code: Running pre-commit"
-	@uv run pre-commit run -a
+	@if [ -f .pre-commit-config.yaml ]; then\
+		echo "🚀 Linting code: Running pre-commit";\
+		uv run --no-sources pre-commit run -a;\
+	fi
 	@echo "🚀 Static type checking: Running mypy"
 	@uv run mypy --config-file=pyproject.toml

--- a/toolkits/math/Makefile
+++ b/toolkits/math/Makefile
@@ -8,7 +8,7 @@ help:
 install: ## Install the uv environment and install all packages with dependencies
 	@echo "🚀 Creating virtual environment and installing all packages using uv"
 	@uv sync --active --all-extras --no-sources
-	@if [ -f .pre-commit-config.yaml ]; then uv run pre-commit install; fi
+	@if [ -f .pre-commit-config.yaml ]; then uv run --no-sources pre-commit install; fi
 	@echo "✅ All packages and dependencies installed via uv"
 
 .PHONY: install-local

--- a/toolkits/math/Makefile
+++ b/toolkits/math/Makefile
@@ -8,14 +8,14 @@ help:
 install: ## Install the uv environment and install all packages with dependencies
 	@echo "🚀 Creating virtual environment and installing all packages using uv"
 	@uv sync --active --all-extras --no-sources
-	@uv run pre-commit install
+	@if [ -f .pre-commit-config.yaml ]; then uv run pre-commit install; fi
 	@echo "✅ All packages and dependencies installed via uv"
 
 .PHONY: install-local
 install-local: ## Install the uv environment and install all packages with dependencies with local Arcade sources
 	@echo "🚀 Creating virtual environment and installing all packages using uv"
 	@uv sync --active --all-extras
-	@uv run pre-commit install
+	@if [ -f .pre-commit-config.yaml ]; then uv run pre-commit install; fi
 	@echo "✅ All packages and dependencies installed via uv"
 
 .PHONY: build
@@ -47,7 +47,9 @@ bump-version: ## Bump the version in the pyproject.toml file by a patch version
 
 .PHONY: check
 check: ## Run code quality tools.
-	@echo "🚀 Linting code: Running pre-commit"
-	@uv run pre-commit run -a
+	@if [ -f .pre-commit-config.yaml ]; then\
+		echo "🚀 Linting code: Running pre-commit";\
+		uv run --no-sources pre-commit run -a;\
+	fi
 	@echo "🚀 Static type checking: Running mypy"
 	@uv run mypy --config-file=pyproject.toml

--- a/toolkits/microsoft/Makefile
+++ b/toolkits/microsoft/Makefile
@@ -8,7 +8,7 @@ help:
 install: ## Install the uv environment and install all packages with dependencies
 	@echo "🚀 Creating virtual environment and installing all packages using uv"
 	@uv sync --active --all-extras --no-sources
-	@if [ -f .pre-commit-config.yaml ]; then uv run pre-commit install; fi
+	@if [ -f .pre-commit-config.yaml ]; then uv run --no-sources pre-commit install; fi
 	@echo "✅ All packages and dependencies installed via uv"
 
 .PHONY: install-local

--- a/toolkits/microsoft/Makefile
+++ b/toolkits/microsoft/Makefile
@@ -8,14 +8,14 @@ help:
 install: ## Install the uv environment and install all packages with dependencies
 	@echo "🚀 Creating virtual environment and installing all packages using uv"
 	@uv sync --active --all-extras --no-sources
-	@uv run pre-commit install
+	@if [ -f .pre-commit-config.yaml ]; then uv run pre-commit install; fi
 	@echo "✅ All packages and dependencies installed via uv"
 
 .PHONY: install-local
 install-local: ## Install the uv environment and install all packages with dependencies with local Arcade sources
 	@echo "🚀 Creating virtual environment and installing all packages using uv"
 	@uv sync --active --all-extras
-	@uv run pre-commit install
+	@if [ -f .pre-commit-config.yaml ]; then uv run pre-commit install; fi
 	@echo "✅ All packages and dependencies installed via uv"
 
 .PHONY: build
@@ -47,7 +47,9 @@ bump-version: ## Bump the version in the pyproject.toml file by a patch version
 
 .PHONY: check
 check: ## Run code quality tools.
-	@echo "🚀 Linting code: Running pre-commit"
-	@uv run pre-commit run -a
+	@if [ -f .pre-commit-config.yaml ]; then\
+		echo "🚀 Linting code: Running pre-commit";\
+		uv run --no-sources pre-commit run -a;\
+	fi
 	@echo "🚀 Static type checking: Running mypy"
 	@uv run mypy --config-file=pyproject.toml

--- a/toolkits/notion/Makefile
+++ b/toolkits/notion/Makefile
@@ -8,7 +8,7 @@ help:
 install: ## Install the uv environment and install all packages with dependencies
 	@echo "🚀 Creating virtual environment and installing all packages using uv"
 	@uv sync --active --all-extras --no-sources
-	@if [ -f .pre-commit-config.yaml ]; then uv run pre-commit install; fi
+	@if [ -f .pre-commit-config.yaml ]; then uv run --no-sources pre-commit install; fi
 	@echo "✅ All packages and dependencies installed via uv"
 
 .PHONY: install-local

--- a/toolkits/notion/Makefile
+++ b/toolkits/notion/Makefile
@@ -8,14 +8,14 @@ help:
 install: ## Install the uv environment and install all packages with dependencies
 	@echo "🚀 Creating virtual environment and installing all packages using uv"
 	@uv sync --active --all-extras --no-sources
-	@uv run pre-commit install
+	@if [ -f .pre-commit-config.yaml ]; then uv run pre-commit install; fi
 	@echo "✅ All packages and dependencies installed via uv"
 
 .PHONY: install-local
 install-local: ## Install the uv environment and install all packages with dependencies with local Arcade sources
 	@echo "🚀 Creating virtual environment and installing all packages using uv"
 	@uv sync --active --all-extras
-	@uv run pre-commit install
+	@if [ -f .pre-commit-config.yaml ]; then uv run pre-commit install; fi
 	@echo "✅ All packages and dependencies installed via uv"
 
 .PHONY: build
@@ -47,7 +47,9 @@ bump-version: ## Bump the version in the pyproject.toml file by a patch version
 
 .PHONY: check
 check: ## Run code quality tools.
-	@echo "🚀 Linting code: Running pre-commit"
-	@uv run pre-commit run -a
+	@if [ -f .pre-commit-config.yaml ]; then\
+		echo "🚀 Linting code: Running pre-commit";\
+		uv run --no-sources pre-commit run -a;\
+	fi
 	@echo "🚀 Static type checking: Running mypy"
 	@uv run mypy --config-file=pyproject.toml

--- a/toolkits/reddit/Makefile
+++ b/toolkits/reddit/Makefile
@@ -8,7 +8,7 @@ help:
 install: ## Install the uv environment and install all packages with dependencies
 	@echo "🚀 Creating virtual environment and installing all packages using uv"
 	@uv sync --active --all-extras --no-sources
-	@if [ -f .pre-commit-config.yaml ]; then uv run pre-commit install; fi
+	@if [ -f .pre-commit-config.yaml ]; then uv run --no-sources pre-commit install; fi
 	@echo "✅ All packages and dependencies installed via uv"
 
 .PHONY: install-local

--- a/toolkits/reddit/Makefile
+++ b/toolkits/reddit/Makefile
@@ -8,14 +8,14 @@ help:
 install: ## Install the uv environment and install all packages with dependencies
 	@echo "🚀 Creating virtual environment and installing all packages using uv"
 	@uv sync --active --all-extras --no-sources
-	@uv run pre-commit install
+	@if [ -f .pre-commit-config.yaml ]; then uv run pre-commit install; fi
 	@echo "✅ All packages and dependencies installed via uv"
 
 .PHONY: install-local
 install-local: ## Install the uv environment and install all packages with dependencies with local Arcade sources
 	@echo "🚀 Creating virtual environment and installing all packages using uv"
 	@uv sync --active --all-extras
-	@uv run pre-commit install
+	@if [ -f .pre-commit-config.yaml ]; then uv run pre-commit install; fi
 	@echo "✅ All packages and dependencies installed via uv"
 
 .PHONY: build
@@ -47,7 +47,9 @@ bump-version: ## Bump the version in the pyproject.toml file by a patch version
 
 .PHONY: check
 check: ## Run code quality tools.
-	@echo "🚀 Linting code: Running pre-commit"
-	@uv run pre-commit run -a
+	@if [ -f .pre-commit-config.yaml ]; then\
+		echo "🚀 Linting code: Running pre-commit";\
+		uv run --no-sources pre-commit run -a;\
+	fi
 	@echo "🚀 Static type checking: Running mypy"
 	@uv run mypy --config-file=pyproject.toml

--- a/toolkits/salesforce/Makefile
+++ b/toolkits/salesforce/Makefile
@@ -8,7 +8,7 @@ help:
 install: ## Install the uv environment and install all packages with dependencies
 	@echo "🚀 Creating virtual environment and installing all packages using uv"
 	@uv sync --active --all-extras --no-sources
-	@if [ -f .pre-commit-config.yaml ]; then uv run pre-commit install; fi
+	@if [ -f .pre-commit-config.yaml ]; then uv run --no-sources pre-commit install; fi
 	@echo "✅ All packages and dependencies installed via uv"
 
 .PHONY: install-local

--- a/toolkits/salesforce/Makefile
+++ b/toolkits/salesforce/Makefile
@@ -8,14 +8,14 @@ help:
 install: ## Install the uv environment and install all packages with dependencies
 	@echo "🚀 Creating virtual environment and installing all packages using uv"
 	@uv sync --active --all-extras --no-sources
-	@uv run pre-commit install
+	@if [ -f .pre-commit-config.yaml ]; then uv run pre-commit install; fi
 	@echo "✅ All packages and dependencies installed via uv"
 
 .PHONY: install-local
 install-local: ## Install the uv environment and install all packages with dependencies with local Arcade sources
 	@echo "🚀 Creating virtual environment and installing all packages using uv"
 	@uv sync --active --all-extras
-	@uv run pre-commit install
+	@if [ -f .pre-commit-config.yaml ]; then uv run pre-commit install; fi
 	@echo "✅ All packages and dependencies installed via uv"
 
 .PHONY: build
@@ -47,7 +47,9 @@ bump-version: ## Bump the version in the pyproject.toml file by a patch version
 
 .PHONY: check
 check: ## Run code quality tools.
-	@echo "🚀 Linting code: Running pre-commit"
-	@uv run pre-commit run -a
+	@if [ -f .pre-commit-config.yaml ]; then\
+		echo "🚀 Linting code: Running pre-commit";\
+		uv run --no-sources pre-commit run -a;\
+	fi
 	@echo "🚀 Static type checking: Running mypy"
 	@uv run mypy --config-file=pyproject.toml

--- a/toolkits/search/Makefile
+++ b/toolkits/search/Makefile
@@ -8,7 +8,7 @@ help:
 install: ## Install the uv environment and install all packages with dependencies
 	@echo "🚀 Creating virtual environment and installing all packages using uv"
 	@uv sync --active --all-extras --no-sources
-	@if [ -f .pre-commit-config.yaml ]; then uv run pre-commit install; fi
+	@if [ -f .pre-commit-config.yaml ]; then uv run --no-sources pre-commit install; fi
 	@echo "✅ All packages and dependencies installed via uv"
 
 .PHONY: install-local

--- a/toolkits/search/Makefile
+++ b/toolkits/search/Makefile
@@ -8,14 +8,14 @@ help:
 install: ## Install the uv environment and install all packages with dependencies
 	@echo "🚀 Creating virtual environment and installing all packages using uv"
 	@uv sync --active --all-extras --no-sources
-	@uv run pre-commit install
+	@if [ -f .pre-commit-config.yaml ]; then uv run pre-commit install; fi
 	@echo "✅ All packages and dependencies installed via uv"
 
 .PHONY: install-local
 install-local: ## Install the uv environment and install all packages with dependencies with local Arcade sources
 	@echo "🚀 Creating virtual environment and installing all packages using uv"
 	@uv sync --active --all-extras
-	@uv run pre-commit install
+	@if [ -f .pre-commit-config.yaml ]; then uv run pre-commit install; fi
 	@echo "✅ All packages and dependencies installed via uv"
 
 .PHONY: build
@@ -47,7 +47,9 @@ bump-version: ## Bump the version in the pyproject.toml file by a patch version
 
 .PHONY: check
 check: ## Run code quality tools.
-	@echo "🚀 Linting code: Running pre-commit"
-	@uv run pre-commit run -a
+	@if [ -f .pre-commit-config.yaml ]; then\
+		echo "🚀 Linting code: Running pre-commit";\
+		uv run --no-sources pre-commit run -a;\
+	fi
 	@echo "🚀 Static type checking: Running mypy"
 	@uv run mypy --config-file=pyproject.toml

--- a/toolkits/slack/Makefile
+++ b/toolkits/slack/Makefile
@@ -8,7 +8,7 @@ help:
 install: ## Install the uv environment and install all packages with dependencies
 	@echo "🚀 Creating virtual environment and installing all packages using uv"
 	@uv sync --active --all-extras --no-sources
-	@if [ -f .pre-commit-config.yaml ]; then uv run pre-commit install; fi
+	@if [ -f .pre-commit-config.yaml ]; then uv run --no-sources pre-commit install; fi
 	@echo "✅ All packages and dependencies installed via uv"
 
 .PHONY: install-local

--- a/toolkits/slack/Makefile
+++ b/toolkits/slack/Makefile
@@ -8,14 +8,14 @@ help:
 install: ## Install the uv environment and install all packages with dependencies
 	@echo "🚀 Creating virtual environment and installing all packages using uv"
 	@uv sync --active --all-extras --no-sources
-	@uv run pre-commit install
+	@if [ -f .pre-commit-config.yaml ]; then uv run pre-commit install; fi
 	@echo "✅ All packages and dependencies installed via uv"
 
 .PHONY: install-local
 install-local: ## Install the uv environment and install all packages with dependencies with local Arcade sources
 	@echo "🚀 Creating virtual environment and installing all packages using uv"
 	@uv sync --active --all-extras
-	@uv run pre-commit install
+	@if [ -f .pre-commit-config.yaml ]; then uv run pre-commit install; fi
 	@echo "✅ All packages and dependencies installed via uv"
 
 .PHONY: build
@@ -47,7 +47,9 @@ bump-version: ## Bump the version in the pyproject.toml file by a patch version
 
 .PHONY: check
 check: ## Run code quality tools.
-	@echo "🚀 Linting code: Running pre-commit"
-	@uv run pre-commit run -a
+	@if [ -f .pre-commit-config.yaml ]; then\
+		echo "🚀 Linting code: Running pre-commit";\
+		uv run --no-sources pre-commit run -a;\
+	fi
 	@echo "🚀 Static type checking: Running mypy"
 	@uv run mypy --config-file=pyproject.toml

--- a/toolkits/spotify/Makefile
+++ b/toolkits/spotify/Makefile
@@ -8,7 +8,7 @@ help:
 install: ## Install the uv environment and install all packages with dependencies
 	@echo "🚀 Creating virtual environment and installing all packages using uv"
 	@uv sync --active --all-extras --no-sources
-	@if [ -f .pre-commit-config.yaml ]; then uv run pre-commit install; fi
+	@if [ -f .pre-commit-config.yaml ]; then uv run --no-sources pre-commit install; fi
 	@echo "✅ All packages and dependencies installed via uv"
 
 .PHONY: install-local

--- a/toolkits/spotify/Makefile
+++ b/toolkits/spotify/Makefile
@@ -8,14 +8,14 @@ help:
 install: ## Install the uv environment and install all packages with dependencies
 	@echo "🚀 Creating virtual environment and installing all packages using uv"
 	@uv sync --active --all-extras --no-sources
-	@uv run pre-commit install
+	@if [ -f .pre-commit-config.yaml ]; then uv run pre-commit install; fi
 	@echo "✅ All packages and dependencies installed via uv"
 
 .PHONY: install-local
 install-local: ## Install the uv environment and install all packages with dependencies with local Arcade sources
 	@echo "🚀 Creating virtual environment and installing all packages using uv"
 	@uv sync --active --all-extras
-	@uv run pre-commit install
+	@if [ -f .pre-commit-config.yaml ]; then uv run pre-commit install; fi
 	@echo "✅ All packages and dependencies installed via uv"
 
 .PHONY: build
@@ -47,7 +47,9 @@ bump-version: ## Bump the version in the pyproject.toml file by a patch version
 
 .PHONY: check
 check: ## Run code quality tools.
-	@echo "🚀 Linting code: Running pre-commit"
-	@uv run pre-commit run -a
+	@if [ -f .pre-commit-config.yaml ]; then\
+		echo "🚀 Linting code: Running pre-commit";\
+		uv run --no-sources pre-commit run -a;\
+	fi
 	@echo "🚀 Static type checking: Running mypy"
 	@uv run mypy --config-file=pyproject.toml

--- a/toolkits/stripe/Makefile
+++ b/toolkits/stripe/Makefile
@@ -8,7 +8,7 @@ help:
 install: ## Install the uv environment and install all packages with dependencies
 	@echo "🚀 Creating virtual environment and installing all packages using uv"
 	@uv sync --active --all-extras --no-sources
-	@if [ -f .pre-commit-config.yaml ]; then uv run pre-commit install; fi
+	@if [ -f .pre-commit-config.yaml ]; then uv run --no-sources pre-commit install; fi
 	@echo "✅ All packages and dependencies installed via uv"
 
 .PHONY: install-local

--- a/toolkits/stripe/Makefile
+++ b/toolkits/stripe/Makefile
@@ -8,14 +8,14 @@ help:
 install: ## Install the uv environment and install all packages with dependencies
 	@echo "🚀 Creating virtual environment and installing all packages using uv"
 	@uv sync --active --all-extras --no-sources
-	@uv run pre-commit install
+	@if [ -f .pre-commit-config.yaml ]; then uv run pre-commit install; fi
 	@echo "✅ All packages and dependencies installed via uv"
 
 .PHONY: install-local
 install-local: ## Install the uv environment and install all packages with dependencies with local Arcade sources
 	@echo "🚀 Creating virtual environment and installing all packages using uv"
 	@uv sync --active --all-extras
-	@uv run pre-commit install
+	@if [ -f .pre-commit-config.yaml ]; then uv run pre-commit install; fi
 	@echo "✅ All packages and dependencies installed via uv"
 
 .PHONY: build
@@ -47,7 +47,9 @@ bump-version: ## Bump the version in the pyproject.toml file by a patch version
 
 .PHONY: check
 check: ## Run code quality tools.
-	@echo "🚀 Linting code: Running pre-commit"
-	@uv run pre-commit run -a
+	@if [ -f .pre-commit-config.yaml ]; then\
+		echo "🚀 Linting code: Running pre-commit";\
+		uv run --no-sources pre-commit run -a;\
+	fi
 	@echo "🚀 Static type checking: Running mypy"
 	@uv run mypy --config-file=pyproject.toml

--- a/toolkits/web/Makefile
+++ b/toolkits/web/Makefile
@@ -8,7 +8,7 @@ help:
 install: ## Install the uv environment and install all packages with dependencies
 	@echo "🚀 Creating virtual environment and installing all packages using uv"
 	@uv sync --active --all-extras --no-sources
-	@if [ -f .pre-commit-config.yaml ]; then uv run pre-commit install; fi
+	@if [ -f .pre-commit-config.yaml ]; then uv run --no-sources pre-commit install; fi
 	@echo "✅ All packages and dependencies installed via uv"
 
 .PHONY: install-local

--- a/toolkits/web/Makefile
+++ b/toolkits/web/Makefile
@@ -8,14 +8,14 @@ help:
 install: ## Install the uv environment and install all packages with dependencies
 	@echo "🚀 Creating virtual environment and installing all packages using uv"
 	@uv sync --active --all-extras --no-sources
-	@uv run pre-commit install
+	@if [ -f .pre-commit-config.yaml ]; then uv run pre-commit install; fi
 	@echo "✅ All packages and dependencies installed via uv"
 
 .PHONY: install-local
 install-local: ## Install the uv environment and install all packages with dependencies with local Arcade sources
 	@echo "🚀 Creating virtual environment and installing all packages using uv"
 	@uv sync --active --all-extras
-	@uv run pre-commit install
+	@if [ -f .pre-commit-config.yaml ]; then uv run pre-commit install; fi
 	@echo "✅ All packages and dependencies installed via uv"
 
 .PHONY: build
@@ -47,7 +47,9 @@ bump-version: ## Bump the version in the pyproject.toml file by a patch version
 
 .PHONY: check
 check: ## Run code quality tools.
-	@echo "🚀 Linting code: Running pre-commit"
-	@uv run pre-commit run -a
+	@if [ -f .pre-commit-config.yaml ]; then\
+		echo "🚀 Linting code: Running pre-commit";\
+		uv run --no-sources pre-commit run -a;\
+	fi
 	@echo "🚀 Static type checking: Running mypy"
 	@uv run mypy --config-file=pyproject.toml

--- a/toolkits/x/Makefile
+++ b/toolkits/x/Makefile
@@ -8,7 +8,7 @@ help:
 install: ## Install the uv environment and install all packages with dependencies
 	@echo "🚀 Creating virtual environment and installing all packages using uv"
 	@uv sync --active --all-extras --no-sources
-	@if [ -f .pre-commit-config.yaml ]; then uv run pre-commit install; fi
+	@if [ -f .pre-commit-config.yaml ]; then uv run --no-sources pre-commit install; fi
 	@echo "✅ All packages and dependencies installed via uv"
 
 .PHONY: install-local

--- a/toolkits/x/Makefile
+++ b/toolkits/x/Makefile
@@ -8,14 +8,14 @@ help:
 install: ## Install the uv environment and install all packages with dependencies
 	@echo "🚀 Creating virtual environment and installing all packages using uv"
 	@uv sync --active --all-extras --no-sources
-	@uv run pre-commit install
+	@if [ -f .pre-commit-config.yaml ]; then uv run pre-commit install; fi
 	@echo "✅ All packages and dependencies installed via uv"
 
 .PHONY: install-local
 install-local: ## Install the uv environment and install all packages with dependencies with local Arcade sources
 	@echo "🚀 Creating virtual environment and installing all packages using uv"
 	@uv sync --active --all-extras
-	@uv run pre-commit install
+	@if [ -f .pre-commit-config.yaml ]; then uv run pre-commit install; fi
 	@echo "✅ All packages and dependencies installed via uv"
 
 .PHONY: build
@@ -47,7 +47,9 @@ bump-version: ## Bump the version in the pyproject.toml file by a patch version
 
 .PHONY: check
 check: ## Run code quality tools.
-	@echo "🚀 Linting code: Running pre-commit"
-	@uv run pre-commit run -a
+	@if [ -f .pre-commit-config.yaml ]; then\
+		echo "🚀 Linting code: Running pre-commit";\
+		uv run --no-sources pre-commit run -a;\
+	fi
 	@echo "🚀 Static type checking: Running mypy"
 	@uv run mypy --config-file=pyproject.toml

--- a/toolkits/zoom/Makefile
+++ b/toolkits/zoom/Makefile
@@ -8,7 +8,7 @@ help:
 install: ## Install the uv environment and install all packages with dependencies
 	@echo "🚀 Creating virtual environment and installing all packages using uv"
 	@uv sync --active --all-extras --no-sources
-	@if [ -f .pre-commit-config.yaml ]; then uv run pre-commit install; fi
+	@if [ -f .pre-commit-config.yaml ]; then uv run --no-sources pre-commit install; fi
 	@echo "✅ All packages and dependencies installed via uv"
 
 .PHONY: install-local

--- a/toolkits/zoom/Makefile
+++ b/toolkits/zoom/Makefile
@@ -8,14 +8,14 @@ help:
 install: ## Install the uv environment and install all packages with dependencies
 	@echo "🚀 Creating virtual environment and installing all packages using uv"
 	@uv sync --active --all-extras --no-sources
-	@uv run pre-commit install
+	@if [ -f .pre-commit-config.yaml ]; then uv run pre-commit install; fi
 	@echo "✅ All packages and dependencies installed via uv"
 
 .PHONY: install-local
 install-local: ## Install the uv environment and install all packages with dependencies with local Arcade sources
 	@echo "🚀 Creating virtual environment and installing all packages using uv"
 	@uv sync --active --all-extras
-	@uv run pre-commit install
+	@if [ -f .pre-commit-config.yaml ]; then uv run pre-commit install; fi
 	@echo "✅ All packages and dependencies installed via uv"
 
 .PHONY: build
@@ -47,7 +47,9 @@ bump-version: ## Bump the version in the pyproject.toml file by a patch version
 
 .PHONY: check
 check: ## Run code quality tools.
-	@echo "🚀 Linting code: Running pre-commit"
-	@uv run pre-commit run -a
+	@if [ -f .pre-commit-config.yaml ]; then\
+		echo "🚀 Linting code: Running pre-commit";\
+		uv run --no-sources pre-commit run -a;\
+	fi
 	@echo "🚀 Static type checking: Running mypy"
 	@uv run mypy --config-file=pyproject.toml


### PR DESCRIPTION
The current `arcade new` command fails to `make install` and `make check` if it's not manually patched with pre-commit files. It also fails due to local dependencies if it's not run inside `arcade-ai/toolkits`

This PR patches the toolkit template to only include the local dependencies if it detects is `arcade new` being run inside `arcade-ai/toolkits`, it also makes pre-commit commands optional.