### PR TITLE
arcade docs: add support for GPT-5 series; improve error handling

### DIFF
--- a/libs/arcade-cli/arcade_cli/main.py
+++ b/libs/arcade-cli/arcade_cli/main.py
@@ -820,13 +820,12 @@ def docs(
         ),
     ),
     openai_model: str = typer.Option(
-        "gpt-4o-mini",
+        "gpt-5-mini",
         "--openai-model",
         "-m",
         help=(
             "A few parts of the documentation are generated using OpenAI API. "
-            "This argument controls which OpenAI model to use. "
-            "E.g. 'gpt-4o', 'gpt-4o-mini'."
+            "Choose one of the 'gpt-4o' and 'gpt-5' series models."
         ),
         show_default=True,
     ),
@@ -845,6 +844,14 @@ def docs(
     ),
     debug: bool = typer.Option(False, "--debug", "-d", help="Show debug information"),
 ) -> None:
+    if not openai_model.startswith("gpt-4o") and not openai_model.startswith("gpt-5"):
+        console.print(
+            f"Attention: '{openai_model}' is not a valid OpenAI model. "
+            "Please choose one of the 'gpt-4o' and 'gpt-5' series models.",
+            style="bold red",
+        )
+        raise typer.Exit()
+
     try:
         success = generate_toolkit_docs(
             console=console,

--- a/libs/arcade-cli/arcade_cli/toolkit_docs/__init__.py
+++ b/libs/arcade-cli/arcade_cli/toolkit_docs/__init__.py
@@ -6,7 +6,6 @@ from rich.console import Console
 from arcade_cli.toolkit_docs.docs_builder import (
     build_example_path,
     build_examples,
-    build_reference_mdx_path,
     build_toolkit_mdx,
     build_toolkit_mdx_path,
 )
@@ -58,8 +57,7 @@ def generate_toolkit_docs(
     enums = get_all_enumerations(toolkit_dir)
 
     print_debug(f"Building /{toolkit_name.lower()}.mdx file")
-    reference_mdx, toolkit_mdx = build_toolkit_mdx(
-        toolkit_dir=toolkit_dir,
+    toolkit_mdx = build_toolkit_mdx(
         tools=tools,
         docs_section=docs_section,
         enums=enums,
@@ -68,13 +66,6 @@ def generate_toolkit_docs(
     )
     toolkit_mdx_path = build_toolkit_mdx_path(docs_section, docs_dir, toolkit_name)
     write_file(toolkit_mdx_path, toolkit_mdx)
-
-    if reference_mdx:
-        print_debug(f"Building /{toolkit_name.lower()}/reference.mdx file")
-        reference_mdx_path = build_reference_mdx_path(docs_section, docs_dir, toolkit_name)
-        write_file(reference_mdx_path, reference_mdx)
-    else:
-        print_debug("No Enums referenced by tool interfaces. Skipping reference.mdx file")
 
     if tool_call_examples:
         print_debug("Building tool-call examples in Python and JavaScript")

--- a/libs/arcade-cli/arcade_cli/toolkit_docs/templates.py
+++ b/libs/arcade-cli/arcade_cli/toolkit_docs/templates.py
@@ -3,7 +3,7 @@ TOOLKIT_PAGE = """{header}
 {table_of_contents}
 
 {tools_specs}
-
+{reference_mdx}
 {footer}
 """
 
@@ -143,9 +143,9 @@ response = client.tools.execute(
 print(json.dumps(response.output.value, indent=2))
 """
 
-ENUM_MDX = """# {toolkit_name} Reference
+ENUM_MDX = """## Reference
 
-Below is a reference of enumerations used by some tools in the {toolkit_name} toolkit:
+Below is a reference of enumerations used by some of the tools in the {toolkit_name} toolkit:
 
 {enum_items}
 """


### PR DESCRIPTION
Adds support for GPT-5 series of models in `arcade docs`.

Improves error handling when the LLM does not generate a valid JSON for a given tool sample inputs. Instead of raising an exception, the CLI uses an empty input, moves on to the next tool, and prints a warning message asking the user the fill in the input sample manually in Javascript and Python files.

This PR also moves the Enumerations from a separate `reference.mdx` file to the main toolkit file, as requested by @EricGustin to simplify the docs structure.