### PR TITLE
Improve Typedict and Basemodel support

### DIFF
--- a/libs/arcade-core/arcade_core/catalog.py
+++ b/libs/arcade-core/arcade_core/catalog.py
@@ -797,7 +797,7 @@ def extract_properties(type_to_check: type) -> dict[str, WireTypeInfo] | None:
 
             # Get wire type info recursively
             # field_type cannot be None here due to the check above
-            wire_info = get_wire_type_info(field_type)  # type: ignore[arg-type]
+            wire_info = get_wire_type_info(field_type)
             properties[field_name] = wire_info
 
     # Handle TypedDict
@@ -810,10 +810,10 @@ def extract_properties(type_to_check: type) -> dict[str, WireTypeInfo] | None:
 
         for field_name, field_type in type_hints.items():
             # Handle Optional types (Union[T, None])
-            if is_strict_optional(field_type):  # type: ignore[arg-type]
+            if is_strict_optional(field_type):
                 # Extract the non-None type from Optional
                 field_type = next(arg for arg in get_args(field_type) if arg is not type(None))
-            wire_info = get_wire_type_info(field_type)  # type: ignore[arg-type]
+            wire_info = get_wire_type_info(field_type)
 
             # Add description if available
             if field_name in field_descriptions:

--- a/libs/arcade-core/arcade_core/catalog.py
+++ b/libs/arcade-core/arcade_core/catalog.py
@@ -483,7 +483,11 @@ def create_output_definition(func: Callable) -> ToolOutput:
         )
 
     if hasattr(return_type, "__metadata__"):
-        description = return_type.__metadata__[0] if return_type.__metadata__ else None  # type: ignore[assignment]
+        description = (
+            return_type.__metadata__[0]
+            if return_type.__metadata__
+            else "No description provided for return type."
+        )
         return_type = return_type.__origin__
 
     # Unwrap Optional types
@@ -792,7 +796,8 @@ def extract_properties(type_to_check: type) -> dict[str, WireTypeInfo] | None:
                 field_type = next(arg for arg in get_args(field_type) if arg is not type(None))
 
             # Get wire type info recursively
-            wire_info = get_wire_type_info(field_type)
+            # field_type cannot be None here due to the check above
+            wire_info = get_wire_type_info(field_type)  # type: ignore[arg-type]
             properties[field_name] = wire_info
 
     # Handle TypedDict
@@ -805,10 +810,10 @@ def extract_properties(type_to_check: type) -> dict[str, WireTypeInfo] | None:
 
         for field_name, field_type in type_hints.items():
             # Handle Optional types (Union[T, None])
-            if is_strict_optional(field_type):
+            if is_strict_optional(field_type):  # type: ignore[arg-type]
                 # Extract the non-None type from Optional
                 field_type = next(arg for arg in get_args(field_type) if arg is not type(None))
-            wire_info = get_wire_type_info(field_type)
+            wire_info = get_wire_type_info(field_type)  # type: ignore[arg-type]
 
             # Add description if available
             if field_name in field_descriptions:
