### PR TITLE
Wrapper Tool and HTTP Endpoint schemas

### DIFF
--- a/libs/arcade-core/arcade_core/api_wrapper/errors.py
+++ b/libs/arcade-core/arcade_core/api_wrapper/errors.py
@@ -1,0 +1,18 @@
+from arcade_core.errors import ToolDefinitionError
+
+
+class WrapperDefinitionError(ToolDefinitionError):
+    """
+    Raised when there is an error in the definition of a wrapper tool.
+    """
+
+    pass
+
+
+class InvalidObjectVersionError(WrapperDefinitionError):
+    """
+    Raised when there is an error in the version of an object.
+    """
+
+    def __init__(self, version: str, object_name: str):
+        super().__init__(f"Invalid version: '{version}' in {object_name} object.")

--- a/libs/arcade-core/arcade_core/api_wrapper/schema.py
+++ b/libs/arcade-core/arcade_core/api_wrapper/schema.py
@@ -1,0 +1,131 @@
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+from arcade_core.schema import InputParameter, ToolDefinition, ToolInput
+
+
+class ObjectMetadata(BaseModel):
+    """Object metadata (part of the serialized JSON stored in a Wrapper toolkit package)."""
+
+    object_type: str
+    """The type of the object."""
+
+    version: str
+    """The version of the object."""
+
+    description: str = ""
+    """The description of the object."""
+
+
+class HttpValueSchema(BaseModel):
+    """The schema of the value of an HTTP API endpoint parameter."""
+
+    val_type: Literal["string", "integer", "number", "boolean", "json", "array"]
+    """The type of the value."""
+
+    inner_val_type: (
+        Literal["string", "integer", "number", "boolean", "json", "array"] | None
+    ) = None
+    """The value schema of the inner value, in case of an array."""
+
+
+class HttpEndpointParameter(BaseModel):
+    """The value of an HTTP API endpoint parameter."""
+
+    name: str
+    """The name of the parameter."""
+
+    description: str = ""
+    """The description of the parameter."""
+
+    value_schema: HttpValueSchema
+    """The schema of the value."""
+
+    accepted_as: Literal["path", "query", "header", "body", "form_data"]
+    """How the parameter is accepted by the HTTP API endpoint."""
+
+    required: bool
+    """Whether the parameter is required."""
+
+    deprecated: bool = False
+    """Whether the parameter is deprecated."""
+
+    # NOTE: sometimes API documentation points to additional URL(s) explaining about the options
+    # accepted by the parameter, or how to build a json value, for example.
+    documentation_urls: list[str] = []
+    """The URLs to the documentation for the parameter."""
+
+
+class HttpEndpointMetadata(ObjectMetadata):
+    object_type: Literal["http_endpoint"] = "http_endpoint"
+
+
+class HttpEndpointDefinition(BaseModel):
+    """The definition of an HTTP API endpoint."""
+
+    metadata: HttpEndpointMetadata = Field(
+        default_factory=HttpEndpointMetadata, exclude=True
+    )
+    """The object metadata."""
+
+    url: str
+    """The URL of the HTTP API endpoint."""
+
+    http_method: Literal["GET", "POST", "PUT", "DELETE"]
+    """The HTTP method of the HTTP API endpoint."""
+
+    headers: dict[str, str] | None = None
+    """The headers of the HTTP API endpoint."""
+
+    parameters: list[HttpEndpointParameter]
+    """The parameters of the HTTP API endpoint."""
+
+    # Utility to facilitate converting tool inputs to HTTP endpoint parameters
+    # when building the HTTP request.
+    parameters_by_name: dict[str, HttpEndpointParameter] = Field(
+        exclude=True,
+        default_factory=dict,
+        init=False,
+    )
+
+    documentation_urls: list[str] = []
+    """The URLs to the documentation for the HTTP API endpoint."""
+
+    def model_post_init(self, __context) -> None:
+        """Initialize computed fields after model creation."""
+        self.parameters_by_name = {param.name: param for param in self.parameters}
+
+
+class WrapperToolInputParameter(InputParameter):
+    """A parameter that can be passed to an API wrapper tool."""
+
+    # This field is used only during tool-call runtime and is excluded from serialization.
+    http_endpoint_parameter_name: str = Field(..., exclude=True)
+    """The name of the HTTP endpoint parameter associated to this Wrapper Tool parameter."""
+
+
+class WrapperToolInput(ToolInput):
+    """The inputs of an Wrapper tool."""
+
+    parameters: list[WrapperToolInputParameter]
+    """The list of parameters that the tool accepts."""
+
+
+class WrapperToolMetadata(ObjectMetadata):
+    object_type: Literal["api_wrapper_tool"] = "api_wrapper_tool"
+
+
+class WrapperToolDefinition(ToolDefinition):
+    """The specification of a Wrapper Tool."""
+
+    metadata: WrapperToolMetadata = Field(
+        default_factory=WrapperToolMetadata, exclude=True
+    )
+    """The object metadata."""
+
+    input: WrapperToolInput
+    """The inputs of the Wrapper Tool."""
+
+    http_endpoint: HttpEndpointDefinition | None = None
+    """The HTTP API endpoint that the Wrapper Tool wraps."""

