### PR TITLE
Skip tests that require secrets in forks

### DIFF
--- a/.github/workflows/test-toolkits.yml
+++ b/.github/workflows/test-toolkits.yml
@@ -30,6 +30,43 @@ jobs:
           echo "toolkits_without_secrets=$TOOLKITS_WITHOUT_SECRETS" >> $GITHUB_OUTPUT
           echo "toolkits_with_secrets=$TOOLKITS_WITH_SECRETS" >> $GITHUB_OUTPUT
 
+  test-toolkits:
+    needs: setup
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        toolkit: ${{ fromJson(needs.setup.outputs.toolkits_without_secrets) }}
+      fail-fast: true
+    steps:
+      - name: Check out
+        uses: actions/checkout@v4
+
+      - name: Set up the environment
+        uses: ./.github/actions/setup-uv-env
+
+      - name: Install toolkit dependencies
+        working-directory: toolkits/${{ matrix.toolkit }}
+        run: uv pip install -e ".[dev]"
+
+      - name: Check toolkit
+        working-directory: toolkits/${{ matrix.toolkit }}
+        run: |
+          uv run --active pre-commit run -a
+          uv run --active mypy --config-file=pyproject.toml
+
+      - name: Test stand-alone toolkits (no secrets)
+        working-directory: toolkits/${{ matrix.toolkit }}
+        run: |
+          # Run pytest and capture exit code
+          uv run --active pytest -W ignore -v --cov=arcade_${{ matrix.toolkit }} --cov-report=xml || EXIT_CODE=$?
+
+          if [ "${EXIT_CODE:-0}" -eq 5 ]; then
+            echo "No tests found for toolkit ${{ matrix.toolkit }}, skipping..."
+            exit 0
+          elif [ "${EXIT_CODE:-0}" -ne 0 ]; then
+            exit ${EXIT_CODE}
+          fi
+
   test-toolkits-with-secrets:
     needs: setup
     runs-on: ubuntu-latest
@@ -56,43 +93,6 @@ jobs:
 
       - name: Test stand-alone toolkits (with secrets)
         if: github.repository == 'ArcadeAI/arcade-ai'
-        working-directory: toolkits/${{ matrix.toolkit }}
-        run: |
-          # Run pytest and capture exit code
-          uv run --active pytest -W ignore -v --cov=arcade_${{ matrix.toolkit }} --cov-report=xml || EXIT_CODE=$?
-
-          if [ "${EXIT_CODE:-0}" -eq 5 ]; then
-            echo "No tests found for toolkit ${{ matrix.toolkit }}, skipping..."
-            exit 0
-          elif [ "${EXIT_CODE:-0}" -ne 0 ]; then
-            exit ${EXIT_CODE}
-          fi
-
-  test-toolkits:
-    needs: setup
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        toolkit: ${{ fromJson(needs.setup.outputs.toolkits_without_secrets) }}
-      fail-fast: true
-    steps:
-      - name: Check out
-        uses: actions/checkout@v4
-
-      - name: Set up the environment
-        uses: ./.github/actions/setup-uv-env
-
-      - name: Install toolkit dependencies
-        working-directory: toolkits/${{ matrix.toolkit }}
-        run: uv pip install -e ".[dev]"
-
-      - name: Check toolkit
-        working-directory: toolkits/${{ matrix.toolkit }}
-        run: |
-          uv run --active pre-commit run -a
-          uv run --active mypy --config-file=pyproject.toml
-
-      - name: Test stand-alone toolkits (no secrets)
         working-directory: toolkits/${{ matrix.toolkit }}
         env:
           TEST_POSTGRES_DATABASE_CONNECTION_STRING: ${{ secrets.TEST_POSTGRES_DATABASE_CONNECTION_STRING }} # TODO: dynamically only load the `TEST_${{ matrix.toolkit }}_DATABASE_CONNECTION_STRING secret`

--- a/.github/workflows/test-toolkits.yml
+++ b/.github/workflows/test-toolkits.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Test toolkits that require secrets
         if: |
           contains(needs.toolkits_with_secrets.outputs.toolkits_with_secrets, matrix.toolkit) &&
