### PR TITLE
Update examples

### DIFF
--- a/examples/ai-sdk/README.md
+++ b/examples/ai-sdk/README.md
@@ -52,7 +52,7 @@ pnpm install
 
 ## Basic Usage
 
-This example demonstrates how to use Arcade's Google toolkit to create an AI agent that can read and summarize emails. The agent will access your Gmail account (after authorization) and process your most recent email.
+This example demonstrates how to use Arcade's Gmail toolkit to create an AI agent that can read and summarize emails. The agent will access your Gmail account (after authorization) and process your most recent email.
 
 To get started, run the development server:
 
@@ -79,7 +79,7 @@ To modify or extend the functionality:
 
 1. Update the `USER_ID` constant in `index.js` with your application's user identification
 2. Modify the `toolkit` parameter in `getArcadeTools` to access different tools. Available toolkits include:
-   - `"google"` - Gmail, Google Calendar, Google Drive
+   - `"gmail"` - Gmail
    - `"slack"` - Slack messaging and channels
    - `"github"` - GitHub repositories and issues
    - And more in [Arcade Integrations](https://docs.arcade.dev/toolkits) documentation

--- a/examples/ai-sdk/generateText.js
+++ b/examples/ai-sdk/generateText.js
@@ -6,11 +6,11 @@ import { generateText } from "ai"
 const arcade = new Arcade()
 
 /**
- * Get the Google toolkit.
+ * Get the Gmail toolkit.
  */
-const googleToolkit = await arcade.tools.list({
+const gmailToolkit = await arcade.tools.list({
     limit: 25,
-    toolkit: "google",
+    toolkit: "gmail",
 })
 
 /**
@@ -30,8 +30,8 @@ const googleToolkit = await arcade.tools.list({
  *
  * Learn more: https://docs.arcade.dev/home/use-tools/get-tool-definitions#get-zod-tool-definitions
  */
-const googleTools = toZodToolSet({
-    tools: googleToolkit.items,
+const gmailTools = toZodToolSet({
+    tools: gmailToolkit.items,
     client: arcade,
     userId: "<YOUR_USER_ID>", // Your app's internal ID for the user (an email, UUID, etc). It's used internally to identify your user in Arcade
     executeFactory: executeOrAuthorizeZodTool, // Checks if tool is authorized and executes it, or returns authorization URL if needed
@@ -40,7 +40,7 @@ const googleTools = toZodToolSet({
 const result = await generateText({
     model: openai("gpt-4o-mini"),
     prompt: "Read my last email and summarize it in a few sentences",
-    tools: googleTools,
+    tools: gmailTools,
     maxSteps: 5,
 })
 

--- a/examples/ai-sdk/index.js
+++ b/examples/ai-sdk/index.js
@@ -6,11 +6,11 @@ import { streamText } from "ai"
 const arcade = new Arcade()
 
 /**
- * Get the Google toolkit.
+ * Get the Gmail toolkit.
  */
-const googleToolkit = await arcade.tools.list({
+const gmailToolkit = await arcade.tools.list({
     limit: 25,
-    toolkit: "google",
+    toolkit: "gmail",
 })
 
 /**
@@ -30,8 +30,8 @@ const googleToolkit = await arcade.tools.list({
  *
  * Learn more: https://docs.arcade.dev/home/use-tools/get-tool-definitions#get-zod-tool-definitions
  */
-const googleTools = toZodToolSet({
-    tools: googleToolkit.items,
+const gmailTools = toZodToolSet({
+    tools: gmailToolkit.items,
     client: arcade,
     userId: "<YOUR_USER_ID>", // Your app's internal ID for the user (an email, UUID, etc). It's used internally to identify your user in Arcade
     executeFactory: executeOrAuthorizeZodTool,
@@ -40,7 +40,7 @@ const googleTools = toZodToolSet({
 const { textStream } = streamText({
     model: openai("gpt-4o-mini"),
     prompt: "Read my last email and summarize it in a few sentences",
-    tools: googleTools,
+    tools: gmailTools,
     maxSteps: 5,
 })
 

--- a/examples/call_a_tool_directly_with_auth.py
+++ b/examples/call_a_tool_directly_with_auth.py
@@ -17,7 +17,7 @@ def call_auth_tool(client: Arcade, user_id: str) -> None:
     """
     # Start the authorization process
     auth_response = client.tools.authorize(
-        tool_name="Google.ListEmails",
+        tool_name="Gmail.ListEmails",
         user_id=user_id,
     )
 
@@ -33,7 +33,7 @@ def call_auth_tool(client: Arcade, user_id: str) -> None:
 
     # Execute the tool
     response = client.tools.execute(
-        tool_name="Google.ListEmails",
+        tool_name="Gmail.ListEmails",
         input=tool_input,
         user_id=user_id,
     )

--- a/examples/crewai/crewai_with_arcade_tool.py
+++ b/examples/crewai/crewai_with_arcade_tool.py
@@ -101,7 +101,7 @@ def main() -> CrewOutput:
     manager = ArcadeToolManager(
         executor=custom_tool_executor,
     )
-    tools = manager.get_tools(tools=["Google.ListEmails"])
+    tools = manager.get_tools(tools=["Gmail.ListEmails"])
 
     crew_agent = Agent(
         role="Main Agent",

--- a/examples/crewai/simple_crewai_with_arcade_tool.py
+++ b/examples/crewai/simple_crewai_with_arcade_tool.py
@@ -14,7 +14,7 @@ from crewai.llm import LLM
 from crewai_arcade import ArcadeToolManager
 
 manager = ArcadeToolManager(default_user_id="user@example.com")
-tools = manager.get_tools(tools=["Google.ListEmails"])
+tools = manager.get_tools(tools=["Gmail.ListEmails"])
 
 crew_agent = Agent(
     role="Main Agent",

--- a/examples/langchain-ts/langgraph-arcade-minimal.ts
+++ b/examples/langchain-ts/langgraph-arcade-minimal.ts
@@ -8,10 +8,10 @@ import { ChatOpenAI } from "@langchain/openai";
 // 1) Initialize Arcade
 const arcade = new Arcade();
 
-// 2) Fetch Google toolkit from Arcade and prepare tools for LangGraph integration
-const googleToolkit = await arcade.tools.list({ toolkit: "google", limit: 30 });
+// 2) Fetch Gmail toolkit from Arcade and prepare tools for LangGraph integration
+const gmailToolkit = await arcade.tools.list({ toolkit: "gmail", limit: 30 });
 const arcadeTools = toZod({
-	tools: googleToolkit.items,
+	tools: gmailToolkit.items,
 	client: arcade,
 	userId: "<YOUR_SYSTEM_USER_ID>", // Replace this with your application's user ID (e.g. email address, UUID, etc.)
 	executeFactory: executeOrAuthorizeZodTool,

--- a/examples/langchain/langgraph_arcade_minimal.py
+++ b/examples/langchain/langgraph_arcade_minimal.py
@@ -13,7 +13,7 @@ openai_api_key = os.environ.get("OPENAI_API_KEY", "YOUR_OPENAI_API_KEY")
 manager = ToolManager(api_key=arcade_api_key)
 
 # Tool names follow the format "ToolkitName.ToolName"
-tools = manager.init_tools(tools=["Web.ScrapeUrl"])
+tools = manager.init_tools(tools=["Firecrawl.ScrapeUrl"])
 print(manager.tools)
 
 # Get all tools from a toolkit
@@ -21,11 +21,11 @@ tools = manager.init_tools(toolkits=["github"])
 print(manager.tools)
 
 # add a tool
-manager.add_tool("Search.SearchGoogle")
+manager.add_tool("GoogleSearch.Search")
 print(manager.tools)
 
 # add a toolkit
-manager.add_toolkit("Search")
+manager.add_toolkit("GoogleSearch")
 print(manager.tools)
 
 # 3) Get StructuredTool objects for langchain

--- a/examples/langgraph-ts/README.md
+++ b/examples/langgraph-ts/README.md
@@ -51,7 +51,7 @@ This approach creates a flexible agent that can interact with multiple services 
 
 The core logic is defined in `src/graph.ts`
 
-1. Loads Arcade tools for multiple toolkits (e.g., Google)
+1. Loads Arcade tools for multiple toolkits (e.g., Gmail)
 2. Creates a model with the tools bound to it
 3. Routes messages between tool calls and model reasoning
 4. Compiles everything into a graph you can invoke and deploy
@@ -66,20 +66,20 @@ The core logic is defined in `src/graph.ts`
 
 To use different Arcade toolkits or queries:
 
-1. Modify the `toolkit` string in `arcade.tools.list` in `src/graph.ts` to include the desired toolkit (e.g., `["google", "github", "notion"]`)
+1. Modify the `toolkit` string in `arcade.tools.list` in `src/graph.ts` to include the desired toolkit (e.g., `["gmail", "github", "notion"]`)
 2. Change the default model in `src/configuration.ts`
 3. Update the system prompt in `src/prompts.ts`
 
 Currently supported Arcade toolkits:
 
 - GitHub
-- Google
+- Gmail
 - Notion
 - Reddit
 - X
-- And more
+- And many more
 
-You can check out our [Integrations](https://docs.arcade.dev/integrations) documentation for more information on how to integrate with other tools.
+You can check out our [Integrations](https://docs.arcade.dev/toolkits) documentation for more information on how to integrate with other tools.
 
 You can also create your own custom tools and integrate them with LangGraph. Check out our [Custom Tools](https://docs.arcade.dev/home/custom-tools) documentation for more information.
 

--- a/examples/langgraph-ts/src/graph.ts
+++ b/examples/langgraph-ts/src/graph.ts
@@ -13,8 +13,8 @@ const arcade = new Arcade();
 
 // Replace this with your application's user ID (e.g. email address, UUID, etc.)
 const USER_ID = "user@example.com";
-// Get the Arcade tools, you can customize the toolkit (e.g. "github", "notion", "google", etc.)
-const googleToolkit = await arcade.tools.list({ toolkit: "google", limit: 30 });
+// Get the Arcade tools, you can customize the toolkit (e.g. "github", "notion", "gmail", etc.)
+const gmailToolkit = await arcade.tools.list({ toolkit: "gmail", limit: 30 });
 
 /**
  * LangGraph requires tools to be defined using Zod, a TypeScript-first schema validation library
@@ -34,7 +34,7 @@ const googleToolkit = await arcade.tools.list({ toolkit: "google", limit: 30 });
  * Learn more: https://docs.arcade.dev/home/use-tools/get-tool-definitions#get-zod-tool-definitions
  */
 const arcadeTools = toZod({
-	tools: googleToolkit.items,
+	tools: gmailToolkit.items,
 	client: arcade,
 	userId: USER_ID,
 	executeFactory: executeOrAuthorizeZodTool, // Checks if tool is authorized and executes it, or returns authorization URL if needed

--- a/examples/mastra/README.md
+++ b/examples/mastra/README.md
@@ -49,7 +49,7 @@ pnpm install
 
 ## Basic Usage
 
-This example demonstrates how to use Arcade's Google toolkit with Mastra to create an AI agent that can help users manage their Google services (Gmail, Calendar, Sheets, Drive, and Contacts). The agent will access your Google account (after authorization) and perform various tasks based on user requests.
+This example demonstrates how to use Arcade's Gmail toolkit with Mastra to create an AI agent that can help users manage their email. The agent will access your Google account (after authorization) and perform various tasks based on user requests.
 
 To get started:
 
@@ -80,9 +80,9 @@ This authorization process is handled by the `executeOrAuthorizeZodTool` helper 
 
 To modify or extend the functionality:
 
-1. Update the `userId` in `agents/google.ts` with your application's user identification
+1. Update the `userId` in `agents/gmail.ts` with your application's user identification
 2. Modify the `toolkit` parameter in `arcade.tools.list()` to access different tools. Available toolkits include:
-   - `"google"` - Gmail, Google Calendar, Google Drive
+   - `"gmail"` - Gmail
    - `"slack"` - Slack messaging and channels
    - `"github"` - GitHub repositories and issues
    - And more in [Arcade Integrations](https://docs.arcade.dev/toolkits) documentation

--- a/examples/mastra/src/mastra/agents/gmail.ts
+++ b/examples/mastra/src/mastra/agents/gmail.ts
@@ -11,8 +11,8 @@ import { LibSQLStore } from "@mastra/libsql";
 // Initialize Arcade
 const arcade = new Arcade();
 
-// Get Google tools
-const googleToolkit = await arcade.tools.list({ toolkit: "google", limit: 30 });
+// Get Gmail tools
+const gmailToolkit = await arcade.tools.list({ toolkit: "gmail", limit: 30 });
 
 /**
  * Mastra requires tools to be defined using Zod, a TypeScript-first schema validation library
@@ -31,8 +31,8 @@ const googleToolkit = await arcade.tools.list({ toolkit: "google", limit: 30 });
  *
  * Learn more: https://docs.arcade.dev/home/use-tools/get-tool-definitions#get-zod-tool-definitions
  */
-export const googleTools = toZodToolSet({
-	tools: googleToolkit.items,
+export const gmailTools = toZodToolSet({
+	tools: gmailToolkit.items,
 	client: arcade,
 	userId: "<YOUR_USER_ID>", // Your app's internal ID for the user (an email, UUID, etc). It's used internally to identify your user in Arcade
 	executeFactory: executeOrAuthorizeZodTool, // Checks if tool is authorized and executes it, or returns authorization URL if needed
@@ -45,10 +45,10 @@ const memory = new Memory({
   }),
 });
 
-// Create an agent with Google tools
-export const googleAgent = new Agent({
-	name: "googleAgent",
-	instructions: `You are a Google assistant that helps users manage their Google services (Gmail, Calendar, Sheets, Drive, and Contacts).
+// Create an agent with Gmail tools
+export const gmailAgent = new Agent({
+	name: "gmailAgent",
+	instructions: `You are a Gmail assistant that helps users manage their Gmail services.
 
 When helping users:
 - Always verify their intent before performing actions
@@ -57,8 +57,8 @@ When helping users:
 - Respect user privacy and data security
 - Specify which Google service you're working with
 
-Use the googleTools to interact with various Google services and perform related tasks.`,
+Use the gmailTools to interact with various Gmail services and perform related tasks.`,
 	model: openai("gpt-4o-mini"),
 	memory,
-	tools: googleTools,
+	tools: gmailTools,
 });

--- a/examples/mastra/src/mastra/index.ts
+++ b/examples/mastra/src/mastra/index.ts
@@ -1,9 +1,9 @@
 import { Mastra } from "@mastra/core";
 import { LibSQLStore } from "@mastra/libsql";
-import { googleAgent } from "./agents/google";
+import { gmailAgent } from "./agents/gmail";
 
 export const mastra = new Mastra({
-	agents: { googleAgent },
+	agents: { gmailAgent },
 	storage: new LibSQLStore({
 		url: "file:../mastra.db",
 	}),

--- a/examples/mcp/run_stdio.py
+++ b/examples/mcp/run_stdio.py
@@ -1,11 +1,11 @@
-import arcade_google  # pip install arcade_google
+import arcade_gmail  # pip install arcade_gmail
 import arcade_search  # pip install arcade_search
 from arcade_core.catalog import ToolCatalog
 from arcade_serve.mcp.stdio import StdioServer
 
 # 2. Create and populate the tool catalog
 catalog = ToolCatalog()
-catalog.add_module(arcade_google)  # Registers all tools in the package
+catalog.add_module(arcade_gmail)  # Registers all tools in the package
 catalog.add_module(arcade_search)
 
 

--- a/examples/openai-agents-ts/README.md
+++ b/examples/openai-agents-ts/README.md
@@ -21,11 +21,11 @@
 
 # OpenAI Agents + Arcade AI
 
-This TypeScript project demonstrates how to integrate [Arcade AI](https://docs.arcade.dev) with [OpenAI Agents](https://openai.github.io/openai-agents-js/) to create powerful AI agents that can interact with external services. Arcade provides access to a wide range of tools including Gmail, Slack, LinkedIn, and more through its Google toolkit and other integrations.
+This TypeScript project demonstrates how to integrate [Arcade AI](https://docs.arcade.dev) with [OpenAI Agents](https://openai.github.io/openai-agents-js/) to create powerful AI agents that can interact with external services. Arcade provides access to a wide range of tools including Gmail, Slack, LinkedIn, and more through its Gmail toolkit and other integrations.
 
 The project showcases two approaches:
 
-- **Basic integration** (`src/index.ts`): Simple one-time execution with Google toolkit
+- **Basic integration** (`src/index.ts`): Simple one-time execution with Gmail toolkit
 - **Authorization handling** (`src/waitForCompletion.ts`): Manual authorization flow management
 
 For a list of all hosted tools and auth providers, see the [Arcade Integrations](https://docs.arcade.dev/toolkits) documentation.
@@ -60,7 +60,7 @@ npm install
 
 ## Basic Usage
 
-This example creates an AI agent that can read and process your Gmail emails using Arcade's Google toolkit.
+This example creates an AI agent that can read and process your Gmail emails using Arcade's Gmail toolkit.
 
 ### Simple Execution
 
@@ -73,9 +73,9 @@ npm run dev
 This script will:
 
 1. Initialize the Arcade client
-2. Fetch available Google toolkit tools (up to 30)
+2. Fetch available Gmail toolkit tools (up to 30)
 3. Convert them to OpenAI Agents compatible format
-4. Create an agent that can assist with Google API calls
+4. Create an agent that can assist with Gmail API calls
 5. Ask "What are my latest emails?" and display the result
 
 ### Authorization Flow Example
@@ -116,7 +116,7 @@ openai-ts/
 
 You can modify the `toolkit` parameter to access different integrations:
 
-- `"google"` - Gmail, Google Calendar, Google Drive, Google Docs
+- `"gmail"` - Gmail
 - `"slack"` - Slack messaging and channels
 - `"github"` - GitHub repositories and issues
 - `"linkedin"` - LinkedIn posts and connections

--- a/examples/openai-agents-ts/src/index.ts
+++ b/examples/openai-agents-ts/src/index.ts
@@ -5,25 +5,25 @@ import { Agent, run, tool } from '@openai/agents';
 // 1) Initialize Arcade client
 const client = new Arcade();
 
-// 2) Fetch Google toolkit from Arcade and prepare tools for OpenAI Agents
-const googleToolkit = await client.tools.list({ toolkit: "google", limit: 30 });
+// 2) Fetch Gmail toolkit from Arcade and prepare tools for OpenAI Agents
+const gmailToolkit = await client.tools.list({ toolkit: "gmail", limit: 30 });
 const tools = toZod({
-  tools: googleToolkit.items,
+  tools: gmailToolkit.items,
   client,
   userId: "<YOUR_SYSTEM_USER_ID>", // Replace this with your application's user ID (e.g. email address, UUID, etc.)
   executeFactory: executeOrAuthorizeZodTool,
 }).map(tool);
 
-// 3) Create a new agent with the Google toolkit
-const googleAgent = new Agent({
-  name: "Google agent",
-  instructions: "You are a helpful assistant that can assist with Google API calls.",
+// 3) Create a new agent with the Gmail toolkit
+const gmailAgent = new Agent({
+  name: "Gmail agent",
+  instructions: "You are a helpful assistant that can assist with Gmail API calls.",
   model: "gpt-4o-mini",
   tools
 });
 
 // 4) Run the agent
-const result = await run(googleAgent, "What are my latest emails?");
+const result = await run(gmailAgent, "What are my latest emails?");
 
 // 5) Print the result
 console.log(result.finalOutput);

--- a/examples/openai-agents-ts/src/waitForCompletion.ts
+++ b/examples/openai-agents-ts/src/waitForCompletion.ts
@@ -6,18 +6,18 @@ async function main() {
   // 1) Initialize Arcade client
   const client = new Arcade();
 
-  // 2) Fetch Google toolkit from Arcade and prepare tools for OpenAI Agents
-  const googleToolkit = await client.tools.list({ toolkit: "google", limit: 30 });
+  // 2) Fetch Gmail toolkit from Arcade and prepare tools for OpenAI Agents
+  const gmailToolkit = await client.tools.list({ toolkit: "gmail", limit: 30 });
   const tools = toZod({
-    tools: googleToolkit.items,
+    tools: gmailToolkit.items,
     client,
     userId: "<YOUR_SYSTEM_USER_ID_2>", // Replace this with your application's user ID (e.g. email address, UUID, etc.)
   }).map(tool);
 
-  // 3) Create a new agent with the Google toolkit
-  const googleAgent = new Agent({
-    name: "Google agent",
-    instructions: "You are a helpful assistant that can assist with Google API calls.",
+  // 3) Create a new agent with the Gmail toolkit
+  const gmailAgent = new Agent({
+    name: "Gmail agent",
+    instructions: "You are a helpful assistant that can assist with Gmail API calls.",
     model: "gpt-4o-mini",
     tools
   });
@@ -25,13 +25,13 @@ async function main() {
   // 4) Run the agent, if authorization is required, wait for it to complete and retry
   while (true) {
     try {
-      const result = await run(googleAgent, "What are my latest emails?");
+      const result = await run(gmailAgent, "What are my latest emails?");
       console.log(result.finalOutput);
       break; // Exit the loop if the result is successful
     } catch (error) {
       if (error instanceof Error && isAuthorizationRequiredError(error)) {
         const response = await client.tools.authorize({
-          tool_name: "Google_ListEmails",
+          tool_name: "Gmail_ListEmails",
           user_id: "<YOUR_SYSTEM_USER_ID_2>",
         });
         if (response.status !== "completed") {

--- a/examples/serving-tools/docker/README.md
+++ b/examples/serving-tools/docker/README.md
@@ -23,8 +23,8 @@ docker run -p 8002:8002 custom-worker:0.1.0
 To change the toolkits, edit the `toolkits.txt` file.
 
 ```
-arcade-google==0.1.0
-arcade-web==0.1.0
+arcade-gmail==0.1.0
+arcade-firecrawl==0.1.0
 arcade-zoom==0.1.2
 ...
 ```

--- a/examples/serving-tools/docker/toolkits.txt
+++ b/examples/serving-tools/docker/toolkits.txt
@@ -1,1 +1,1 @@
-arcade-google
+arcade-gmail

--- a/examples/serving-tools/modal/run-arcade-worker.py
+++ b/examples/serving-tools/modal/run-arcade-worker.py
@@ -5,7 +5,7 @@ from modal import App, Image, asgi_app
 # Define the FastAPI app
 app = App("arcade-worker")
 
-toolkits = ["arcade_google", "arcade_slack"]
+toolkits = ["arcade_gmail", "arcade_slack"]
 
 image = (
     Image.debian_slim().pip_install("arcade_tdk").pip_install("arcade_serve").pip_install(toolkits)


### PR DESCRIPTION
Update code examples to not use the deprecated Google toolkit (use Gmail instead) and Web toolkit (use Firecrawl instead)