### PR TITLE
Add startup warnings for missing tool secrets

### DIFF
--- a/libs/arcade-mcp-server/arcade_mcp_server/server.py
+++ b/libs/arcade-mcp-server/arcade_mcp_server/server.py
@@ -664,7 +664,20 @@ class MCPServer:
         This provides early feedback about configuration issues without
         preventing server startup. Warnings are logged for each tool that
         declares secret requirements that are not currently available.
+        
+        Note: This check is only performed when worker routes are disabled.
+        When worker routes are enabled (ARCADE_WORKER_SECRET is set), secrets
+        are sent with the tool execution information, so local secret checking
+        is not necessary.
         """
+        # Skip secret checking when worker routes are enabled
+        if self.settings.arcade.server_secret:
+            logger.debug(
+                "Skipping secret validation check - worker routes are enabled "
+                "(secrets will be sent with tool execution information)"
+            )
+            return
+        
         try:
             # Get all tools from the manager
             tools_list = await self._tool_manager.list_tools()


### PR DESCRIPTION
Add startup warnings for missing tool secrets to provide faster feedback on misconfigurations.

---
Linear Issue: [TOO-198](https://linear.app/arcadedev/issue/TOO-198/add-startup-warnings-for-missing-tool-secrets)

<a href="https://cursor.com/background-agent?bcId=bc-e4d7d942-8e2e-4d6c-b083-8468f35ecf75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e4d7d942-8e2e-4d6c-b083-8468f35ecf75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

