### PR TITLE
Fix stdio bugs

### DIFF
--- a/libs/arcade-cli/arcade_cli/new.py
+++ b/libs/arcade-cli/arcade_cli/new.py
@@ -19,14 +19,14 @@ try:
     ARCADE_MCP_MAX_VERSION = str(int(ARCADE_MCP_MIN_VERSION.split(".")[0]) + 1) + ".0.0"
 except Exception as e:
     console.print(f"[red]Failed to get arcade-mcp version: {e}[/red]")
-    ARCADE_MCP_MIN_VERSION = "1.0.0"  # Default version if unable to fetch
+    ARCADE_MCP_MIN_VERSION = "1.1.0"  # Default version if unable to fetch
     ARCADE_MCP_MAX_VERSION = "2.0.0"
 
 ARCADE_TDK_MIN_VERSION = "3.0.0"
 ARCADE_TDK_MAX_VERSION = "4.0.0"
 ARCADE_SERVE_MIN_VERSION = "3.0.0"
 ARCADE_SERVE_MAX_VERSION = "4.0.0"
-ARCADE_MCP_SERVER_MIN_VERSION = "1.0.1"
+ARCADE_MCP_SERVER_MIN_VERSION = "1.1.1"
 ARCADE_MCP_SERVER_MAX_VERSION = "2.0.0"
 
 

--- a/libs/arcade-cli/arcade_cli/templates/minimal/{{ toolkit_name }}/pyproject.toml
+++ b/libs/arcade-cli/arcade_cli/templates/minimal/{{ toolkit_name }}/pyproject.toml
@@ -9,6 +9,7 @@ description = "MCP Server created with Arcade.dev"
 requires-python = ">=3.10"
 dependencies = [
     "arcade-mcp-server>={{ arcade_mcp_server_min_version }},<{{ arcade_mcp_server_max_version }}",
+    "httpx>=0.28.0,<1.0.0",
 ]
 
 [project.optional-dependencies]

--- a/libs/arcade-mcp-server/arcade_mcp_server/__main__.py
+++ b/libs/arcade-mcp-server/arcade_mcp_server/__main__.py
@@ -54,7 +54,7 @@ def setup_logging(level: str = "INFO", stdio_mode: bool = False) -> None:
     # Remove existing handlers
     logger.remove()
 
-    # Configure output destination
+    # In stdio mode, use stderr (stdout is reserved for JSON-RPC)
     sink = sys.stderr if stdio_mode else sys.stdout
 
     # Add handler with appropriate format
@@ -69,7 +69,7 @@ def setup_logging(level: str = "INFO", stdio_mode: bool = False) -> None:
         sink,
         format=format_str,
         level=level,
-        colorize=True,
+        colorize=(not stdio_mode),
         diagnose=(level == "DEBUG"),
     )
 

--- a/libs/arcade-mcp-server/pyproject.toml
+++ b/libs/arcade-mcp-server/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "arcade-mcp-server"
-version = "1.1.0"
+version = "1.1.1"
 description = "Model Context Protocol (MCP) server framework for Arcade.dev"
 readme = "README.md"
 authors = [{ name = "Arcade.dev" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "arcade-mcp"
-version = "1.0.2"
+version = "1.1.0"
 description = "Arcade.dev - Tool Calling platform for Agents"
 readme = "README.md"
 license = {file = "LICENSE"}
@@ -21,7 +21,7 @@ requires-python = ">=3.10"
 
 dependencies = [
     # CLI dependencies
-    "arcade-mcp-server>=1.1.0,<2.0.0",
+    "arcade-mcp-server>=1.1.1,<2.0.0",
     "arcade-core>=3.0.0,<4.0.0",
     "typer==0.10.0",
     "rich==13.9.4",
@@ -42,7 +42,7 @@ all = [
     "pytz>=2024.1",
     "python-dateutil>=2.8.2",
     # mcp
-    "arcade-mcp-server>=1.1.0,<2.0.0",
+    "arcade-mcp-server>=1.1.1,<2.0.0",
     # serve
     "arcade-serve>=3.0.0,<4.0.0",
     # tdk


### PR DESCRIPTION
1. Updates `arcade configure claude --from-local` to create a valid json config for claude desktop. NOTE: The `arcade configure` command needs some re-work. It's fragile.
2. Fixes bug where stdio servers were sending logs to the wrong sink.
3. Disabled colorized logs for stdio.
4. Added missing dependency `httpx` for servers created with `arcade new`

## Claude Desktop json configuration for stdio
Personally I like option 1 because the configuration looks the simplest
### Option 1:
Equivalent to `python server.py stdio`
```
{
  "globalShortcut": "Alt+Ctrl+Space",
  "mcpServers": {
    "my_server": {
      "command": "/path/to/my/mcp/server/directory/.venv/bin/python",
      "args": [
        "/path/to/my/mcp/server/directory/server.py",
        "stdio"
      ]
    }
  }
}
```
### Option 2:
Equivalent to `uv run server.py stdio`
```
{
  "mcpServers": {
    "my_server": {
      "command": "uv",
      "args": [
        "run",
        "--directory",
        "/path/to/my/mcp/server/directory",
        "python",
        "server.py",
        "stdio"
      ]
    }
  }
}
```
### Option 3:
Equivalent to `python -m arcade_mcp_server stdio --cwd ./`
```
{
  "mcpServers": {
    "my_server": {
      "command": "/path/to/my/mcp/server/directory/.venv/bin/python",
      "args": [
        "-m",
        "arcade_mcp_server",
        "stdio",
        "--cwd",
        "/path/to/my/mcp/server/directory"
      ]
    }
  }
}
```