### PR TITLE
Add basic pagination to `GoogleSheets.GetSpreadsheet` tool

### DIFF
--- a/toolkits/google_sheets/arcade_google_sheets/enums.py
+++ b/toolkits/google_sheets/arcade_google_sheets/enums.py
@@ -23,3 +23,8 @@ class NumberFormatType(str, Enum):
     NUMBER = "NUMBER"
     PERCENT = "PERCENT"
     CURRENCY = "CURRENCY"
+
+
+class SheetIdentifierType(str, Enum):
+    POSITION = "position"
+    ID_OR_NAME = "id_or_name"

--- a/toolkits/google_sheets/arcade_google_sheets/tools/read.py
+++ b/toolkits/google_sheets/arcade_google_sheets/tools/read.py
@@ -6,7 +6,8 @@ from arcade_tdk.auth import Google
 from arcade_google_sheets.decorators import with_filepicker_fallback
 from arcade_google_sheets.utils import (
     build_sheets_service,
-    parse_get_spreadsheet_response,
+    get_spreadsheet_simple,
+    get_spreadsheet_with_pagination,
 )
 
 
@@ -20,23 +21,53 @@ from arcade_google_sheets.utils import (
 async def get_spreadsheet(
     context: ToolContext,
     spreadsheet_id: Annotated[str, "The id of the spreadsheet to get"],
+    max_rows_per_request: Annotated[
+        int, "Maximum rows to fetch per request (defaults to 1000)"
+    ] = 1000,
+    max_cols_per_request: Annotated[int, "Maximum columns to fetch per request (default: 26)"] = 26,
+    start_row: Annotated[int, "Starting row number (1-indexed, defaults to 1)"] = 1,
+    start_col: Annotated[str, "Starting column letter (defaults to 'A')"] = "A",
+    max_rows: Annotated[
+        int | None, "Maximum total rows to fetch (optional, default: None for all rows)"
+    ] = None,
+    max_cols: Annotated[
+        int | None, "Maximum total columns to fetch (optional, default: None for all columns)"
+    ] = None,
 ) -> Annotated[
     dict,
     "The spreadsheet properties and data for all sheets in the spreadsheet",
 ]:
     """
     Get the user entered values and formatted values for all cells in all sheets in the spreadsheet
-    along with the spreadsheet's properties
+    along with the spreadsheet's properties. Supports pagination for large spreadsheets.
+
+    For large spreadsheets, use pagination parameters to control memory usage:
+    - max_rows_per_request: Chunk size for rows per API request
+    - max_cols_per_request: Chunk size for columns per API request
+    - start_row/start_col: Starting position
+    - max_rows/max_cols: Optional limits on total data to fetch
     """
     service = build_sheets_service(context.get_auth_token_or_empty())
 
-    response = (
-        service.spreadsheets()
-        .get(
-            spreadsheetId=spreadsheet_id,
-            includeGridData=True,
-            fields="spreadsheetId,spreadsheetUrl,properties/title,sheets/properties,sheets/data/rowData/values/userEnteredValue,sheets/data/rowData/values/formattedValue,sheets/data/rowData/values/effectiveValue",
-        )
-        .execute()
+    is_using_defaults = (
+        max_rows_per_request == 1000
+        and max_cols_per_request == 26
+        and start_row == 1
+        and start_col == "A"
+        and max_rows is None
+        and max_cols is None
     )
-    return parse_get_spreadsheet_response(response)
+
+    if is_using_defaults:
+        return get_spreadsheet_simple(service, spreadsheet_id)
+    else:
+        return get_spreadsheet_with_pagination(
+            service,
+            spreadsheet_id,
+            max_rows_per_request,
+            max_cols_per_request,
+            start_row,
+            start_col,
+            max_rows,
+            max_cols,
+        )

--- a/toolkits/google_sheets/arcade_google_sheets/tools/read.py
+++ b/toolkits/google_sheets/arcade_google_sheets/tools/read.py
@@ -6,6 +6,7 @@ from arcade_tdk.auth import Google
 from arcade_google_sheets.decorators import with_filepicker_fallback
 from arcade_google_sheets.utils import (
     build_sheets_service,
+    enforce_data_size_limit,
     get_spreadsheet_with_pagination,
     process_get_spreadsheet_params,
 )
@@ -21,6 +22,12 @@ from arcade_google_sheets.utils import (
 async def get_spreadsheet(
     context: ToolContext,
     spreadsheet_id: Annotated[str, "The id of the spreadsheet to get"],
+    sheet_identifier: Annotated[
+        str,
+        "The identifier of the sheet to get. This can be the order it appears "
+        "in the spreadsheet (1-based), the sheet name, or the sheet id. Defaults to '1', "
+        "which represents the first sheet in the spreadsheet.",
+    ] = "1",
     start_row: Annotated[int, "Starting row number (1-indexed, defaults to 1)"] = 1,
     start_col: Annotated[
         str, "Starting column letter(s) or 1-based column number (defaults to 'A')"
@@ -33,27 +40,28 @@ async def get_spreadsheet(
     max_cols: Annotated[
         int,
         "Maximum number of columns to fetch for each sheet in the spreadsheet. "
-        "Must be between 1 and 26. Defaults to 26.",
-    ] = 26,
+        "Must be between 1 and 100. Defaults to 100.",
+    ] = 100,
 ) -> Annotated[
     dict,
-    "The spreadsheet properties and data for all sheets in the spreadsheet",
+    "The spreadsheet properties and data for the specified sheet in the spreadsheet",
 ]:
-    """
-    Get the user entered values and formatted values for all cells in all sheets in the spreadsheet
-    along with the spreadsheet's properties.
-    """
+    """Gets the specified range of cells from a single sheet in the spreadsheet."""
     start_row, start_col, max_rows, max_cols = process_get_spreadsheet_params(
         start_row, start_col, max_rows, max_cols
     )
 
     service = build_sheets_service(context.get_auth_token_or_empty())
 
-    return get_spreadsheet_with_pagination(
+    data = get_spreadsheet_with_pagination(
         service,
         spreadsheet_id,
+        sheet_identifier,
         start_row,
         start_col,
         max_rows,
         max_cols,
     )
+
+    enforce_data_size_limit(data)
+    return data

--- a/toolkits/google_sheets/arcade_google_sheets/tools/read.py
+++ b/toolkits/google_sheets/arcade_google_sheets/tools/read.py
@@ -26,10 +26,14 @@ async def get_spreadsheet(
         str, "Starting column letter(s) or 1-based column number (defaults to 'A')"
     ] = "A",
     max_rows: Annotated[
-        int, "Maximum total rows to fetch. Must be between 1 and 1000. Defaults to 1000."
+        int,
+        "Maximum number of rows to fetch for each sheet in the spreadsheet. "
+        "Must be between 1 and 1000. Defaults to 1000.",
     ] = 1000,
     max_cols: Annotated[
-        int, "Maximum total columns to fetch. Must be between 1 and 26. Defaults to 26."
+        int,
+        "Maximum number of columns to fetch for each sheet in the spreadsheet. "
+        "Must be between 1 and 26. Defaults to 26.",
     ] = 26,
 ) -> Annotated[
     dict,

--- a/toolkits/google_sheets/arcade_google_sheets/tools/read.py
+++ b/toolkits/google_sheets/arcade_google_sheets/tools/read.py
@@ -6,9 +6,9 @@ from arcade_tdk.auth import Google
 from arcade_google_sheets.decorators import with_filepicker_fallback
 from arcade_google_sheets.utils import (
     build_sheets_service,
-    enforce_data_size_limit,
     get_spreadsheet_with_pagination,
     process_get_spreadsheet_params,
+    raise_for_large_payload,
 )
 
 
@@ -22,12 +22,17 @@ from arcade_google_sheets.utils import (
 async def get_spreadsheet(
     context: ToolContext,
     spreadsheet_id: Annotated[str, "The id of the spreadsheet to get"],
-    sheet_identifier: Annotated[
-        str,
-        "The identifier of the sheet to get. This can be the order it appears "
-        "in the spreadsheet (1-based), the sheet name, or the sheet id. Defaults to '1', "
-        "which represents the first sheet in the spreadsheet.",
-    ] = "1",
+    sheet_position: Annotated[
+        int | None,
+        "The position/tab of the sheet in the spreadsheet to get. "
+        "A value of 1 represents the first (leftmost/Sheet1) sheet . "
+        "Defaults to 1.",
+    ] = 1,
+    sheet_id_or_name: Annotated[
+        str | None,
+        "The id or name of the sheet to get. "
+        "Defaults to None, which means sheet_position will be used instead.",
+    ] = None,
     start_row: Annotated[int, "Starting row number (1-indexed, defaults to 1)"] = 1,
     start_col: Annotated[
         str, "Starting column letter(s) or 1-based column number (defaults to 'A')"
@@ -46,9 +51,20 @@ async def get_spreadsheet(
     dict,
     "The spreadsheet properties and data for the specified sheet in the spreadsheet",
 ]:
-    """Gets the specified range of cells from a single sheet in the spreadsheet."""
-    start_row, start_col, max_rows, max_cols = process_get_spreadsheet_params(
-        start_row, start_col, max_rows, max_cols
+    """Gets the specified range of cells from a single sheet in the spreadsheet.
+
+    sheet_id_or_name takes precedence over sheet_position. If a sheet is not mentioned,
+    then always assume the default sheet_position is sufficient.
+    """
+    sheet_identifier, sheet_identifier_type, start_row, start_col, max_rows, max_cols = (
+        process_get_spreadsheet_params(
+            sheet_position,
+            sheet_id_or_name,
+            start_row,
+            start_col,
+            max_rows,
+            max_cols,
+        )
     )
 
     service = build_sheets_service(context.get_auth_token_or_empty())
@@ -57,11 +73,12 @@ async def get_spreadsheet(
         service,
         spreadsheet_id,
         sheet_identifier,
+        sheet_identifier_type,
         start_row,
         start_col,
         max_rows,
         max_cols,
     )
 
-    enforce_data_size_limit(data)
+    raise_for_large_payload(data)
     return data

--- a/toolkits/google_sheets/arcade_google_sheets/tools/read.py
+++ b/toolkits/google_sheets/arcade_google_sheets/tools/read.py
@@ -6,8 +6,8 @@ from arcade_tdk.auth import Google
 from arcade_google_sheets.decorators import with_filepicker_fallback
 from arcade_google_sheets.utils import (
     build_sheets_service,
-    get_spreadsheet_simple,
     get_spreadsheet_with_pagination,
+    process_get_spreadsheet_params,
 )
 
 
@@ -21,53 +21,35 @@ from arcade_google_sheets.utils import (
 async def get_spreadsheet(
     context: ToolContext,
     spreadsheet_id: Annotated[str, "The id of the spreadsheet to get"],
-    max_rows_per_request: Annotated[
-        int, "Maximum rows to fetch per request (defaults to 1000)"
-    ] = 1000,
-    max_cols_per_request: Annotated[int, "Maximum columns to fetch per request (default: 26)"] = 26,
     start_row: Annotated[int, "Starting row number (1-indexed, defaults to 1)"] = 1,
-    start_col: Annotated[str, "Starting column letter (defaults to 'A')"] = "A",
+    start_col: Annotated[
+        str, "Starting column letter(s) or 1-based column number (defaults to 'A')"
+    ] = "A",
     max_rows: Annotated[
-        int | None, "Maximum total rows to fetch (optional, default: None for all rows)"
-    ] = None,
+        int, "Maximum total rows to fetch. Must be between 1 and 1000. Defaults to 1000."
+    ] = 1000,
     max_cols: Annotated[
-        int | None, "Maximum total columns to fetch (optional, default: None for all columns)"
-    ] = None,
+        int, "Maximum total columns to fetch. Must be between 1 and 26. Defaults to 26."
+    ] = 26,
 ) -> Annotated[
     dict,
     "The spreadsheet properties and data for all sheets in the spreadsheet",
 ]:
     """
     Get the user entered values and formatted values for all cells in all sheets in the spreadsheet
-    along with the spreadsheet's properties. Supports pagination for large spreadsheets.
-
-    For large spreadsheets, use pagination parameters to control memory usage:
-    - max_rows_per_request: Chunk size for rows per API request
-    - max_cols_per_request: Chunk size for columns per API request
-    - start_row/start_col: Starting position
-    - max_rows/max_cols: Optional limits on total data to fetch
+    along with the spreadsheet's properties.
     """
-    service = build_sheets_service(context.get_auth_token_or_empty())
-
-    is_using_defaults = (
-        max_rows_per_request == 1000
-        and max_cols_per_request == 26
-        and start_row == 1
-        and start_col == "A"
-        and max_rows is None
-        and max_cols is None
+    start_row, start_col, max_rows, max_cols = process_get_spreadsheet_params(
+        start_row, start_col, max_rows, max_cols
     )
 
-    if is_using_defaults:
-        return get_spreadsheet_simple(service, spreadsheet_id)
-    else:
-        return get_spreadsheet_with_pagination(
-            service,
-            spreadsheet_id,
-            max_rows_per_request,
-            max_cols_per_request,
-            start_row,
-            start_col,
-            max_rows,
-            max_cols,
-        )
+    service = build_sheets_service(context.get_auth_token_or_empty())
+
+    return get_spreadsheet_with_pagination(
+        service,
+        spreadsheet_id,
+        start_row,
+        start_col,
+        max_rows,
+        max_cols,
+    )

--- a/toolkits/google_sheets/evals/eval_google_sheets.py
+++ b/toolkits/google_sheets/evals/eval_google_sheets.py
@@ -204,6 +204,34 @@ def get_spreadsheet_eval() -> EvalSuite:
     )
 
     suite.add_case(
+        name="Get a sheet range in a spreadsheet",
+        user_message="Get F3:BA900 from the spreadsheet id 1L2ovCUcRNOacoWxtLV3jgaidWZq4Bw_WXbIWJcxobN0",
+        expected_tool_calls=[
+            ExpectedToolCall(
+                func=get_spreadsheet,
+                args={
+                    "spreadsheet_id": "1L2ovCUcRNOacoWxtLV3jgaidWZq4Bw_WXbIWJcxobN0",
+                    "sheet_position": 1,
+                    "sheet_id_or_name": None,
+                    "start_row": 3,
+                    "start_col": "F",
+                    "max_rows": 897,  # 900 - 3 = 897
+                    "max_cols": 47,  # BA - F = 52 - 5 = 47
+                },
+            )
+        ],
+        critics=[
+            BinaryCritic(critic_field="spreadsheet_id", weight=1 / 7),
+            BinaryCritic(critic_field="sheet_position", weight=1 / 7),
+            BinaryCritic(critic_field="sheet_id_or_name", weight=1 / 7),
+            BinaryCritic(critic_field="start_row", weight=1 / 7),
+            BinaryCritic(critic_field="start_col", weight=1 / 7),
+            BinaryCritic(critic_field="max_rows", weight=1 / 7),
+            BinaryCritic(critic_field="max_cols", weight=1 / 7),
+        ],
+    )
+
+    suite.add_case(
         name="Get the next rows in a sheet given a previous conversation",
         user_message="Get the next 10 rows.",
         expected_tool_calls=[

--- a/toolkits/google_sheets/evals/eval_google_sheets.py
+++ b/toolkits/google_sheets/evals/eval_google_sheets.py
@@ -101,7 +101,7 @@ first_page_of_sheet_conversation = [
                 "type": "function",
                 "function": {
                     "name": "GoogleSheets_GetSpreadsheet",
-                    "arguments": '{"spreadsheet_id":"1eIvMFbodYgtrKe6xMHhvuIDoViM5JdA21hj91pZmBCs","sheet_identifier":"2","start_col":"A","max_cols":3,"start_row":1,"max_rows":5}',
+                    "arguments": '{"spreadsheet_id":"1eIvMFbodYgtrKe6xMHhvuIDoViM5JdA21hj91pZmBCs","sheet_position":"2","start_col":"A","max_cols":3,"start_row":1,"max_rows":5}',
                 },
             }
         ],
@@ -191,13 +191,15 @@ def get_spreadsheet_eval() -> EvalSuite:
                 func=get_spreadsheet,
                 args={
                     "spreadsheet_id": "1L2ovCUcRNOacoWxtLV3jgaidWZq4Bw_WXbIWJcxobN0",
-                    "sheet_identifier": "2",
+                    "sheet_position": 2,
+                    "sheet_id_or_name": None,
                 },
             )
         ],
         critics=[
-            BinaryCritic(critic_field="spreadsheet_id", weight=0.5),
-            BinaryCritic(critic_field="sheet_identifier", weight=0.5),
+            BinaryCritic(critic_field="spreadsheet_id", weight=1 / 3),
+            BinaryCritic(critic_field="sheet_position", weight=1 / 3),
+            BinaryCritic(critic_field="sheet_id_or_name", weight=1 / 3),
         ],
     )
 
@@ -209,7 +211,8 @@ def get_spreadsheet_eval() -> EvalSuite:
                 func=get_spreadsheet,
                 args={
                     "spreadsheet_id": "1eIvMFbodYgtrKe6xMHhvuIDoViM5JdA21hj91pZmBCs",
-                    "sheet_identifier": "2",
+                    "sheet_position": 2,
+                    "sheet_id_or_name": None,
                     "start_row": 6,
                     "max_rows": 10,
                     "start_col": "A",
@@ -218,12 +221,13 @@ def get_spreadsheet_eval() -> EvalSuite:
             )
         ],
         critics=[
-            BinaryCritic(critic_field="spreadsheet_id", weight=1 / 6),
-            BinaryCritic(critic_field="sheet_identifier", weight=1 / 6),
-            BinaryCritic(critic_field="start_row", weight=1 / 6),
-            BinaryCritic(critic_field="max_rows", weight=1 / 6),
-            BinaryCritic(critic_field="start_col", weight=1 / 6),
-            BinaryCritic(critic_field="max_cols", weight=1 / 6),
+            BinaryCritic(critic_field="spreadsheet_id", weight=1 / 7),
+            BinaryCritic(critic_field="sheet_position", weight=1 / 7),
+            BinaryCritic(critic_field="sheet_id_or_name", weight=1 / 7),
+            BinaryCritic(critic_field="start_row", weight=1 / 7),
+            BinaryCritic(critic_field="start_col", weight=1 / 7),
+            BinaryCritic(critic_field="max_rows", weight=1 / 7),
+            BinaryCritic(critic_field="max_cols", weight=1 / 7),
         ],
         additional_messages=first_page_of_sheet_conversation,
     )

--- a/toolkits/google_sheets/pyproject.toml
+++ b/toolkits/google_sheets/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "arcade_google_sheets"
-version = "2.0.0"
+version = "2.1.0"
 description = "Arcade.dev LLM tools for Google Sheets"
 requires-python = ">=3.10"
 dependencies = [

--- a/toolkits/google_sheets/pyproject.toml
+++ b/toolkits/google_sheets/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "arcade_google_sheets"
-version = "2.1.0"
+version = "3.0.0"
 description = "Arcade.dev LLM tools for Google Sheets"
 requires-python = ">=3.10"
 dependencies = [


### PR DESCRIPTION
A customer reported `tool execution failed: GoogleSheets.GetSpreadsheet@2.0.0: response body is too large to decode"` when calling the tool for very large spreadsheets. Large amounts of data in the tool response is not the desired paradigm for language model tools.

This PR adds **basic** pagination for the `get_spreadsheet` tool in the `GoogleSheets` toolkit. This update restricts the number of rows returned to up to 1000 and the number of columns to up to 100 for each sheet in the spreadsheet. `start_col` and `start_row` parameters have been added to support paginating through a large spreadsheet if one truly desires to do so. Also, `sheet_identifier` input parameter was added so that the tool only returns data for a single sheet. The sheet can be identified by its name, its ID, or its position within the spreadsheet (e.g., the 1st, 2nd, etc).

Perhaps a tool in the future can more intelligently select the range of columns & rows based on the structure of the spreadsheet. That is not this tool though.