### PR TITLE
fix: Don't double-include template files

### DIFF
--- a/.github/workflows/release-on-version-change.yml
+++ b/.github/workflows/release-on-version-change.yml
@@ -107,6 +107,41 @@ jobs:
         run: |
           uv build --out-dir dist | tee build.log
 
+          # Validate wheel archives: PyPI rejects duplicate filenames in wheels
+          python - <<'PY'
+          from __future__ import annotations
+
+          from pathlib import Path
+          import sys
+          import zipfile
+
+          dist = Path("dist")
+          wheels = sorted(dist.glob("*.whl"))
+          if not wheels:
+            print("No wheels found in dist/, skipping wheel validation.")
+            raise SystemExit(0)
+
+          for whl in wheels:
+            with zipfile.ZipFile(whl) as zf:
+              names = zf.namelist()
+
+            seen: set[str] = set()
+            dupes: set[str] = set()
+            for name in names:
+              if name in seen:
+                dupes.add(name)
+              else:
+                seen.add(name)
+
+            if dupes:
+              print(f"ERROR: {whl} contains duplicate paths (PyPI will reject this wheel):", file=sys.stderr)
+              for name in sorted(dupes):
+                print(f"  - {name}", file=sys.stderr)
+              raise SystemExit(1)
+
+          print("Wheel validation OK (no duplicate filenames).")
+          PY
+
           # Verify build artifacts
           ls -la dist/
           echo "Built artifacts for ${{ env.PACKAGE_NAME }} v${{ env.VERSION }}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "arcade-mcp"
-version = "1.6.0"
+version = "1.6.1"
 description = "Arcade.dev - Tool Calling platform for Agents"
 readme = "README.md"
 license = {file = "LICENSE"}
@@ -93,10 +93,6 @@ packages = [
     "libs/arcade-cli/arcade_cli",
     "libs/arcade-evals/arcade_evals",
 ]
-
-# Include Jinja templates in the CLI package
-[tool.hatch.build.targets.wheel.force-include]
-"libs/arcade-cli/arcade_cli/templates" = "arcade_cli/templates"
 
 [tool.uv.workspace]
 members = [


### PR DESCRIPTION
Fixes broken publishing action: https://github.com/ArcadeAI/arcade-mcp/actions/runs/20147239181

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes template force-include to avoid duplicate files and adds CI wheel-duplicate validation; bumps version to 1.6.1.
> 
> - **Packaging**:
>   - Bump `arcade-mcp` version from `1.6.0` to `1.6.1` in `pyproject.toml`.
>   - Remove `[tool.hatch.build.targets.wheel.force-include]` for `arcade_cli/templates` to prevent double-including template files.
> - **CI/CD**:
>   - In `.github/workflows/release-on-version-change.yml`, add a post-build Python step to validate built wheels for duplicate filenames before publishing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3a15e08772b2b4851b185b04c763f3f5898bdbd5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->