-          github.repository == 'arcade-ai/arcade-ai'
+          github.repository == 'ArcadeAI/arcade-ai'
         working-directory: toolkits/${{ matrix.toolkit }}
         env:
           TEST_POSTGRES_DATABASE_CONNECTION_STRING: ${{ secrets.TEST_POSTGRES_DATABASE_CONNECTION_STRING }} # TODO: dynamically only load the `TEST_${{ matrix.toolkit }}_DATABASE_CONNECTION_STRING secret`

--- a/.github/workflows/test-toolkits.yml
+++ b/.github/workflows/test-toolkits.yml
@@ -54,7 +54,7 @@ jobs:
           echo "toolkits_with_secrets=$(grep -rl 'arcade-ci:requires-secret' toolkits/* | cut -d'/' -f2 | sort -u | tr '\n' ' ')" >> $GITHUB_OUTPUT        run: |
           echo "toolkits_with_secrets: ${{ needs.toolkits_with_secrets.outputs.toolkits_with_secrets }}"
 
-      - name: Test toolkit stand-alone toolkits
+      - name: Test stand-alone toolkits (no secrets)
         working-directory: toolkits/${{ matrix.toolkit }}
         if: |
           !contains(needs.toolkits_with_secrets.outputs.toolkits_with_secrets , matrix.toolkit)
@@ -75,8 +75,7 @@ jobs:
           github.repository == 'arcade-ai/arcade-ai'
         working-directory: toolkits/${{ matrix.toolkit }}
         env:
-          # TODO: dynamically only load the `TEST_${{ matrix.toolkit }}_DATABASE_CONNECTION_STRING secret`
-          TEST_POSTGRES_DATABASE_CONNECTION_STRING: ${{ secrets.TEST_POSTGRES_DATABASE_CONNECTION_STRING }}
+          TEST_POSTGRES_DATABASE_CONNECTION_STRING: ${{ secrets.TEST_POSTGRES_DATABASE_CONNECTION_STRING }} # TODO: dynamically only load the `TEST_${{ matrix.toolkit }}_DATABASE_CONNECTION_STRING secret`
         run: |
           # Run pytest and capture exit code
           uv run --active pytest -W ignore -v --cov=arcade_${{ matrix.toolkit }} --cov-report=xml || EXIT_CODE=$?

--- a/.github/workflows/test-toolkits.yml
+++ b/.github/workflows/test-toolkits.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       matrix:
         toolkit: ${{ fromJson(needs.setup.outputs.tool_matrix) }}
-      fail-fast: false
+      fail-fast: true
     steps:
       - name: Check out
         uses: actions/checkout@v4

--- a/.github/workflows/test-toolkits.yml
+++ b/.github/workflows/test-toolkits.yml
@@ -17,20 +17,16 @@ jobs:
       - name: Check out
         uses: actions/checkout@v4
 
