### PR TITLE
Bump toolkit versions

### DIFF
--- a/toolkits/asana/pyproject.toml
+++ b/toolkits/asana/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "arcade_asana"
-version = "0.1.0"
+version = "0.1.1"
 description = "Arcade tools designed for LLMs to interact with Asana"
 requires-python = ">=3.10"
 dependencies = [

--- a/toolkits/code_sandbox/pyproject.toml
+++ b/toolkits/code_sandbox/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "arcade_code_sandbox"
-version = "1.0.0"
+version = "1.0.1"
 description = "Arcade.dev LLM tools for running code in a sandbox"
 requires-python = ">=3.10"
 dependencies = [

--- a/toolkits/confluence/pyproject.toml
+++ b/toolkits/confluence/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "arcade_confluence"
-version = "0.0.1"
+version = "0.0.2"
 description = "Arcade.dev LLM tools for Confluence"
 requires-python = ">=3.10"
 dependencies = [

--- a/toolkits/dropbox/pyproject.toml
+++ b/toolkits/dropbox/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "arcade_dropbox"
-version = "0.1.1"
+version = "0.1.2"
 description = "Arcade tools designed for LLMs to interact with Dropbox"
 requires-python = ">=3.10"
 dependencies = [

--- a/toolkits/github/pyproject.toml
+++ b/toolkits/github/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "arcade_github"
-version = "0.1.10"
+version = "0.1.11"
 description = "Arcade.dev LLM tools for Github"
 requires-python = ">=3.10"
 dependencies = [

--- a/toolkits/google/pyproject.toml
+++ b/toolkits/google/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "arcade_google"
-version = "1.2.1"
+version = "1.2.2"
 description = "Arcade.dev LLM tools for Google Workspace"
 requires-python = ">=3.10"
 dependencies = [

--- a/toolkits/hubspot/pyproject.toml
+++ b/toolkits/hubspot/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "arcade_hubspot"
-version = "0.2.0"
+version = "0.2.1"
 description = "Arcade tools designed for LLMs to interact with Hubspot"
 requires-python = ">=3.10"
 dependencies = [

--- a/toolkits/linkedin/pyproject.toml
+++ b/toolkits/linkedin/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "arcade_linkedin"
-version = "0.1.10"
+version = "0.1.11"
 description = "Arcade.dev LLM tools for LinkedIn"
 requires-python = ">=3.10"
 dependencies = [

--- a/toolkits/math/pyproject.toml
+++ b/toolkits/math/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "arcade_math"
-version = "1.0.1"
+version = "1.0.2"
 description = "Arcade.dev LLM tools for doing math"
 requires-python = ">=3.10"
 dependencies = [

--- a/toolkits/microsoft/pyproject.toml
+++ b/toolkits/microsoft/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "arcade_microsoft"
-version = "0.2.0"
+version = "0.2.1"
 description = "Arcade.dev LLM tools for Outlook Mail"
 requires-python = ">=3.10"
 dependencies = [

--- a/toolkits/notion/pyproject.toml
+++ b/toolkits/notion/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "arcade_notion_toolkit"
-version = "0.1.3"
+version = "0.1.4"
 description = "Arcade.dev LLM tools for Notion"
 requires-python = ">=3.10"
 dependencies = [

--- a/toolkits/reddit/pyproject.toml
+++ b/toolkits/reddit/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "arcade_reddit"
-version = "0.1.0"
+version = "0.1.1"
 description = "Arcade.dev LLM tools Reddit"
 requires-python = ">=3.10"
 dependencies = [ "arcade-tdk>=2.0.0,<3.0.0", "httpx>=0.27.2,<1.0.0",]

--- a/toolkits/salesforce/pyproject.toml
+++ b/toolkits/salesforce/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "arcade_salesforce"
-version = "0.1.0"
+version = "0.1.1"
 description = "Arcade tools designed for LLMs to interact with Salesforce"
 requires-python = ">=3.10"
 dependencies = [ "arcade-tdk>=2.0.0,<3.0.0", "httpx>=0.27.2,<1.0.0",]

--- a/toolkits/search/pyproject.toml
+++ b/toolkits/search/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "arcade_search"
-version = "1.4.0"
+version = "1.4.1"
 description = "Arcade.dev LLM tools for searching the web"
 requires-python = ">=3.10"
 dependencies = [ "arcade-tdk>=2.0.0,<3.0.0", "serpapi>=0.1.5,<1.0.0",]

--- a/toolkits/slack/pyproject.toml
+++ b/toolkits/slack/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "arcade_slack"
-version = "0.4.3"
+version = "0.4.4"
 description = "Arcade.dev LLM tools for Slack"
 requires-python = ">=3.10"
 dependencies = [ "aiodns>=1.0,<2.0.0", "typing; python_version < '3.7'", "aiohttp>=3.7.3,<4.0.0", "arcade-tdk>=2.0.0,<3.0.0", "slack-sdk>=3.31.0,<4.0.0",]

--- a/toolkits/spotify/pyproject.toml
+++ b/toolkits/spotify/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "arcade_spotify"
-version = "0.2.1"
+version = "0.2.2"
 description = "Arcade.dev LLM tools for Spotify"
 requires-python = ">=3.10"
 dependencies = [ "arcade-tdk>=2.0.0,<3.0.0", "httpx>=0.27.2,<1.0.0",]

--- a/toolkits/stripe/pyproject.toml
+++ b/toolkits/stripe/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "arcade_stripe"
-version = "0.0.1"
+version = "0.0.2"
 description = "Arcade.dev LLM tools for Stripe"
 requires-python = ">=3.10"
 dependencies = [ "arcade-tdk>=2.0.0,<3.0.0", "stripe-agent-toolkit>=0.6.1,<1.0.0", "stripe>=11.0.0,<12.0.0",]

--- a/toolkits/web/pyproject.toml
+++ b/toolkits/web/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "arcade_web"
-version = "1.0.1"
+version = "1.0.2"
 description = "Arcade.dev LLM tools for web scraping related tasks"
 requires-python = ">=3.10"
 dependencies = [ "arcade-tdk>=2.0.0,<3.0.0", "firecrawl-py>=1.3.1,<2.0.0",]

--- a/toolkits/x/pyproject.toml
+++ b/toolkits/x/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "arcade_x"
-version = "0.1.12"
+version = "0.1.13"
 description = "Arcade.dev LLM tools for X (Twitter)"
 requires-python = ">=3.10"
 dependencies = [ "arcade-tdk>=2.0.0,<3.0.0", "httpx>=0.27.2,<1.0.0",]

--- a/toolkits/zoom/pyproject.toml
+++ b/toolkits/zoom/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "arcade_zoom"
-version = "0.1.10"
+version = "0.1.11"
 description = "Arcade.dev LLM tools for Zoom"
 requires-python = ">=3.10"
 dependencies = [ "arcade-tdk>=2.0.0,<3.0.0", "httpx>=0.27.2,<1.0.0",]


### PR DESCRIPTION
The PyPI packages haven't been bumped since migrating them to use the TDK. This PR excludes bumping Jira since it was bumped last week.