### PR TITLE
Bump some verisons

### DIFF
--- a/examples/mcp_servers/authorization/pyproject.toml
+++ b/examples/mcp_servers/authorization/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "MCP Server created with Arcade.dev"
 requires-python = ">=3.10"
 dependencies = [
-    "arcade-mcp-server>=1.8.0,<2.0.0",
+    "arcade-mcp-server>=1.12.0,<2.0.0",
     "httpx>=0.28.0,<1.0.0",
 ]
 

--- a/libs/arcade-mcp-server/pyproject.toml
+++ b/libs/arcade-mcp-server/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "arcade-mcp-server"
-version = "1.12.0"
+version = "1.13.0"
 description = "Model Context Protocol (MCP) server framework for Arcade.dev"
 readme = "README.md"
 authors = [{ name = "Arcade.dev" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "arcade-mcp"
-version = "1.6.1"
+version = "1.6.2"
 description = "Arcade.dev - Tool Calling platform for Agents"
 readme = "README.md"
 license = {file = "LICENSE"}
@@ -21,7 +21,7 @@ requires-python = ">=3.10"
 
 dependencies = [
     # CLI dependencies
-    "arcade-mcp-server>=1.12.0,<2.0.0",
+    "arcade-mcp-server>=1.13.0,<2.0.0",
     "arcade-core>=4.0.0,<5.0.0",
     "typer==0.10.0",
     "rich==13.9.4",
@@ -43,7 +43,7 @@ all = [
     "pytz>=2024.1",
     "python-dateutil>=2.8.2",
     # mcp
-    "arcade-mcp-server>=1.12.0,<2.0.0",
+    "arcade-mcp-server>=1.13.0,<2.0.0",
     # serve
     "arcade-serve>=3.2.0,<4.0.0",
     # tdk


### PR DESCRIPTION
`arcade-mcp-server` version was not bumped in https://github.com/ArcadeAI/arcade-mcp/pull/717, so this PR bumps `arcade-mcp-server`, and then update's `arcade-mcp`'s dependency on `arcade-mcp-server` by increasing the minimum version

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps arcade-mcp-server to 1.13.0, updates arcade-mcp to 1.6.2, and raises related dependency minimums (including example auth server).
> 
> - **Versions**:
>   - Bump `libs/arcade-mcp-server` project version from `1.12.0` to `1.13.0`.
>   - Bump `arcade-mcp` package version from `1.6.1` to `1.6.2`.
> - **Dependencies**:
>   - Raise `arcade-mcp` dependency on `arcade-mcp-server` to `>=1.13.0` in `pyproject.toml` (including `all` extra).
>   - Increase example server `examples/mcp_servers/authorization/pyproject.toml` minimum `arcade-mcp-server` to `>=1.12.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8a4f606bd8d0b48dd50e3e8e836d31bb679c6eba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->