### PR TITLE
Rename example servers

### DIFF
--- a/examples/mcp_servers/echo/src/echo/server.py
+++ b/examples/mcp_servers/echo/src/echo/server.py
@@ -2,7 +2,7 @@ from typing import Annotated
 
 from arcade_mcp_server import MCPApp
 
-app = MCPApp("Echo server")
+app = MCPApp("EchoServer")
 
 
 @app.tool

--- a/examples/mcp_servers/logging/src/logging/server.py
+++ b/examples/mcp_servers/logging/src/logging/server.py
@@ -3,7 +3,7 @@ from typing import Annotated
 from arcade_mcp_server import Context, MCPApp
 from loguru import logger
 
-app = MCPApp("Logging server")
+app = MCPApp("LoggingServer")
 
 
 @app.tool

--- a/examples/mcp_servers/server_with_evaluations/src/server_with_evaluations/server.py
+++ b/examples/mcp_servers/server_with_evaluations/src/server_with_evaluations/server.py
@@ -5,7 +5,7 @@ from arcade_mcp_server import MCPApp
 
 import server_with_evaluations
 
-app = MCPApp(name="server-with-evaluations", version="1.0.0", log_level="DEBUG")
+app = MCPApp(name="ServerWithEvaluations", version="1.0.0", log_level="DEBUG")
 
 app.add_tools_from_module(server_with_evaluations)
 


### PR DESCRIPTION
We disallow spaces in the name