-      - name: Define toolkits that require secrets
-        id: toolkits_with_secrets
-        run: |
-          # Find toolkits that have "arcade-ci:requires-secret" in any file
-          TOOLKITS_WITH_SECRETS=$(grep -rl 'arcade-ci:requires-secret' toolkits/* | cut -d'/' -f2 | sort -u | jq -R -s -c 'split("\n")[:-1]')
-          echo "Found toolkits with secrets: $TOOLKITS_WITH_SECRETS"
-          echo "toolkits_with_secrets=$TOOLKITS_WITH_SECRETS" >> $GITHUB_OUTPUT
-
       - name: determine toolkits without secrets
         id: toolkits_without_secrets
         run: |
-          # Find toolkits that do not have "arcade-ci:requires-secret" in any file
-          TOOLKITS_WITHOUT_SECRETS=$(grep -L 'arcade-ci:requires-secret' toolkits/* | cut -d'/' -f2 | sort -u | jq -R -s -c 'split("\n")[:-1]')
+          # Find all directories in toolkits/ that have a pyproject.toml
+          TOOLKITS=$(find toolkits -maxdepth 1 -type d -not -name "toolkits" -exec test -f {}/pyproject.toml \; -exec basename {} \; | jq -R -s -c 'split("\n")[:-1]')
+          TOOLKITS_WITH_SECRETS=$(grep -rl 'arcade-ci:requires-secret' toolkits/* | cut -d'/' -f2 | sort -u | jq -R -s -c 'split("\n")[:-1]')
+          TOOLKITS_WITHOUT_SECRETS=$(echo "$TOOLKITS" | jq -c --argjson with "$TOOLKITS_WITH_SECRETS" '[.[] | select(. as $t | $with | index($t) | not)]')
+          echo "Found toolkits: $TOOLKITS"
           echo "Found toolkits without secrets: $TOOLKITS_WITHOUT_SECRETS"
+          echo "Found toolkits with secrets: $TOOLKITS_WITH_SECRETS"
           echo "toolkits_without_secrets=$TOOLKITS_WITHOUT_SECRETS" >> $GITHUB_OUTPUT
 
   test-toolkits-with-secrets:
@@ -70,7 +66,7 @@ jobs:
             exit ${EXIT_CODE}
           fi
 
-  test-toolkits-without-secrets:
+  test-toolkits:
     needs: setup
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/test-toolkits.yml
+++ b/.github/workflows/test-toolkits.yml
@@ -22,7 +22,7 @@ jobs:
         run: |
           # Find all directories in toolkits/ that have a pyproject.toml
           TOOLKITS=$(find toolkits -maxdepth 1 -type d -not -name "toolkits" -exec test -f {}/pyproject.toml \; -exec basename {} \; | jq -R -s -c 'split("\n")[:-1]')
-          TOOLKITS_WITH_SECRETS=["postgres"]
+          TOOLKITS_WITH_SECRETS='["postgres"]'
           TOOLKITS_WITHOUT_SECRETS=$(echo "$TOOLKITS" | jq -c --argjson with "$TOOLKITS_WITH_SECRETS" '[.[] | select(. as $t | $with | index($t) | not)]')
           echo "Found toolkits: $TOOLKITS"
           echo "Found toolkits without secrets: $TOOLKITS_WITHOUT_SECRETS"

--- a/.github/workflows/test-toolkits.yml
+++ b/.github/workflows/test-toolkits.yml
@@ -54,7 +54,8 @@ jobs:
           uv run --active pre-commit run -a
           uv run --active mypy --config-file=pyproject.toml
 
-      - name: Test stand-alone toolkits (no secrets)
+      - name: Test stand-alone toolkits (with secrets)
+        if: github.repository == 'ArcadeAI/arcade-ai'
         working-directory: toolkits/${{ matrix.toolkit }}
         run: |
           # Run pytest and capture exit code
@@ -92,18 +93,16 @@ jobs:
           uv run --active mypy --config-file=pyproject.toml
 
       - name: Test stand-alone toolkits (no secrets)
-        if: github.repository == 'ArcadeAI/arcade-ai'
         working-directory: toolkits/${{ matrix.toolkit }}
         env:
           TEST_POSTGRES_DATABASE_CONNECTION_STRING: ${{ secrets.TEST_POSTGRES_DATABASE_CONNECTION_STRING }} # TODO: dynamically only load the `TEST_${{ matrix.toolkit }}_DATABASE_CONNECTION_STRING secret`
         run: |
-          if:
-            # Run pytest and capture exit code
-            uv run --active pytest -W ignore -v --cov=arcade_${{ matrix.toolkit }} --cov-report=xml || EXIT_CODE=$?
+          # Run pytest and capture exit code
+          uv run --active pytest -W ignore -v --cov=arcade_${{ matrix.toolkit }} --cov-report=xml || EXIT_CODE=$?
 
-            if [ "${EXIT_CODE:-0}" -eq 5 ]; then
-              echo "No tests found for toolkit ${{ matrix.toolkit }}, skipping..."
-              exit 0
-            elif [ "${EXIT_CODE:-0}" -ne 0 ]; then
-              exit ${EXIT_CODE}
+          if [ "${EXIT_CODE:-0}" -eq 5 ]; then
+            echo "No tests found for toolkit ${{ matrix.toolkit }}, skipping..."
+            exit 0
+          elif [ "${EXIT_CODE:-0}" -ne 0 ]; then
+            exit ${EXIT_CODE}
           fi

--- a/.github/workflows/test-toolkits.yml
+++ b/.github/workflows/test-toolkits.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       matrix:
         toolkit: ${{ fromJson(needs.setup.outputs.tool_matrix) }}
-      fail-fast: true
+      fail-fast: false
     steps:
       - name: Check out
         uses: actions/checkout@v4

--- a/.github/workflows/test-toolkits.yml
+++ b/.github/workflows/test-toolkits.yml
@@ -11,25 +11,34 @@ jobs:
   setup:
     runs-on: ubuntu-latest
     outputs:
-      tool_matrix: ${{ steps.get-toolkits.outputs.toolkits }}
+      toolkits_with_secrets: ${{ steps.toolkits_with_secrets.outputs.toolkits_with_secrets }}
+      toolkits_without_secrets: ${{ steps.toolkits_without_secrets.outputs.toolkits_without_secrets }}
     steps:
       - name: Check out
         uses: actions/checkout@v4
 
-      - name: Get toolkits
-        id: get-toolkits
+      - name: Define toolkits that require secrets
+        id: toolkits_with_secrets
         run: |
-          # Find all directories in toolkits/ that have a pyproject.toml
-          TOOLKITS=$(find toolkits -maxdepth 1 -type d -not -name "toolkits" -exec test -f {}/pyproject.toml \; -exec basename {} \; | jq -R -s -c 'split("\n")[:-1]')
-          echo "Found toolkits: $TOOLKITS"
-          echo "toolkits=$TOOLKITS" >> $GITHUB_OUTPUT
+          # Find toolkits that have "arcade-ci:requires-secret" in any file
+          TOOLKITS_WITH_SECRETS=$(grep -rl 'arcade-ci:requires-secret' toolkits/* | cut -d'/' -f2 | sort -u | jq -R -s -c 'split("\n")[:-1]')
+          echo "Found toolkits with secrets: $TOOLKITS_WITH_SECRETS"
+          echo "toolkits_with_secrets=$TOOLKITS_WITH_SECRETS" >> $GITHUB_OUTPUT
 
-  test-toolkits:
+      - name: determine toolkits without secrets
+        id: toolkits_without_secrets
+        run: |
+          # Find toolkits that do not have "arcade-ci:requires-secret" in any file
+          TOOLKITS_WITHOUT_SECRETS=$(grep -L 'arcade-ci:requires-secret' toolkits/* | cut -d'/' -f2 | sort -u | jq -R -s -c 'split("\n")[:-1]')
+          echo "Found toolkits without secrets: $TOOLKITS_WITHOUT_SECRETS"
+          echo "toolkits_without_secrets=$TOOLKITS_WITHOUT_SECRETS" >> $GITHUB_OUTPUT
+
+  test-toolkits-with-secrets:
     needs: setup
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        toolkit: ${{ fromJson(needs.setup.outputs.tool_matrix) }}
+        toolkit: ${{ fromJson(needs.setup.outputs.toolkits_with_secrets) }}
       fail-fast: true
     steps:
       - name: Check out
@@ -48,16 +57,8 @@ jobs:
           uv run --active pre-commit run -a
           uv run --active mypy --config-file=pyproject.toml
 
-      - name: Define toolkits that require secrets
-        id: toolkits_with_secrets
-        run: |
-          echo "toolkits_with_secrets=$(grep -rl 'arcade-ci:requires-secret' toolkits/* | cut -d'/' -f2 | sort -u | tr '\n' ' ')" >> $GITHUB_OUTPUT        run: |
-          echo "toolkits_with_secrets: ${{ needs.toolkits_with_secrets.outputs.toolkits_with_secrets }}"
-
       - name: Test stand-alone toolkits (no secrets)
         working-directory: toolkits/${{ matrix.toolkit }}
-        if: |
-          !contains(needs.toolkits_with_secrets.outputs.toolkits_with_secrets , matrix.toolkit)
         run: |
           # Run pytest and capture exit code
           uv run --active pytest -W ignore -v --cov=arcade_${{ matrix.toolkit }} --cov-report=xml || EXIT_CODE=$?
@@ -69,20 +70,43 @@ jobs:
             exit ${EXIT_CODE}
           fi
 
-      - name: Test toolkits that require secrets
-        if: |
-          contains(needs.toolkits_with_secrets.outputs.toolkits_with_secrets, matrix.toolkit) &&
-          github.repository == 'ArcadeAI/arcade-ai'
+  test-toolkits-without-secrets:
+    needs: setup
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        toolkit: ${{ fromJson(needs.setup.outputs.toolkits_without_secrets) }}
+      fail-fast: true
+    steps:
+      - name: Check out
+        uses: actions/checkout@v4
+
+      - name: Set up the environment
+        uses: ./.github/actions/setup-uv-env
+
+      - name: Install toolkit dependencies
+        working-directory: toolkits/${{ matrix.toolkit }}
+        run: uv pip install -e ".[dev]"
+
+      - name: Check toolkit
+        working-directory: toolkits/${{ matrix.toolkit }}
+        run: |
+          uv run --active pre-commit run -a
+          uv run --active mypy --config-file=pyproject.toml
+
+      - name: Test stand-alone toolkits (no secrets)
+        if: github.repository == 'ArcadeAI/arcade-ai'
         working-directory: toolkits/${{ matrix.toolkit }}
         env:
           TEST_POSTGRES_DATABASE_CONNECTION_STRING: ${{ secrets.TEST_POSTGRES_DATABASE_CONNECTION_STRING }} # TODO: dynamically only load the `TEST_${{ matrix.toolkit }}_DATABASE_CONNECTION_STRING secret`
         run: |
-          # Run pytest and capture exit code
-          uv run --active pytest -W ignore -v --cov=arcade_${{ matrix.toolkit }} --cov-report=xml || EXIT_CODE=$?
+          if:
+            # Run pytest and capture exit code
+            uv run --active pytest -W ignore -v --cov=arcade_${{ matrix.toolkit }} --cov-report=xml || EXIT_CODE=$?
 
-          if [ "${EXIT_CODE:-0}" -eq 5 ]; then
-            echo "No tests found for toolkit ${{ matrix.toolkit }}, skipping..."
-            exit 0
-          elif [ "${EXIT_CODE:-0}" -ne 0 ]; then
-            exit ${EXIT_CODE}
+            if [ "${EXIT_CODE:-0}" -eq 5 ]; then
+              echo "No tests found for toolkit ${{ matrix.toolkit }}, skipping..."
+              exit 0
+            elif [ "${EXIT_CODE:-0}" -ne 0 ]; then
+              exit ${EXIT_CODE}
           fi

--- a/.github/workflows/test-toolkits.yml
+++ b/.github/workflows/test-toolkits.yml
@@ -51,7 +51,8 @@ jobs:
       - name: Define toolkits that require secrets
         id: toolkits_with_secrets
         run: |
-          echo "toolkits_with_secrets=$(grep -rl 'arcade-ci:requires-secret' toolkits/* | cut -d'/' -f2 | sort -u | tr '\n' ' ')" >> $GITHUB_OUTPUT
+          echo "toolkits_with_secrets=$(grep -rl 'arcade-ci:requires-secret' toolkits/* | cut -d'/' -f2 | sort -u | tr '\n' ' ')" >> $GITHUB_OUTPUT        run: |
+          echo "toolkits_with_secrets: ${{ needs.toolkits_with_secrets.outputs.toolkits_with_secrets }}"
 
       - name: Test toolkit stand-alone toolkits
         working-directory: toolkits/${{ matrix.toolkit }}

--- a/.github/workflows/test-toolkits.yml
+++ b/.github/workflows/test-toolkits.yml
@@ -11,31 +11,31 @@ jobs:
   setup:
     runs-on: ubuntu-latest
     outputs:
-      toolkits_with_secrets: ${{ steps.load_toolkits.outputs.toolkits_with_secrets }}
-      toolkits_without_secrets: ${{ steps.load_toolkits.outputs.toolkits_without_secrets }}
+      toolkits_with_gha_secrets: ${{ steps.load_toolkits.outputs.toolkits_with_gha_secrets }}
+      toolkits_without_gha_secrets: ${{ steps.load_toolkits.outputs.toolkits_without_gha_secrets }}
     steps:
       - name: Check out
         uses: actions/checkout@v4
 
-      - name: determine toolkits without secrets
+      - name: determine toolkits with and without GHA secrets
         id: load_toolkits
         run: |
           # Find all directories in toolkits/ that have a pyproject.toml
           TOOLKITS=$(find toolkits -maxdepth 1 -type d -not -name "toolkits" -exec test -f {}/pyproject.toml \; -exec basename {} \; | jq -R -s -c 'split("\n")[:-1]')
-          TOOLKITS_WITH_SECRETS='["postgres"]'
-          TOOLKITS_WITHOUT_SECRETS=$(echo "$TOOLKITS" | jq -c --argjson with "$TOOLKITS_WITH_SECRETS" '[.[] | select(. as $t | $with | index($t) | not)]')
+          TOOLKITS_WITH_GHA_SECRETS='["postgres"]'
+          TOOLKITS_WITHOUT_GHA_SECRETS=$(echo "$TOOLKITS" | jq -c --argjson with "$TOOLKITS_WITH_GHA_SECRETS" '[.[] | select(. as $t | $with | index($t) | not)]')
           echo "Found toolkits: $TOOLKITS"
-          echo "Found toolkits without secrets: $TOOLKITS_WITHOUT_SECRETS"
-          echo "Found toolkits with secrets: $TOOLKITS_WITH_SECRETS"
-          echo "toolkits_without_secrets=$TOOLKITS_WITHOUT_SECRETS" >> $GITHUB_OUTPUT
-          echo "toolkits_with_secrets=$TOOLKITS_WITH_SECRETS" >> $GITHUB_OUTPUT
+          echo "Found toolkits without GHA secrets: $TOOLKITS_WITHOUT_GHA_SECRETS"
+          echo "Found toolkits with GHA secrets: $TOOLKITS_WITH_GHA_SECRETS"
+          echo "toolkits_without_gha_secrets=$TOOLKITS_WITHOUT_GHA_SECRETS" >> $GITHUB_OUTPUT
+          echo "toolkits_with_gha_secrets=$TOOLKITS_WITH_GHA_SECRETS" >> $GITHUB_OUTPUT
 
   test-toolkits:
     needs: setup
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        toolkit: ${{ fromJson(needs.setup.outputs.toolkits_without_secrets) }}
+        toolkit: ${{ fromJson(needs.setup.outputs.toolkits_without_gha_secrets) }}
       fail-fast: true
     steps:
       - name: Check out
@@ -67,12 +67,12 @@ jobs:
             exit ${EXIT_CODE}
           fi
 
-  test-toolkits-with-secrets:
+  test-toolkits-with-gha-secrets:
     needs: setup
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        toolkit: ${{ fromJson(needs.setup.outputs.toolkits_with_secrets) }}
+        toolkit: ${{ fromJson(needs.setup.outputs.toolkits_with_gha_secrets) }}
       fail-fast: true
     steps:
       - name: Check out

--- a/.github/workflows/test-toolkits.yml
+++ b/.github/workflows/test-toolkits.yml
@@ -48,10 +48,34 @@ jobs:
           uv run --active pre-commit run -a
           uv run --active mypy --config-file=pyproject.toml
 
-      - name: Test toolkit
+      - name: Define toolkits that require secrets
+        id: toolkits_with_secrets
+        run: |
+          echo "toolkits_with_secrets=$(grep -rl 'arcade-ci:requires-secret' toolkits/* | cut -d'/' -f2 | sort -u | tr '\n' ' ')" >> $GITHUB_OUTPUT
+
+      - name: Test toolkit stand-alone toolkits
+        working-directory: toolkits/${{ matrix.toolkit }}
+        if: |
+          !contains(needs.toolkits_with_secrets.outputs.toolkits_with_secrets , matrix.toolkit)
+        run: |
+          # Run pytest and capture exit code
+          uv run --active pytest -W ignore -v --cov=arcade_${{ matrix.toolkit }} --cov-report=xml || EXIT_CODE=$?
+
+          if [ "${EXIT_CODE:-0}" -eq 5 ]; then
+            echo "No tests found for toolkit ${{ matrix.toolkit }}, skipping..."
+            exit 0
+          elif [ "${EXIT_CODE:-0}" -ne 0 ]; then
+            exit ${EXIT_CODE}
+          fi
+
+      - name: Test toolkits that require secrets
+        if: |
+          contains(needs.toolkits_with_secrets.outputs.toolkits_with_secrets, matrix.toolkit) &&
+          github.repository == 'arcade-ai/arcade-ai'
         working-directory: toolkits/${{ matrix.toolkit }}
         env:
-          TEST_POSTGRES_DATABASE_CONNECTION_STRING: ${{ secrets.TEST_POSTGRES_DATABASE_CONNECTION_STRING }} # TODO: dynamically only load the `TEST_${{ matrix.toolkit }}_DATABASE_CONNECTION_STRING secret`
+          # TODO: dynamically only load the `TEST_${{ matrix.toolkit }}_DATABASE_CONNECTION_STRING secret`
+          TEST_POSTGRES_DATABASE_CONNECTION_STRING: ${{ secrets.TEST_POSTGRES_DATABASE_CONNECTION_STRING }}
         run: |
           # Run pytest and capture exit code
           uv run --active pytest -W ignore -v --cov=arcade_${{ matrix.toolkit }} --cov-report=xml || EXIT_CODE=$?

--- a/.github/workflows/test-toolkits.yml
+++ b/.github/workflows/test-toolkits.yml
@@ -11,14 +11,14 @@ jobs:
   setup:
     runs-on: ubuntu-latest
     outputs:
-      toolkits_with_secrets: ${{ steps.toolkits_with_secrets.outputs.toolkits_with_secrets }}
-      toolkits_without_secrets: ${{ steps.toolkits_without_secrets.outputs.toolkits_without_secrets }}
+      toolkits_with_secrets: ${{ steps.load_toolkits.outputs.toolkits_with_secrets }}
+      toolkits_without_secrets: ${{ steps.load_toolkits.outputs.toolkits_without_secrets }}
     steps:
       - name: Check out
         uses: actions/checkout@v4
 
       - name: determine toolkits without secrets
-        id: toolkits_without_secrets
+        id: load_toolkits
         run: |
           # Find all directories in toolkits/ that have a pyproject.toml
           TOOLKITS=$(find toolkits -maxdepth 1 -type d -not -name "toolkits" -exec test -f {}/pyproject.toml \; -exec basename {} \; | jq -R -s -c 'split("\n")[:-1]')
@@ -28,6 +28,7 @@ jobs:
           echo "Found toolkits without secrets: $TOOLKITS_WITHOUT_SECRETS"
           echo "Found toolkits with secrets: $TOOLKITS_WITH_SECRETS"
           echo "toolkits_without_secrets=$TOOLKITS_WITHOUT_SECRETS" >> $GITHUB_OUTPUT
+          echo "toolkits_with_secrets=$TOOLKITS_WITH_SECRETS" >> $GITHUB_OUTPUT
 
   test-toolkits-with-secrets:
     needs: setup

--- a/.github/workflows/test-toolkits.yml
+++ b/.github/workflows/test-toolkits.yml
@@ -22,7 +22,7 @@ jobs:
         run: |
           # Find all directories in toolkits/ that have a pyproject.toml
           TOOLKITS=$(find toolkits -maxdepth 1 -type d -not -name "toolkits" -exec test -f {}/pyproject.toml \; -exec basename {} \; | jq -R -s -c 'split("\n")[:-1]')
-          TOOLKITS_WITH_SECRETS=$(grep -rl 'arcade-ci:requires-secret' toolkits/* | cut -d'/' -f2 | sort -u | jq -R -s -c 'split("\n")[:-1]')
+          TOOLKITS_WITH_SECRETS=["postgres"]
           TOOLKITS_WITHOUT_SECRETS=$(echo "$TOOLKITS" | jq -c --argjson with "$TOOLKITS_WITH_SECRETS" '[.[] | select(. as $t | $with | index($t) | not)]')
           echo "Found toolkits: $TOOLKITS"
           echo "Found toolkits without secrets: $TOOLKITS_WITHOUT_SECRETS"

--- a/toolkits/postgres/tests/test_postgres.py
+++ b/toolkits/postgres/tests/test_postgres.py
@@ -1,5 +1,3 @@
-# arcade-ci:requires-secret:TEST_POSTGRES_DATABASE_CONNECTION_STRING
-
 import os
 from os import environ
 

--- a/toolkits/postgres/tests/test_postgres.py
+++ b/toolkits/postgres/tests/test_postgres.py
@@ -1,3 +1,5 @@
+# arcade-ci:requires-secret:TEST_POSTGRES_DATABASE_CONNECTION_STRING
+
 import os
 from os import environ
 


### PR DESCRIPTION
We know that forks won't have our secrets, so we separate those toolkits out to new a new test group and skip them if you aren't in this main repo.  We know if a test suite has a secret via a magic comment