### PR TITLE
upgraded langchain_arcade

### DIFF
--- a/contrib/langchain/pyproject.toml
+++ b/contrib/langchain/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "langchain-arcade"
-version = "1.3.1"
+version = "1.4.0"
 description = "An integration package connecting Arcade and Langchain/LangGraph"
 authors = ["Arcade <dev@arcade.dev>"]
 readme = "README.md"
@@ -9,7 +9,7 @@ license = "MIT"
 
 [tool.poetry.dependencies]
 python = ">=3.10,<4"
-arcadepy = "1.3.*"
+arcadepy = "1.7.*"
 langchain-core = ">=0.3.49,<0.4"
 
 


### PR DESCRIPTION
This bumps the requirement version of the Arcade client to the latest version (which supports the new function for the custom user verifier)
It also moves the tests to be compatible to our new tool names