### PR TITLE
Fix `arcade worker list` endpoints

### DIFF
--- a/libs/arcade-cli/arcade_cli/worker.py
+++ b/libs/arcade-cli/arcade_cli/worker.py
@@ -164,9 +164,11 @@ def compare_endpoints(worker_id: str, engine_endpoint: str, deployments: list[di
     if is_cloud_deployment(worker_id, deployments):
         for deployment in deployments:
             deployment_endpoint = deployment["endpoint"]
-            if deployment_endpoint == engine_endpoint:
-                return engine_endpoint
-            return f"[red]Endpoint Mismatch[/red]\n[yellow]Registered Endpoint: {engine_endpoint}[/yellow]\n[green]Actual Endpoint:     {deployment_endpoint}[/green]"
+            if deployment["name"] == worker_id:
+                if deployment_endpoint == engine_endpoint:
+                    return engine_endpoint
+                else:
+                    return f"[red]Endpoint Mismatch[/red]\n[yellow]Registered Endpoint: {engine_endpoint}[/yellow]\n[green]Actual Endpoint:     {deployment_endpoint}[/green]"
     return engine_endpoint
 
 


### PR DESCRIPTION
We weren't checking that the engine version of the worker was the same as the cloud version that we were comparing against and incorrectly saying the URL was wrong

Before
<img width="1447" height="340" alt="Screenshot 2025-07-21 at 1 55 13 PM" src="https://github.com/user-attachments/assets/cf39ce9f-0c86-45fd-a68e-c92369876292" />

After
<img width="1454" height="308" alt="Screenshot 2025-07-21 at 1 55 07 PM" src="https://github.com/user-attachments/assets/efcfe6c8-b892-45f7-bf4c-71edc66c8325" />
