### PR TITLE
Filter out unneeded files/directories before deploying workers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "arcade-ai"
-version = "2.0.2"
+version = "2.0.3"
 description = "Arcade.dev - Tool Calling platform for Agents"
 readme = "README.md"
 license = {file = "LICENSE"}


### PR DESCRIPTION
`arcade deploy` is failing for local packages that have large unneeded files such as `uv.lock`. It is failing because it is taking too long for the CLI to compress and PUT to the cloud.