### PR TITLE
Fix arcade tdk and core version incompatibility

### DIFF
--- a/libs/arcade-mcp-server/pyproject.toml
+++ b/libs/arcade-mcp-server/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "arcade-mcp-server"
-version = "1.10.2"
+version = "1.10.3"
 description = "Model Context Protocol (MCP) server framework for Arcade.dev"
 readme = "README.md"
 authors = [{ name = "Arcade.dev" }]

--- a/libs/arcade-tdk/pyproject.toml
+++ b/libs/arcade-tdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "arcade-tdk"
-version = "3.2.0"
+version = "3.2.1"
 description = "Arcade TDK - Toolkit Development Kit for building Arcade tools"
 readme = "README.md"
 license = {text = "MIT"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "arcade-mcp"
-version = "1.5.6"
+version = "1.5.7"
 description = "Arcade.dev - Tool Calling platform for Agents"
 readme = "README.md"
 license = {file = "LICENSE"}


### PR DESCRIPTION
Update `arcade-core` and `arcade-tdk` dependency versions to resolve `ImportError` caused by incompatible `Figma` auth provider imports.

The `Figma` OAuth2 provider was introduced in `arcade-core` 3.3.5. `arcade-tdk` 3.2.0 and `arcade-mcp-server` 1.10.2 started importing `Figma`, but their `pyproject.toml` dependency constraints were not updated to require `arcade-core>=3.3.5`. This led to `ImportError` when `arcade-tdk` or `arcade-mcp-server` were installed with an older `arcade-core` version. This PR updates the minimum required versions in `pyproject.toml` files across `arcade-tdk`, `arcade-mcp-server`, and the root project to ensure compatibility.

---
Linear Issue: [TOO-231](https://linear.app/arcadedev/issue/TOO-231/worker-fails-to-start-due-to-arcade-core-auth-import)

<a href="https://cursor.com/background-agent?bcId=bc-4383bd24-eb8c-4d2e-bafe-c116a9d83e8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4383bd24-eb8c-4d2e-bafe-c116a9d83e8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Align dependency minimums to `arcade-core>=3.3.5` and `arcade-tdk>=3.2.0` and bump package versions across projects.
> 
> - **Dependencies**:
>   - Raise `arcade-core` minimum to `>=3.3.5,<4.0.0` in `libs/arcade-mcp-server/pyproject.toml`, `libs/arcade-tdk/pyproject.toml`, and root `pyproject.toml`.
>   - Raise `arcade-tdk` minimum to `>=3.2.0,<4.0.0` in `libs/arcade-mcp-server/pyproject.toml` and root `pyproject.toml`.
> - **Version bumps**:
>   - `libs/arcade-mcp-server` version `1.10.2` → `1.10.3`.
>   - `libs/arcade-tdk` version `3.2.0` → `3.2.1`.
>   - Root package `arcade-mcp` version `1.5.6` → `1.5.7`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit abec5dff0d18c9e9c1c5a0ceafa73c67b6af661a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->