--- a/libs/arcade-core/arcade_core/api_wrapper/schema.py
+++ b/libs/arcade-core/arcade_core/api_wrapper/schema.py
@@ -36,8 +36,10 @@ class HttpValueSchema(BaseModel):
     val_type: Literal["string", "integer", "number", "boolean", "json", "array"]
     """The type of the value."""
 
-    inner_val_type: Literal["string", "integer", "number", "boolean"] | None = None
-    """The value schema of the inner value, in case of an array."""
+    array_inner_val_type: Literal["string", "integer", "number", "boolean"] | None = (
+        None
+    )
+    """The value schema of the inner value of an array (if applicable)."""
 
 
 class HttpEndpointParameter(BaseModel):

--- a/libs/arcade-core/arcade_core/api_wrapper/schema.py
+++ b/libs/arcade-core/arcade_core/api_wrapper/schema.py
@@ -10,7 +10,7 @@ from arcade_core.schema import InputParameter, ToolDefinition, ToolInput
 class ObjectMetadata(BaseModel):
     """Object metadata (part of the serialized JSON stored in a Wrapper toolkit package)."""
 
-    object_type: str
+    object_type: Literal["http_endpoint", "api_wrapper_tool"]
     """The type of the object."""
 
     version: str

--- a/libs/arcade-core/arcade_core/api_wrapper/schema.py
+++ b/libs/arcade-core/arcade_core/api_wrapper/schema.py
@@ -1,7 +1,9 @@
 from typing import Literal
 
-from pydantic import BaseModel, Field
+from packaging.version import InvalidVersion, Version
+from pydantic import BaseModel, Field, field_validator
 
+from arcade_core.api_wrapper.errors import InvalidObjectVersionError
 from arcade_core.schema import InputParameter, ToolDefinition, ToolInput
 
 
@@ -16,6 +18,16 @@ class ObjectMetadata(BaseModel):
 
     description: str = ""
     """The description of the object."""
+
+    @field_validator("version")
+    @classmethod
+    def validate_semver(cls, version: str) -> str:
+        """Validate that object version follows semantic versioning format."""
+        try:
+            Version(version)
+            return version
+        except InvalidVersion as e:
+            raise InvalidObjectVersionError(version, cls.__name__) from e
 
 
 class HttpValueSchema(BaseModel):

--- a/libs/arcade-core/arcade_core/api_wrapper/schema.py
+++ b/libs/arcade-core/arcade_core/api_wrapper/schema.py
@@ -127,5 +127,5 @@ class WrapperToolDefinition(ToolDefinition):
     input: WrapperToolInput
     """The inputs of the Wrapper Tool."""
 
-    http_endpoint: HttpEndpointDefinition | None = None
+    http_endpoint: HttpEndpointDefinition = Field(..., exclude=True)
     """The HTTP API endpoint that the Wrapper Tool wraps."""

--- a/libs/arcade-core/arcade_core/api_wrapper/schema.py
+++ b/libs/arcade-core/arcade_core/api_wrapper/schema.py
@@ -24,9 +24,7 @@ class HttpValueSchema(BaseModel):
     val_type: Literal["string", "integer", "number", "boolean", "json", "array"]
     """The type of the value."""
 
-    inner_val_type: (
-        Literal["string", "integer", "number", "boolean", "json", "array"] | None
-    ) = None
+    inner_val_type: Literal["string", "integer", "number", "boolean"] | None = None
     """The value schema of the inner value, in case of an array."""
 
 

--- a/libs/arcade-core/pyproject.toml
+++ b/libs/arcade-core/pyproject.toml
@@ -63,3 +63,6 @@ warn_return_any = true
 warn_unused_ignores = true
 show_error_codes = true
 ignore_missing_imports = true
+
+[tool.ruff.lint.isort]
+known-first-party = ["arcade_core",]


### PR DESCRIPTION
Chose to write the schema as Pydantic models to follow the same standard as our current models in `arcade_core.schema`.

The `WrapperToolDefinition` and `HttpEndpointDefinition` classes will be used by agent moar to output the JSON files in the wrapper toolkit packages. The worker will then load these JSONs using these Pydantic models.

The `metadata` property in `WrapperToolDefinition` and `HttpEndpointDefinition`, as well as the `http_endpoint` property in `WrapperToolDefinition` are set with `exclude=True`. When the Worker dumps the WrapperTool data, it will look just like the `ToolDefinition` model dump. When agent moar outputs the JSON files, these properties will be included.