### PR TITLE
Release libs for arcade-mcp

### DIFF
--- a/libs/arcade-cli/arcade_cli/new.py
+++ b/libs/arcade-cli/arcade_cli/new.py
@@ -19,15 +19,15 @@ try:
     ARCADE_MCP_MAX_VERSION = str(int(ARCADE_MCP_MIN_VERSION.split(".")[0]) + 1) + ".0.0"
 except Exception as e:
     console.print(f"[red]Failed to get arcade-mcp version: {e}[/red]")
-    ARCADE_MCP_MIN_VERSION = "1.0.0rc2"  # Default version if unable to fetch
-    ARCADE_MCP_MAX_VERSION = "4.0.0"
+    ARCADE_MCP_MIN_VERSION = "1.0.0"  # Default version if unable to fetch
+    ARCADE_MCP_MAX_VERSION = "2.0.0"
 
-ARCADE_TDK_MIN_VERSION = "2.6.0rc2"
-ARCADE_TDK_MAX_VERSION = "3.0.0"
-ARCADE_SERVE_MIN_VERSION = "2.2.0rc2"
-ARCADE_SERVE_MAX_VERSION = "3.0.0"
-ARCADE_MCP_SERVER_MIN_VERSION = "1.0.0rc2"
-ARCADE_MCP_SERVER_MAX_VERSION = "3.0.0"
+ARCADE_TDK_MIN_VERSION = "3.0.0"
+ARCADE_TDK_MAX_VERSION = "4.0.0"
+ARCADE_SERVE_MIN_VERSION = "3.0.0"
+ARCADE_SERVE_MAX_VERSION = "4.0.0"
+ARCADE_MCP_SERVER_MIN_VERSION = "1.0.0"
+ARCADE_MCP_SERVER_MAX_VERSION = "2.0.0"
 
 
 def ask_question(question: str, default: Optional[str] = None) -> str:

--- a/libs/arcade-core/pyproject.toml
+++ b/libs/arcade-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "arcade-core"
-version = "2.5.0rc2"
+version = "3.0.0"
 description = "Arcade Core - Core library for Arcade platform"
 readme = "README.md"
 license = {text = "MIT"}
@@ -8,7 +8,7 @@ authors = [
     {name = "Arcade", email = "dev@arcade.dev"},
 ]
 classifiers = [
-    "Development Status :: 4 - Beta",
+    "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",

--- a/libs/arcade-mcp-server/pyproject.toml
+++ b/libs/arcade-mcp-server/pyproject.toml
@@ -4,13 +4,13 @@ build-backend = "hatchling.build"
 
 [project]
 name = "arcade-mcp-server"
-version = "1.0.0rc3"
+version = "1.0.0"
 description = "Model Context Protocol (MCP) server framework for Arcade.dev"
 readme = "README.md"
 authors = [{ name = "Arcade.dev" }]
 license = { text = "MIT" }
 classifiers = [
-    "Development Status :: 4 - Beta",
+    "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
@@ -21,9 +21,9 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "arcade-core>=2.5.0rc2,<3.0.0",
-    "arcade-serve>=2.2.0rc2,<3.0.0",
-    "arcade-tdk>=2.6.0rc2,<3.0.0",
+    "arcade-core>=3.0.0,<4.0.0",
+    "arcade-serve>=3.0.0,<4.0.0",
+    "arcade-tdk>=3.0.0,<4.0.0",
     "arcadepy>=1.5.0",
     "pydantic>=2.0.0",
     "fastapi>=0.100.0",

--- a/libs/arcade-serve/pyproject.toml
+++ b/libs/arcade-serve/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "arcade-serve"
-version = "2.2.0rc2"
+version = "3.0.0"
 description = "Arcade Serve - Serving infrastructure for Arcade tools and workers"
 readme = "README.md"
 license = {text = "MIT"}
@@ -8,7 +8,7 @@ authors = [
     {name = "Arcade", email = "dev@arcade.dev"},
 ]
 classifiers = [
-    "Development Status :: 4 - Beta",
+    "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
@@ -19,7 +19,7 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "arcade-core>=2.5.0rc2,<3.0.0",
+    "arcade-core>=3.0.0,<4.0.0",
     "fastapi>=0.115.3",
     "uvicorn>=0.30.0",
     "watchfiles>=1.0.5",

--- a/libs/arcade-tdk/pyproject.toml
+++ b/libs/arcade-tdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "arcade-tdk"
-version = "2.6.0rc2"
+version = "3.0.0"
 description = "Arcade TDK - Toolkit Development Kit for building Arcade tools"
 readme = "README.md"
 license = {text = "MIT"}
@@ -8,7 +8,7 @@ authors = [
     {name = "Arcade", email = "dev@arcade.dev"},
 ]
 classifiers = [
-    "Development Status :: 4 - Beta",
+    "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
@@ -19,7 +19,7 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "arcade-core>=2.5.0rc2,<3.0.0",
+    "arcade-core>=3.0.0,<4.0.0",
     "pydantic>=2.7.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "arcade-mcp"
-version = "1.0.0rc4"
+version = "1.0.0"
 description = "Arcade.dev - Tool Calling platform for Agents"
 readme = "README.md"
 license = {file = "LICENSE"}
@@ -21,8 +21,8 @@ requires-python = ">=3.10"
 
 dependencies = [
     # CLI dependencies
-    "arcade-mcp-server>=1.0.0rc3,<3.0.0",
-    "arcade-core>=2.5.0rc2,<3.0.0",
+    "arcade-mcp-server>=1.0.0,<2.0.0",
+    "arcade-core>=3.0.0,<4.0.0",
     "typer==0.10.0",
     "rich==13.9.4",
     "Jinja2==3.1.6",
@@ -42,11 +42,11 @@ all = [
     "pytz>=2024.1",
     "python-dateutil>=2.8.2",
     # mcp
-    "arcade-mcp-server>=1.0.0rc3,<3.0.0",
+    "arcade-mcp-server>=1.0.0,<2.0.0",
     # serve
-    "arcade-serve>=2.2.0rc2,<3.0.0",
+    "arcade-serve>=3.0.0,<4.0.0",
     # tdk
-    "arcade-tdk>=2.6.0rc2,<3.0.0",
+    "arcade-tdk>=3.0.0,<4.0.0",
 ]
 # Evals also depends on arcade-core and openai, but they are already required deps
 evals = [


### PR DESCRIPTION
Seeing that arcade-ai==2.2.3 doesn't allow for core, serve, or tdk versions 3.x.x and that it doesn't know about arcade-mcp-server or arcade-mcp, I feel confident that we can get this past the release candidate stage. The current state of our documentation (docs.arcade.dev) still references the 'old way' of doing things, so we can gradually introduce these new packages to users without the hassle of specifying pre release flags when installing

### New packages:
arcade-mcp==1.0.0
arcade-mcp-server==1.0.0

### Breaking change with major bump:
arcade-core==3.0.0 from 2.4.0
arcade-serve==3.0.0 from 2.1.0
arcade-tdk==3.0.0 from 2.5.0

### Deprecated:
arcade-ai==2.2.3