### PR TITLE
Bump arcade-ai PyPI Package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "arcade-ai"
-version = "2.0.0"
+version = "2.0.2"
 description = "Arcade.dev - Tool Calling platform for Agents"
 readme = "README.md"
 license = {file = "LICENSE"}


### PR DESCRIPTION
v2.0.1 was missed last week. Going straight to 2.0.2 to match the container version.