### PR TITLE
Add tool name and version to otel spans for worker

### DIFF
--- a/libs/arcade-serve/arcade_serve/core/base.py
+++ b/libs/arcade-serve/arcade_serve/core/base.py
@@ -132,8 +132,7 @@ class BaseWorker(Worker):
         logger.debug(f"{execution_id} | Tool inputs: {tool_request.inputs}")
 
         tracer = trace.get_tracer(__name__)
-        with tracer.start_as_current_span("RunTool"):
-            current_span = trace.get_current_span()
+        with tracer.start_as_current_span("RunTool") as current_span:
             current_span.set_attribute("tool_name", str(tool_fqname.name))
             current_span.set_attribute("toolkit_version", str(tool_fqname.toolkit_version))
             current_span.set_attribute("toolkit_name", str(tool_fqname.toolkit_name))

--- a/libs/arcade-serve/arcade_serve/core/components.py
+++ b/libs/arcade-serve/arcade_serve/core/components.py
@@ -66,11 +66,10 @@ class CallToolComponent(WorkerComponent):
         Handle the request to call (invoke) a tool.
         """
         tracer = trace.get_tracer(__name__)
-        with tracer.start_as_current_span("CallTool"):
+        with tracer.start_as_current_span("CallTool") as current_span:
             call_tool_request_data = request.body_json
             call_tool_request = ToolCallRequest.model_validate(call_tool_request_data)
 
-            current_span = trace.get_current_span()
             current_span.set_attribute("tool_name", str(call_tool_request.tool.name))
             current_span.set_attribute("toolkit_version", str(call_tool_request.tool.version))
             current_span.set_attribute("toolkit_name", str(call_tool_request.tool.toolkit))


### PR DESCRIPTION
Knowing which tools we called seems important

<img width="1554" height="293" alt="Screenshot 2025-11-20 at 1 36 48 PM" src="https://github.com/user-attachments/assets/1b3cf297-749f-4ea1-9d1c-606707540d5b" />

Closes PLT-748