### PR TITLE
Abstract HTTP Client class to share across toolkits

### DIFF
--- a/libs/arcade-tdk/arcade_tdk/__init__.py
+++ b/libs/arcade-tdk/arcade_tdk/__init__.py
@@ -8,9 +8,11 @@ from arcade_core.schema import (
 )
 from arcade_core.toolkit import Toolkit
 
+from arcade_tdk.model import BaseHttpClient
 from arcade_tdk.tool import tool
 
 __all__ = [
+    "BaseHttpClient",
     "ToolAuthorizationContext",
     "ToolCatalog",
     "ToolContext",

--- a/libs/arcade-tdk/arcade_tdk/model.py
+++ b/libs/arcade-tdk/arcade_tdk/model.py
@@ -1,0 +1,155 @@
+import asyncio
+import json
+import logging
+from abc import ABC, abstractmethod
+from datetime import datetime, timezone
+from typing import cast
+
+import httpx
+
+from arcade_tdk import ToolContext
+from arcade_tdk.errors import RetryableToolError, ToolExecutionError, ToolRuntimeError
+
+logger = logging.getLogger(__name__)
+
+
+class BaseHttpClient(ABC):
+    def __init__(
+        self,
+        context: ToolContext,
+        max_concurrent_requests: int = 3,
+    ) -> None:
+        self.context: ToolContext = context
+
+        # max_concurrent_requests value set by the context takes precedence
+        secret_key = f"{self.service_name}_max_concurrent_requests"
+
+        try:
+            secret_value = context.get_secret(secret_key)
+        except ValueError:
+            pass
+        else:
+            try:
+                max_concurrent_requests = int(secret_value)
+            except ValueError:
+                raise ValueError(
+                    f"Invalid value set for the secret '{secret_key}'. "
+                    f"Expected a numeric string, got '{secret_value}'."
+                )
+
+        if max_concurrent_requests < 1:
+            raise ValueError(
+                "Invalid value set for 'max_concurrent_requests'. "
+                f"Expected a positive integer, got '{max_concurrent_requests}'."
+            )
+
+        self.max_concurrent_requests = max_concurrent_requests
+        self._semaphore = asyncio.Semaphore(self.max_concurrent_requests)
+
+    @property
+    @abstractmethod
+    def service_name(self) -> str:
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def default_api_version(self) -> str:
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def default_headers(self) -> dict[str, str]:
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def base_url(self) -> str:
+        raise NotImplementedError
+
+    @property
+    def auth_token(self) -> str | None:
+        return self.context.get_auth_token_or_empty()
+
+    @abstractmethod
+    def _build_url(self, path: str) -> str:
+        raise NotImplementedError
+
+    async def request(
+        self,
+        method: str,
+        path: str,
+        headers: dict[str, str] | None = None,
+        **kwargs,
+    ) -> dict:
+        headers = {**self.default_headers, **(headers or {})}
+        url = self._build_url(path=path)
+        async with self._semaphore, httpx.AsyncClient() as client:
+            response = await client.request(method, url, headers=headers, **kwargs)
+            self._raise_for_status(response)
+            return self._format_response_dict(response)
+
+    async def get(self, path: str, headers: dict[str, str] | None = None, **kwargs) -> dict:
+        return await self.request("GET", path, headers=headers, **kwargs)
+
+    async def post(self, path: str, headers: dict[str, str] | None = None, **kwargs) -> dict:
+        return await self.request("POST", path, headers=headers, **kwargs)
+
+    async def put(self, path: str, headers: dict[str, str] | None = None, **kwargs) -> dict:
+        return await self.request("PUT", path, headers=headers, **kwargs)
+
+    async def delete(self, path: str, headers: dict[str, str] | None = None, **kwargs) -> dict:
+        return await self.request("DELETE", path, headers=headers, **kwargs)
+
+    def _format_response_dict(self, response: httpx.Response) -> dict:
+        try:
+            return cast(dict, response.json())
+        except (UnicodeDecodeError, json.decoder.JSONDecodeError):
+            return {"response": response.text}
+
+    def _raise_for_status(self, response: httpx.Response) -> None:
+        try:
+            if response.status_code < 300:
+                return
+
+            if response.status_code == 404:
+                message = f"Not found error: {response.text}"
+            elif response.status_code == 429:
+                message = "Too many requests, the service is busy. Please try again later."
+            elif response.status_code < 500:
+                message = f"Bad request error: {response.text}"
+            else:
+                message = f"Server error: {response.text}"
+
+            developer_message = (
+                f"Request to '{response.request.url}' failed "
+                f"with status code {response.status_code}: {response.text}. "
+                f"Response headers: {response.headers}. "
+            )
+
+            retry_after = self._retry_after_header_to_milliseconds(
+                response.headers.get("Retry-After")
+            )
+            if retry_after:
+                raise RetryableToolError(message, developer_message, retry_after_ms=retry_after)  # noqa: TRY301
+
+            raise ToolExecutionError(message, developer_message)  # noqa: TRY301
+        except ToolRuntimeError:
+            raise
+        except Exception:
+            logger.exception()
+            message = f"There was an error: {response.text}"
+            raise ToolExecutionError(message, developer_message)
+
+    def _retry_after_header_to_milliseconds(self, header: str | None) -> int | None:
+        if not header:
+            return None
+
+        if header.isdigit():
+            return int(header)
+        else:
+            try:
+                datetime_obj = datetime.strptime(header, "%a, %d %b %Y %H:%M:%S GMT")
+                datetime_obj = datetime_obj.replace(tzinfo=timezone.utc)
+                return int(datetime_obj.timestamp() * 1000)
+            except ValueError:
+                return None

--- a/libs/arcade-tdk/pyproject.toml
+++ b/libs/arcade-tdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "arcade-tdk"
-version = "2.2.0"
+version = "2.3.0"
 description = "Arcade TDK - Toolkit Development Kit for building Arcade tools"
 readme = "README.md"
 license = {text = "MIT"}

--- a/libs/tests/tdk/test_http_client.py
+++ b/libs/tests/tdk/test_http_client.py
@@ -1,0 +1,516 @@
+import asyncio
+import json
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+from arcade_core.schema import ToolSecretItem
+from arcade_tdk import BaseHttpClient, ToolContext
+from arcade_tdk.errors import RetryableToolError, ToolExecutionError
+
+
+class DummyHttpClient(BaseHttpClient):
+    """A dummy HTTP client implementation for testing purposes."""
+
+    @property
+    def service_name(self) -> str:
+        return "dummy"
+
+    @property
+    def default_api_version(self) -> str:
+        return "v1"
+
+    @property
+    def default_headers(self) -> dict[str, str]:
+        return {
+            "Content-Type": "application/json",
+            "User-Agent": "DummyClient/1.0",
+        }
+
+    @property
+    def base_url(self) -> str:
+        return "https://api.dummy.com"
+
+    def _build_url(self, path: str) -> str:
+        return f"{self.base_url}/{self.default_api_version}{path}"
+
+
+@pytest.fixture
+def basic_context():
+    """Create a basic ToolContext without secrets."""
+    return ToolContext()
+
+
+@pytest.fixture
+def context_with_max_requests():
+    """Create a ToolContext with max concurrent requests secret."""
+    return ToolContext(secrets=[ToolSecretItem(key="dummy_max_concurrent_requests", value="5")])
+
+
+@pytest.fixture
+def context_with_invalid_max_requests():
+    """Create a ToolContext with invalid max concurrent requests secret."""
+    return ToolContext(
+        secrets=[ToolSecretItem(key="dummy_max_concurrent_requests", value="invalid")]
+    )
+
+
+class TestDummyHttpClientInitialization:
+    """Test the initialization of DummyHttpClient."""
+
+    def test_basic_initialization(self, basic_context):
+        client = DummyHttpClient(basic_context)
+
+        assert client.context == basic_context
+        assert client.max_concurrent_requests == 3  # default value
+        assert client._semaphore._value == 3
+
+    def test_initialization_with_custom_max_requests(self, basic_context):
+        client = DummyHttpClient(basic_context, max_concurrent_requests=10)
+
+        assert client.max_concurrent_requests == 10
+        assert client._semaphore._value == 10
+
+    def test_initialization_with_context_max_requests(self, context_with_max_requests):
+        client = DummyHttpClient(context_with_max_requests, max_concurrent_requests=3)
+
+        # Context value should take precedence
+        assert client.max_concurrent_requests == 5
+        assert client._semaphore._value == 5
+
+    def test_initialization_with_invalid_context_max_requests(
+        self, context_with_invalid_max_requests
+    ):
+        with pytest.raises(
+            ValueError, match="Invalid value set for the secret 'dummy_max_concurrent_requests'"
+        ):
+            DummyHttpClient(context_with_invalid_max_requests)
+
+    def test_initialization_with_negative_max_requests(self, basic_context):
+        with pytest.raises(ValueError, match="Invalid value set for 'max_concurrent_requests'"):
+            DummyHttpClient(basic_context, max_concurrent_requests=-1)
+
+    def test_initialization_with_zero_max_requests(self, basic_context):
+        with pytest.raises(ValueError, match="Invalid value set for 'max_concurrent_requests'"):
+            DummyHttpClient(basic_context, max_concurrent_requests=0)
+
+
+class TestDummyHttpClientProperties:
+    """Test the properties of DummyHttpClient."""
+
+    def test_service_name(self, basic_context):
+        client = DummyHttpClient(basic_context)
+        assert client.service_name == "dummy"
+
+    def test_default_api_version(self, basic_context):
+        client = DummyHttpClient(basic_context)
+        assert client.default_api_version == "v1"
+
+    def test_default_headers(self, basic_context):
+        client = DummyHttpClient(basic_context)
+        expected_headers = {
+            "Content-Type": "application/json",
+            "User-Agent": "DummyClient/1.0",
+        }
+        assert client.default_headers == expected_headers
+
+    def test_base_url(self, basic_context):
+        client = DummyHttpClient(basic_context)
+        assert client.base_url == "https://api.dummy.com"
+
+    def test_build_url(self, basic_context):
+        client = DummyHttpClient(basic_context)
+        url = client._build_url("/test")
+        assert url == "https://api.dummy.com/v1/test"
+
+    def test_auth_token_empty(self, basic_context):
+        client = DummyHttpClient(basic_context)
+        assert client.auth_token == ""
+
+
+class TestHttpClientRequests:
+    """Test HTTP request handling."""
+
+    @pytest.mark.asyncio
+    async def test_successful_json_response(self, basic_context):
+        client = DummyHttpClient(basic_context)
+        mock_response_data = {"status": "success", "data": {"id": 123}}
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client_class.return_value.__aenter__.return_value = mock_client
+
+            mock_response = Mock()
+            mock_response.status_code = 200
+            mock_response.json.return_value = mock_response_data
+            mock_client.request.return_value = mock_response
+
+            result = await client.get("/test")
+
+            assert result == mock_response_data
+            mock_client.request.assert_called_once_with(
+                "GET",
+                "https://api.dummy.com/v1/test",
+                headers={
+                    "Content-Type": "application/json",
+                    "User-Agent": "DummyClient/1.0",
+                },
+            )
+
+    @pytest.mark.asyncio
+    async def test_successful_non_json_response(self, basic_context):
+        client = DummyHttpClient(basic_context)
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client_class.return_value.__aenter__.return_value = mock_client
+
+            mock_response = Mock()
+            mock_response.status_code = 200
+            mock_response.text = "plain text response"
+            mock_response.json.side_effect = json.JSONDecodeError("msg", "doc", 0)
+            mock_client.request.return_value = mock_response
+
+            result = await client.get("/test")
+
+            assert result == {"response": "plain text response"}
+
+    @pytest.mark.asyncio
+    async def test_404_error(self, basic_context):
+        client = DummyHttpClient(basic_context)
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client_class.return_value.__aenter__.return_value = mock_client
+
+            mock_response = Mock()
+            mock_response.status_code = 404
+            mock_response.text = "Not found"
+            mock_response.request.url = "https://api.dummy.com/v1/test"
+            mock_response.headers = {}
+            mock_client.request.return_value = mock_response
+
+            with pytest.raises(ToolExecutionError) as exc_info:
+                await client.get("/test")
+
+            assert "Not found error: Not found" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_400_error(self, basic_context):
+        client = DummyHttpClient(basic_context)
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client_class.return_value.__aenter__.return_value = mock_client
+
+            mock_response = Mock()
+            mock_response.status_code = 400
+            mock_response.text = "Bad request"
+            mock_response.request.url = "https://api.dummy.com/v1/test"
+            mock_response.headers = {}
+            mock_client.request.return_value = mock_response
+
+            with pytest.raises(ToolExecutionError) as exc_info:
+                await client.get("/test")
+
+            assert "Bad request error: Bad request" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_429_error_without_retry_after(self, basic_context):
+        client = DummyHttpClient(basic_context)
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client_class.return_value.__aenter__.return_value = mock_client
+
+            mock_response = Mock()
+            mock_response.status_code = 429
+            mock_response.text = "Rate limited"
+            mock_response.request.url = "https://api.dummy.com/v1/test"
+            mock_response.headers = {}
+            mock_client.request.return_value = mock_response
+
+            with pytest.raises(ToolExecutionError) as exc_info:
+                await client.get("/test")
+
+            assert "Too many requests, the service is busy. Please try again later." in str(
+                exc_info.value
+            )
+
+    @pytest.mark.asyncio
+    async def test_429_error_with_retry_after_seconds(self, basic_context):
+        client = DummyHttpClient(basic_context)
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client_class.return_value.__aenter__.return_value = mock_client
+
+            mock_response = Mock()
+            mock_response.status_code = 429
+            mock_response.text = "Rate limited"
+            mock_response.request.url = "https://api.dummy.com/v1/test"
+            mock_response.headers = {"Retry-After": "60"}
+            mock_client.request.return_value = mock_response
+
+            with pytest.raises(RetryableToolError) as exc_info:
+                await client.get("/test")
+
+            assert "Too many requests, the service is busy. Please try again later." in str(
+                exc_info.value
+            )
+            assert exc_info.value.retry_after_ms == 60
+
+    @pytest.mark.asyncio
+    async def test_500_error(self, basic_context):
+        client = DummyHttpClient(basic_context)
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client_class.return_value.__aenter__.return_value = mock_client
+
+            mock_response = Mock()
+            mock_response.status_code = 500
+            mock_response.text = "Internal server error"
+            mock_response.request.url = "https://api.dummy.com/v1/test"
+            mock_response.headers = {}
+            mock_client.request.return_value = mock_response
+
+            with pytest.raises(ToolExecutionError) as exc_info:
+                await client.get("/test")
+
+            assert "Server error: Internal server error" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_503_error_with_retry_after_http_date(self, basic_context):
+        client = DummyHttpClient(basic_context)
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client_class.return_value.__aenter__.return_value = mock_client
+
+            mock_response = Mock()
+            mock_response.status_code = 503
+            mock_response.text = "Service unavailable"
+            mock_response.request.url = "https://api.dummy.com/v1/test"
+            mock_response.headers = {"Retry-After": "Wed, 21 Oct 2015 07:28:00 GMT"}
+            mock_client.request.return_value = mock_response
+
+            with pytest.raises(RetryableToolError) as exc_info:
+                await client.get("/test")
+
+            assert "Server error: Service unavailable" in str(exc_info.value)
+            # The retry_after should be a timestamp in milliseconds
+            assert exc_info.value.retry_after_ms == 1445412480000
+
+    @pytest.mark.asyncio
+    async def test_503_error_without_retry_after(self, basic_context):
+        client = DummyHttpClient(basic_context)
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client_class.return_value.__aenter__.return_value = mock_client
+
+            mock_response = Mock()
+            mock_response.status_code = 503
+            mock_response.text = "Service unavailable"
+            mock_response.request.url = "https://api.dummy.com/v1/test"
+            mock_response.headers = {}
+            mock_client.request.return_value = mock_response
+
+            with pytest.raises(ToolExecutionError) as exc_info:
+                await client.get("/test")
+
+            assert "Server error: Service unavailable" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_post_request(self, basic_context):
+        client = DummyHttpClient(basic_context)
+        mock_response_data = {"created": True}
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client_class.return_value.__aenter__.return_value = mock_client
+
+            mock_response = Mock()
+            mock_response.status_code = 201
+            mock_response.json.return_value = mock_response_data
+            mock_client.request.return_value = mock_response
+
+            result = await client.post("/create", json={"name": "test"})
+
+            assert result == mock_response_data
+            mock_client.request.assert_called_once_with(
+                "POST",
+                "https://api.dummy.com/v1/create",
+                headers={
+                    "Content-Type": "application/json",
+                    "User-Agent": "DummyClient/1.0",
+                },
+                json={"name": "test"},
+            )
+
+    @pytest.mark.asyncio
+    async def test_put_request(self, basic_context):
+        client = DummyHttpClient(basic_context)
+        mock_response_data = {"updated": True}
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client_class.return_value.__aenter__.return_value = mock_client
+
+            mock_response = Mock()
+            mock_response.status_code = 200
+            mock_response.json.return_value = mock_response_data
+            mock_client.request.return_value = mock_response
+
+            result = await client.put("/update/123", json={"name": "updated"})
+
+            assert result == mock_response_data
+            mock_client.request.assert_called_once_with(
+                "PUT",
+                "https://api.dummy.com/v1/update/123",
+                headers={
+                    "Content-Type": "application/json",
+                    "User-Agent": "DummyClient/1.0",
+                },
+                json={"name": "updated"},
+            )
+
+    @pytest.mark.asyncio
+    async def test_delete_request(self, basic_context):
+        client = DummyHttpClient(basic_context)
+        mock_response_data = {"deleted": True}
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client_class.return_value.__aenter__.return_value = mock_client
+
+            mock_response = Mock()
+            mock_response.status_code = 200
+            mock_response.json.return_value = mock_response_data
+            mock_client.request.return_value = mock_response
+
+            result = await client.delete("/delete/123")
+
+            assert result == mock_response_data
+            mock_client.request.assert_called_once_with(
+                "DELETE",
+                "https://api.dummy.com/v1/delete/123",
+                headers={
+                    "Content-Type": "application/json",
+                    "User-Agent": "DummyClient/1.0",
+                },
+            )
+
+    @pytest.mark.asyncio
+    async def test_custom_headers_merge(self, basic_context):
+        client = DummyHttpClient(basic_context)
+        mock_response_data = {"success": True}
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client_class.return_value.__aenter__.return_value = mock_client
+
+            mock_response = Mock()
+            mock_response.status_code = 200
+            mock_response.json.return_value = mock_response_data
+            mock_client.request.return_value = mock_response
+
+            custom_headers = {"Authorization": "Bearer token", "X-Custom": "value"}
+            result = await client.get("/test", headers=custom_headers)
+
+            expected_headers = {
+                "Content-Type": "application/json",
+                "User-Agent": "DummyClient/1.0",
+                "Authorization": "Bearer token",
+                "X-Custom": "value",
+            }
+
+            assert result == mock_response_data
+            mock_client.request.assert_called_once_with(
+                "GET", "https://api.dummy.com/v1/test", headers=expected_headers
+            )
+
+
+class TestRetryAfterHeaderParsing:
+    """Test parsing of Retry-After headers."""
+
+    def test_retry_after_seconds(self, basic_context):
+        client = DummyHttpClient(basic_context)
+        result = client._retry_after_header_to_milliseconds("120")
+        assert result == 120
+
+    def test_retry_after_zero_seconds(self, basic_context):
+        client = DummyHttpClient(basic_context)
+        result = client._retry_after_header_to_milliseconds("0")
+        assert result == 0
+
+    def test_retry_after_http_date(self, basic_context):
+        client = DummyHttpClient(basic_context)
+        # Wed, 21 Oct 2015 07:28:00 GMT
+        result = client._retry_after_header_to_milliseconds("Wed, 21 Oct 2015 07:28:00 GMT")
+        assert result == 1445412480000  # timestamp in milliseconds
+
+    def test_retry_after_invalid_format(self, basic_context):
+        client = DummyHttpClient(basic_context)
+        result = client._retry_after_header_to_milliseconds("invalid")
+        assert result is None
+
+    def test_retry_after_none(self, basic_context):
+        client = DummyHttpClient(basic_context)
+        result = client._retry_after_header_to_milliseconds(None)
+        assert result is None
+
+    def test_retry_after_empty_string(self, basic_context):
+        client = DummyHttpClient(basic_context)
+        result = client._retry_after_header_to_milliseconds("")
+        assert result is None
+
+
+class TestConcurrencyControl:
+    """Test concurrent request limiting."""
+
+    @pytest.mark.asyncio
+    async def test_concurrent_request_limit(self, basic_context):
+        client = DummyHttpClient(basic_context, max_concurrent_requests=2)
+
+        # Track when requests start and finish
+        request_log = []
+
+        async def mock_request(*_args, **_kwargs):
+            request_log.append("start")
+            await asyncio.sleep(0.1)  # Simulate network delay
+            request_log.append("end")
+
+            mock_response = Mock()
+            mock_response.status_code = 200
+            mock_response.json.return_value = {"success": True}
+            return mock_response
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client_class.return_value.__aenter__.return_value = mock_client
+            mock_client.request.side_effect = mock_request
+
+            # Start 3 concurrent requests
+            tasks = [
+                asyncio.create_task(client.get("/test1")),
+                asyncio.create_task(client.get("/test2")),
+                asyncio.create_task(client.get("/test3")),
+            ]
+
+            await asyncio.gather(*tasks)
+
+            # With max_concurrent_requests=2, we should see:
+            # - First 2 requests start immediately
+            # - Third request waits until one of the first two finishes
+            assert len(request_log) == 6  # 3 start + 3 end
+
+            # The first two requests should start before any end
+            start_count = 0
+            for event in request_log:
+                if event == "start":
+                    start_count += 1
+                elif event == "end":
+                    # When we see the first end, we should have seen at most 2 starts
+                    assert start_count <= 2
+                    break


### PR DESCRIPTION
Adds an `arcade_tdk.models` module with a `BaseHttpClient` abstract class.

This class encapsulates HTTP-calling logic that will be needed by all api-wrapper toolkits:

- Concurrency control with `asyncio.Semaphore` (uses `{service}_max_concurrent_requests` secret, when available)
- Logic to send asynchronous GET, POST, PUT, DELETE requests
- Format all HTTP responses as a `dict`, to standardize api-wrapper tool response type
- Handle common HTTP errors and raises either `ToolExecutionError` or `RetryableToolError`
- Extract the value for `retry_after_ms` from the `Retry-After` HTTP response header, when available (handles both possible values according to the HTTP spec: seconds or date -- ignores if not formatted correctly by the service API response)

Unit-tests with 96% coverage.