### PR TITLE
bugfix: URL expansion in Twitter

### DIFF
--- a/toolkits/x/arcade_x/tools/utils.py
+++ b/toolkits/x/arcade_x/tools/utils.py
@@ -82,9 +82,10 @@ def expand_urls_in_tweets(
         new_tweet = tweet_data.copy()
         if "entities" in new_tweet and "urls" in new_tweet["entities"]:
             for url_entity in new_tweet["entities"]["urls"]:
-                short_url = url_entity["url"]
-                expanded_url = url_entity["expanded_url"]
-                new_tweet["text"] = new_tweet["text"].replace(short_url, expanded_url)
+                if "url" in url_entity and "expanded_url" in url_entity:
+                    short_url = url_entity["url"]
+                    expanded_url = url_entity["expanded_url"]
+                    new_tweet["text"] = new_tweet["text"].replace(short_url, expanded_url)
 
         if delete_entities:
             new_tweet.pop("entities", None)

--- a/toolkits/x/pyproject.toml
+++ b/toolkits/x/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "arcade_x"
-version = "0.1.2"
+version = "0.1.16"
 description = "Arcade.dev LLM tools for X (Twitter)"
 requires-python = ">=3.10"
 dependencies = [ "arcade-tdk>=2.0.0,<3.0.0", "httpx>=0.27.2,<1.0.0",]

--- a/toolkits/x/pyproject.toml
+++ b/toolkits/x/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "arcade_x"
-version = "0.1.15"
+version = "0.1.2"
 description = "Arcade.dev LLM tools for X (Twitter)"
 requires-python = ">=3.10"
 dependencies = [ "arcade-tdk>=2.0.0,<3.0.0", "httpx>=0.27.2,<1.0.0",]


### PR DESCRIPTION
This solves an edge case where the `"url"` entity does not have an `"expanded_url"` case when expanding. The behavior for now is simply don't replace the URL as it seems the display_url is NOT what we want to keep as it's normally abbreviated