### PR TITLE
Run all tests with dependabot

### DIFF
--- a/.github/workflows/test-toolkits.yml
+++ b/.github/workflows/test-toolkits.yml
@@ -99,8 +99,7 @@ jobs:
 
       - name: Test stand-alone toolkits (with secrets)
         if: |
-          !github.event.pull_request.head.repo.fork &&
-          github.actor != 'dependabot[bot]'
+          !github.event.pull_request.head.repo.fork
         working-directory: toolkits/${{ matrix.toolkit }}
         env:
           TEST_POSTGRES_DATABASE_CONNECTION_STRING: ${{ secrets.TEST_POSTGRES_DATABASE_CONNECTION_STRING }} # TODO: dynamically only load the `TEST_${{ matrix.toolkit }}_DATABASE_CONNECTION_STRING secret`


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Removes the dependabot exclusion so secret-backed toolkit tests run on any non-fork PR.
> 
> - **CI (GitHub Actions)**
>   - Update `if` condition in `/.github/workflows/test-toolkits.yml` for "Test stand-alone toolkits (with secrets)":
>     - Remove `github.actor != 'dependabot[bot]'`, leaving only `!github.event.pull_request.head.repo.fork` to allow tests with secrets on non-fork PRs (including dependabot).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fab42ac63abe305cc5f5344ab6bcb8386c541fb6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->