### PR TITLE
added missing parameter to the usage example templates

### DIFF
--- a/libs/arcade-cli/arcade_cli/toolkit_docs/templates.py
+++ b/libs/arcade-cli/arcade_cli/toolkit_docs/templates.py
@@ -97,7 +97,10 @@ const USER_ID = "{{arcade_user_id}}";
 const TOOL_NAME = "{tool_fully_qualified_name}";
 
 // Start the authorization process
-const authResponse = await client.tools.authorize({{tool_name: TOOL_NAME}});
+const authResponse = await client.tools.authorize({{
+    tool_name: TOOL_NAME,
+    user_id: USER_ID
+}});
 
 if (authResponse.status !== "completed") {{
   console.log(`Click this link to authorize: ${{authResponse.url}}`);
@@ -125,7 +128,10 @@ client = Arcade()  # Automatically finds the `ARCADE_API_KEY` env variable
 USER_ID = "{{arcade_user_id}}"
 TOOL_NAME = "{tool_fully_qualified_name}"
 
-auth_response = client.tools.authorize(tool_name=TOOL_NAME)
+auth_response = client.tools.authorize(
+    tool_name=TOOL_NAME,
+    user_id=TOOL_NAME
+)
 
 if auth_response.status != "completed":
     print(f"Click this link to authorize: {{auth_response.url}}")


### PR DESCRIPTION
Example templates were missing the `user_id` param, this was caught by @evantahler, thanks!