### PR TITLE
Instrumentation for outbound requests

### DIFF
--- a/libs/arcade-serve/arcade_serve/core/components.py
+++ b/libs/arcade-serve/arcade_serve/core/components.py
@@ -73,7 +73,8 @@ class CallToolComponent(WorkerComponent):
             current_span.set_attribute("tool_name", str(call_tool_request.tool.name))
             current_span.set_attribute("toolkit_version", str(call_tool_request.tool.version))
             current_span.set_attribute("toolkit_name", str(call_tool_request.tool.toolkit))
-            current_span.set_attribute("environment", self.worker.environment)
+            if hasattr(self.worker, "environment"):
+                current_span.set_attribute("environment", self.worker.environment)
 
             return await self.worker.call_tool(call_tool_request)
 

--- a/libs/arcade-serve/pyproject.toml
+++ b/libs/arcade-serve/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "arcade-serve"
-version = "3.2.0"
+version = "3.2.1"
 description = "Arcade Serve - Serving infrastructure for Arcade tools and workers"
 readme = "README.md"
 license = {text = "MIT"}
@@ -27,6 +27,10 @@ dependencies = [
     "opentelemetry-instrumentation-fastapi==0.49b2",
     "opentelemetry-exporter-otlp-proto-http==1.28.2",
     "opentelemetry-exporter-otlp-proto-common==1.28.2",
+    "opentelemetry-instrumentation-httpx==0.49b2",
+    "opentelemetry-instrumentation-aiohttp-client==0.49b2",
+    "opentelemetry-instrumentation-requests==0.49b2",
+    "aiohttp>=3.0.0,<4.0.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds OpenTelemetry instrumentation for outbound HTTP (httpx, aiohttp, requests), guards span environment attribute, and updates package/version deps.
> 
> - **Telemetry**:
>   - Instrument outbound HTTP clients with OpenTelemetry: `httpx`, `aiohttp-client`, and `requests`.
>   - Tighten excluded span types using `Literal`.
> - **Core**:
>   - Guard setting `environment` span attribute in `CallToolComponent` only if present on `worker`.
> - **Packaging**:
>   - Bump `arcade-serve` to `3.2.1`.
>   - Add new dependencies for HTTP client instrumentation and `aiohttp`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9ab57f3c33d6033ff9ec4c6a40445a85328b169a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->