### PR TITLE
A couple of fixes for the docs generator

### DIFF
--- a/libs/arcade-cli/arcade_cli/toolkit_docs/docs_builder.py
+++ b/libs/arcade-cli/arcade_cli/toolkit_docs/docs_builder.py
@@ -123,8 +123,12 @@ def build_reference_mdx(
     enum_mdx_template: str = ENUM_MDX,
 ) -> str:
     enum_items = ""
+    enum_names_seen = set()
 
     for enum_name, enum_class in referenced_enums:
+        if enum_name in enum_names_seen:
+            continue
+        enum_names_seen.add(enum_name)
         enum_items += enum_item_template.format(
             enum_name=enum_name,
             enum_values=build_enum_values(
@@ -247,6 +251,9 @@ def build_tool_spec(
         enums=enums,
         tool_parameter_template=tool_parameter_template,
     )
+
+    if not parameters:
+        parameters = "This tool does not take any parameters."
 
     secrets = (
         build_tool_secrets(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "arcade-ai"
-version = "2.1.1"
+version = "2.1.2"
 description = "Arcade.dev - Tool Calling platform for Agents"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "arcade-ai"
-version = "2.1.2"
+version = "2.2.0"
 description = "Arcade.dev - Tool Calling platform for Agents"
 readme = "README.md"
 license = {file = "LICENSE"}


### PR DESCRIPTION
Display "This tool does not take any parameters." when the tool interface has no arguments other than context.

Prevent the same Enum from being referenced multiple times in the reference.mdx file.