@@ -973,7 +978,9 @@ def create_func_models(func: Callable) -> tuple[type[BaseModel], type[BaseModel]
         tool_field_info = extract_field_info(param)
         param_fields = {
             "default": tool_field_info.default,
-            "description": tool_field_info.description,
+            "description": tool_field_info.description
+            if tool_field_info.description
+            else "No description provided.",
             # TODO more here?
         }
         input_fields[name] = (tool_field_info.field_type, Field(**param_fields))
@@ -991,8 +998,14 @@ def determine_output_model(func: Callable) -> type[BaseModel]:  # noqa: C901
     """
     return_annotation = inspect.signature(func).return_annotation
     output_model_name = f"{snake_to_pascal_case(func.__name__)}Output"
+
+    # If the return annotation is empty, create a model with no fields
     if return_annotation is inspect.Signature.empty:
         return create_model(output_model_name)
+
+    # If the return annotation has an __origin__ attribute
+    # and does not have a __metadata__ attribute.
+    # This is the case for TypedDicts.
     elif hasattr(return_annotation, "__origin__"):
         if hasattr(return_annotation, "__metadata__"):
             field_type = return_annotation.__args__[0]
@@ -1008,15 +1021,24 @@ def determine_output_model(func: Callable) -> type[BaseModel]:  # noqa: C901
                 )
                 return create_model(
                     output_model_name,
-                    result=(typeddict_model, Field(description=str(description))),
+                    result=(
+                        typeddict_model,
+                        Field(
+                            description=str(description)
+                            if description
+                            else "No description provided."
+                        ),
+                    ),
                 )
 
+            # If the return annotation has a description, use it
             if description:
                 return create_model(
                     output_model_name,
                     result=(field_type, Field(description=str(description))),
                 )
-        # Handle Union types
+
+        # If the return annotation is a Union type
         origin = return_annotation.__origin__
         if origin is typing.Union:
             # For union types, create a model with the first non-None argument
@@ -1037,10 +1059,15 @@ def determine_output_model(func: Callable) -> type[BaseModel]:  # noqa: C901
                         )
                     return create_model(
                         output_model_name,
-                        result=(arg, Field(description="No description provided.")),
+                        result=(
+                            arg,
+                            Field(description="No description provided."),
+                        ),
                     )
-        # when the return_annotation has an __origin__ attribute
+
+        # If the return annotation has an __origin__ attribute
         # and does not have a __metadata__ attribute.
+        # This is the case for TypedDicts.
         return create_model(
             output_model_name,
             result=(
@@ -1049,7 +1076,7 @@ def determine_output_model(func: Callable) -> type[BaseModel]:  # noqa: C901
             ),
         )
     else:
-        # Check if return type is TypedDict
+        # If the return annotation is a TypedDict
         if is_typeddict(return_annotation):
             typeddict_model = create_model_from_typeddict(return_annotation, output_model_name)
             return create_model(
@@ -1060,10 +1087,13 @@ def determine_output_model(func: Callable) -> type[BaseModel]:  # noqa: C901
                 ),
             )
 
-        # Handle simple return types (like str)
+        # If the return annotation is a simple type (like str)
         return create_model(
             output_model_name,
-            result=(return_annotation, Field(description="No description provided.")),
+            result=(
+                return_annotation,
+                Field(description="No description provided."),
+            ),
         )
 
 

--- a/libs/arcade-core/arcade_core/schema.py
+++ b/libs/arcade-core/arcade_core/schema.py
@@ -418,7 +418,7 @@ class ToolCallRequiresAuthorization(BaseModel):
 class ToolCallOutput(BaseModel):
     """The output of a tool invocation."""
 
-    value: str | int | float | bool | dict | list[str] | None = None
+    value: str | int | float | bool | dict | list | None = None
     """The value returned by the tool."""
     logs: list[ToolCallLog] | None = None
     """The logs that occurred during the tool invocation."""

--- a/libs/arcade-core/pyproject.toml
+++ b/libs/arcade-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "arcade-core"
-version = "2.2.1"
+version = "2.3.0"
 description = "Arcade Core - Core library for Arcade platform"
 readme = "README.md"
 license = {text = "MIT"}

--- a/libs/tests/core/test_schema_validation.py
+++ b/libs/tests/core/test_schema_validation.py
@@ -1,0 +1,196 @@
+"""
+Tests for ToolCallOutput schema validation with complex types.
+"""
+
+import pytest
+from arcade_core.schema import ToolCallError, ToolCallLog, ToolCallOutput
+from pydantic import ValidationError
+
+
+class TestToolCallOutputValidation:
+    """Test ToolCallOutput validation with various data types."""
+
+    def test_basic_types(self):
+        """Test that basic types are validated correctly."""
+        # String
+        output = ToolCallOutput(value="test string")
+        assert output.value == "test string"
+
+        # Integer
+        output = ToolCallOutput(value=42)
+        assert output.value == 42
+
+        # Float
+        output = ToolCallOutput(value=3.14)
+        assert output.value == 3.14
+
+        # Boolean
+        output = ToolCallOutput(value=True)
+        assert output.value is True
+
+        # None
+        output = ToolCallOutput(value=None)
+        assert output.value is None
+
+    def test_dict_types(self):
+        """Test that dict types are validated correctly."""
+        # Simple dict
+        output = ToolCallOutput(value={"key": "value"})
+        assert output.value == {"key": "value"}
+
+        # Nested dict
+        output = ToolCallOutput(value={"outer": {"inner": "value"}})
+        assert output.value == {"outer": {"inner": "value"}}
+
+        # Empty dict
+        output = ToolCallOutput(value={})
+        assert output.value == {}
+
+        # Dict with mixed types
+        output = ToolCallOutput(
+            value={
+                "string": "text",
+                "number": 123,
+                "float": 45.6,
+                "bool": True,
+                "null": None,
+                "list": [1, 2, 3],
+                "dict": {"nested": "value"},
+            }
+        )
+        assert output.value["string"] == "text"
+        assert output.value["number"] == 123
+        assert output.value["list"] == [1, 2, 3]
+
+    def test_list_types(self):
+        """Test that list types are validated correctly."""
+        # List of strings (original type)
+        output = ToolCallOutput(value=["a", "b", "c"])
+        assert output.value == ["a", "b", "c"]
+
+        # List of integers
+        output = ToolCallOutput(value=[1, 2, 3])
+        assert output.value == [1, 2, 3]
+
+        # List of dicts (TypedDict at runtime)
+        output = ToolCallOutput(value=[{"id": 1, "name": "first"}, {"id": 2, "name": "second"}])
+        assert output.value == [{"id": 1, "name": "first"}, {"id": 2, "name": "second"}]
+
+        # Mixed type list
+        output = ToolCallOutput(value=[1, "two", 3.0, True, None, {"key": "value"}])
+        assert len(output.value) == 6
+        assert output.value[5] == {"key": "value"}
+
+        # Empty list
+        output = ToolCallOutput(value=[])
+        assert output.value == []
+
+        # Nested lists
+        output = ToolCallOutput(value=[[1, 2], [3, 4], [5, 6]])
+        assert output.value == [[1, 2], [3, 4], [5, 6]]
+
+    def test_complex_nested_structures(self):
+        """Test complex nested structures that might come from TypedDict."""
+        # Simulate a complex API response structure
+        complex_data = {
+            "status": "success",
+            "data": {
+                "users": [
+                    {
+                        "id": 1,
+                        "name": "Alice",
+                        "roles": ["admin", "user"],
+                        "metadata": {"last_login": "2024-01-01", "active": True},
+                    },
+                    {
+                        "id": 2,
+                        "name": "Bob",
+                        "roles": ["user"],
+                        "metadata": {"last_login": "2024-01-02", "active": False},
+                    },
+                ],
+                "total": 2,
+                "page_info": {"page": 1, "per_page": 10, "has_next": False},
+            },
+            "errors": [],
+        }
+
+        output = ToolCallOutput(value=complex_data)
+        assert output.value == complex_data
+        assert output.value["data"]["users"][0]["name"] == "Alice"
+        assert output.value["data"]["page_info"]["has_next"] is False
+
+    def test_error_and_logs_with_value(self):
+        """Test that error and logs can coexist with different value types."""
+        # With dict value and logs
+        output = ToolCallOutput(
+            value={"result": "success"},
+            logs=[
+                ToolCallLog(message="Processing started", level="info"),
+                ToolCallLog(message="Deprecation warning", level="warning", subtype="deprecation"),
+            ],
+        )
+        assert output.value == {"result": "success"}
+        assert len(output.logs) == 2
+
+        # With list value and error
+        output = ToolCallOutput(
+            error=ToolCallError(
+                message="Partial failure",
+                developer_message="Some items failed to process",
+                can_retry=True,
+            )
+        )
+        assert output.error.message == "Partial failure"
+        assert output.value is None
+
+    def test_unsupported_types_still_fail(self):
+        """Test that truly unsupported types still fail validation."""
+
+        # Custom object (not dict, list, or basic type)
+        class CustomClass:
+            def __init__(self):
+                self.data = "test"
+
+        # This should fail because CustomClass instance is not a supported type
+        # Note: This test is about Pydantic validation, not the output factory
+        # The output factory would catch this earlier
+        with pytest.raises(ValidationError):
+            # Directly creating with an unsupported type should fail
+            ToolCallOutput(value=CustomClass())
+
+    def test_very_large_structures(self):
+        """Test that large structures are handled properly."""
+        # Large list of dicts
+        large_list = [{"id": i, "value": f"item_{i}"} for i in range(1000)]
+        output = ToolCallOutput(value=large_list)
+        assert len(output.value) == 1000
+        assert output.value[500]["id"] == 500
+
+        # Deeply nested structure
+        deep_dict = {"level1": {"level2": {"level3": {"level4": {"level5": "deep_value"}}}}}
+        output = ToolCallOutput(value=deep_dict)
+        assert output.value["level1"]["level2"]["level3"]["level4"]["level5"] == "deep_value"
+
+    def test_json_serializable(self):
+        """Test that all supported types are JSON serializable."""
+        import json
+
+        test_cases = [
+            {"type": "string"},
+            ["list", "of", "strings"],
+            [{"id": 1}, {"id": 2}],
+            {"nested": {"data": [1, 2, 3]}},
+            123,
+            45.6,
+            True,
+            None,
+        ]
+
+        for test_value in test_cases:
+            output = ToolCallOutput(value=test_value)
+            # This should not raise an exception
+            json_str = json.dumps(output.model_dump())
+            # And we should be able to parse it back
+            parsed = json.loads(json_str)
+            assert parsed["value"] == test_value

--- a/libs/tests/core/test_typeddict_output_execution.py
+++ b/libs/tests/core/test_typeddict_output_execution.py
@@ -97,6 +97,7 @@ class TestTypeDictOutputExecution:
     def context(self):
         return ToolContext()
 
+    @pytest.mark.asyncio
     async def test_returns_typeddict(self, catalog, context):
         """Test executing a tool that returns a TypedDict."""
         # Create tool definition
@@ -120,6 +121,7 @@ class TestTypeDictOutputExecution:
         assert result.error is None
         assert result.value == {"name": "test", "value": 42}
 
+    @pytest.mark.asyncio
     async def test_returns_list_of_typeddict(self, catalog, context):
         """Test executing a tool that returns a list of TypedDict."""
         definition = catalog.create_tool_definition(
@@ -143,6 +145,7 @@ class TestTypeDictOutputExecution:
             {"name": "item3", "value": 3},
         ]
 
+    @pytest.mark.asyncio
     async def test_returns_optional_typeddict(self, catalog, context):
         """Test executing a tool that returns an optional TypedDict."""
         definition = catalog.create_tool_definition(
@@ -177,6 +180,7 @@ class TestTypeDictOutputExecution:
         assert result_none.error is None
         assert result_none.value == ""  # None is converted to empty string
 
+    @pytest.mark.asyncio
     async def test_returns_nested_typeddict(self, catalog, context):
         """Test executing a tool that returns a nested TypedDict."""
         definition = catalog.create_tool_definition(
@@ -200,6 +204,7 @@ class TestTypeDictOutputExecution:
             "tags": ["tag1", "tag2", "tag3"],
         }
 
+    @pytest.mark.asyncio
     async def test_accepts_and_returns_typeddict(self, catalog, context):
         """Test executing a tool that accepts and returns TypedDict."""
         definition = catalog.create_tool_definition(
@@ -220,6 +225,7 @@ class TestTypeDictOutputExecution:
         assert result.error is None
         assert result.value == {"name": "Modified: input", "value": 42}
 
+    @pytest.mark.asyncio
     async def test_returns_dict_list(self, catalog, context):
         """Test executing a tool that returns a list of dicts."""
         definition = catalog.create_tool_definition(

--- a/libs/tests/core/test_typeddict_output_execution.py
+++ b/libs/tests/core/test_typeddict_output_execution.py
@@ -1,0 +1,244 @@
+"""
+End-to-end tests for TypedDict output execution through the entire tool pipeline.
+"""
+
+from typing import Annotated, Optional
+
+import pytest
+from arcade_core.catalog import ToolCatalog, create_func_models
+from arcade_core.executor import ToolExecutor
+from arcade_core.schema import ToolContext
+from arcade_tdk import tool
+from typing_extensions import TypedDict
+
+
+# Define various TypedDict structures for testing
+class SimpleDict(TypedDict):
+    """A simple typed dictionary."""
+
+    name: str
+    value: int
+
+
+class NestedDict(TypedDict):
+    """A nested typed dictionary."""
+
+    id: int
+    info: SimpleDict
+    tags: list[str]
+
+
+class OptionalFieldsDict(TypedDict, total=False):
+    """TypedDict with optional fields."""
+
+    required_field: str
+    optional_field: int
+
+
+# Define test tools
+@tool
+def returns_typeddict() -> Annotated[SimpleDict, "Returns a simple TypedDict"]:
+    """Tool that returns a TypedDict."""
+    return SimpleDict(name="test", value=42)
+
+
+@tool
+def returns_list_of_typeddict() -> Annotated[list[SimpleDict], "Returns list of TypedDict"]:
+    """Tool that returns a list of TypedDict."""
+    return [
+        SimpleDict(name="item1", value=1),
+        SimpleDict(name="item2", value=2),
+        SimpleDict(name="item3", value=3),
+    ]
+
+
+@tool
+def returns_optional_typeddict(
+    return_none: Annotated[bool, "Whether to return None"] = False,
+) -> Annotated[Optional[SimpleDict], "Returns optional TypedDict"]:
+    """Tool that returns an optional TypedDict."""
+    if return_none:
+        return None
+    return SimpleDict(name="optional", value=100)
+
+
+@tool
+def returns_nested_typeddict() -> Annotated[NestedDict, "Returns nested TypedDict"]:
+    """Tool that returns a nested TypedDict."""
+    return NestedDict(id=1, info=SimpleDict(name="nested", value=99), tags=["tag1", "tag2", "tag3"])
+
+
+@tool
+def accepts_and_returns_typeddict(
+    data: Annotated[SimpleDict, "Input TypedDict"],
+) -> Annotated[SimpleDict, "Modified TypedDict"]:
+    """Tool that accepts and returns a TypedDict."""
+    return SimpleDict(name=f"Modified: {data['name']}", value=data["value"] * 2)
+
+
+@tool
+def returns_dict_list() -> Annotated[list[dict], "Returns list of dicts"]:
+    """Tool that returns a list of dictionaries including TypedDicts."""
+    return [
+        {"type": "plain", "value": 42},
+        {"name": "string", "data": "test"},
+        SimpleDict(name="typed", value=99),
+    ]
+
+
+class TestTypeDictOutputExecution:
+    """Test TypedDict outputs through the full execution pipeline."""
+
+    @pytest.fixture
+    def catalog(self):
+        return ToolCatalog()
+
+    @pytest.fixture
+    def context(self):
+        return ToolContext()
+
+    async def test_returns_typeddict(self, catalog, context):
+        """Test executing a tool that returns a TypedDict."""
+        # Create tool definition
+        definition = catalog.create_tool_definition(
+            returns_typeddict, toolkit_name="test", toolkit_version="1.0.0"
+        )
+
+        # Create models
+        input_model, output_model = create_func_models(returns_typeddict)
+
+        # Execute tool
+        result = await ToolExecutor.run(
+            func=returns_typeddict,
+            definition=definition,
+            input_model=input_model,
+            output_model=output_model,
+            context=context,
+        )
+
+        # Verify result
+        assert result.error is None
+        assert result.value == {"name": "test", "value": 42}
+
+    async def test_returns_list_of_typeddict(self, catalog, context):
+        """Test executing a tool that returns a list of TypedDict."""
+        definition = catalog.create_tool_definition(
+            returns_list_of_typeddict, toolkit_name="test", toolkit_version="1.0.0"
+        )
+
+        input_model, output_model = create_func_models(returns_list_of_typeddict)
+
+        result = await ToolExecutor.run(
+            func=returns_list_of_typeddict,
+            definition=definition,
+            input_model=input_model,
+            output_model=output_model,
+            context=context,
+        )
+
+        assert result.error is None
+        assert result.value == [
+            {"name": "item1", "value": 1},
+            {"name": "item2", "value": 2},
+            {"name": "item3", "value": 3},
+        ]
+
+    async def test_returns_optional_typeddict(self, catalog, context):
+        """Test executing a tool that returns an optional TypedDict."""
+        definition = catalog.create_tool_definition(
+            returns_optional_typeddict, toolkit_name="test", toolkit_version="1.0.0"
+        )
+
+        input_model, output_model = create_func_models(returns_optional_typeddict)
+
+        # Test returning a value
+        result = await ToolExecutor.run(
+            func=returns_optional_typeddict,
+            definition=definition,
+            input_model=input_model,
+            output_model=output_model,
+            context=context,
+            return_none=False,
+        )
+
+        assert result.error is None
+        assert result.value == {"name": "optional", "value": 100}
+
+        # Test returning None
+        result_none = await ToolExecutor.run(
+            func=returns_optional_typeddict,
+            definition=definition,
+            input_model=input_model,
+            output_model=output_model,
+            context=context,
+            return_none=True,
+        )
+
+        assert result_none.error is None
+        assert result_none.value == ""  # None is converted to empty string
+
+    async def test_returns_nested_typeddict(self, catalog, context):
+        """Test executing a tool that returns a nested TypedDict."""
+        definition = catalog.create_tool_definition(
+            returns_nested_typeddict, toolkit_name="test", toolkit_version="1.0.0"
+        )
+
+        input_model, output_model = create_func_models(returns_nested_typeddict)
+
+        result = await ToolExecutor.run(
+            func=returns_nested_typeddict,
+            definition=definition,
+            input_model=input_model,
+            output_model=output_model,
+            context=context,
+        )
+
+        assert result.error is None
+        assert result.value == {
+            "id": 1,
+            "info": {"name": "nested", "value": 99},
+            "tags": ["tag1", "tag2", "tag3"],
+        }
+
+    async def test_accepts_and_returns_typeddict(self, catalog, context):
+        """Test executing a tool that accepts and returns TypedDict."""
+        definition = catalog.create_tool_definition(
+            accepts_and_returns_typeddict, toolkit_name="test", toolkit_version="1.0.0"
+        )
+
+        input_model, output_model = create_func_models(accepts_and_returns_typeddict)
+
+        result = await ToolExecutor.run(
+            func=accepts_and_returns_typeddict,
+            definition=definition,
+            input_model=input_model,
+            output_model=output_model,
+            context=context,
+            data={"name": "input", "value": 21},
+        )
+
+        assert result.error is None
+        assert result.value == {"name": "Modified: input", "value": 42}
+
+    async def test_returns_dict_list(self, catalog, context):
+        """Test executing a tool that returns a list of dicts."""
+        definition = catalog.create_tool_definition(
+            returns_dict_list, toolkit_name="test", toolkit_version="1.0.0"
+        )
+
+        input_model, output_model = create_func_models(returns_dict_list)
+
+        result = await ToolExecutor.run(
+            func=returns_dict_list,
+            definition=definition,
+            input_model=input_model,
+            output_model=output_model,
+            context=context,
+        )
+
+        assert result.error is None
+        assert result.value == [
+            {"type": "plain", "value": 42},
+            {"name": "string", "data": "test"},
+            {"name": "typed", "value": 99},  # TypedDict becomes regular dict at runtime
+        ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "arcade-ai"
-version = "2.1.3"
+version = "2.1.4"
 description = "Arcade.dev - Tool Calling platform for Agents"
 readme = "README.md"
 license = {file = "LICENSE"}


### PR DESCRIPTION
Improve Pydantic and Typedict support and add a bunch of tets.

  1. Fixed the test failure where TypeDict was being serialized as a list of tuples instead of a dict by:
    - Adding proper handling for BaseModel instances in the output.py file
    - Converting BaseModel results (from TypeDict conversion) to dicts using model_dump()
    - Handling lists containing BaseModel objects
  2. Fixed None handling to ensure None results are converted to empty strings as expected
  3. Updated the schema.py to allow dict and list types in ToolCallOutput.value
  4. new tests
    - TypeDict output execution tests
    - Output factory tests
    - Executor tests with TypeDict support
    - Schema validation tests

  The key changes were:
  - In ``arcade_core/output.py``: Added BaseModel conversion logic in the success method
  - In ``arcade_core/schema.py``: Changed ToolCallOutput.value type from list[str] to list to support complex types


TODO
- [ ] Confirm engine compatibility without changes made to engine