### PR TITLE
Fix broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,16 +32,16 @@
 </div>
 
 <p align="center" style="display: flex; justify-content: center; gap: 5px; font-size: 15px;">
-    <a href="https://docs.arcade.dev/tools" target="_blank">Prebuilt Tools</a> •
-    <a href="https://docs.arcade.dev/home/contact-us" target="_blank">Contact Us</a>
+    <a href="https://docs.arcade.dev/en/resources/integrations" target="_blank">Prebuilt Tools</a> •
+    <a href="https://docs.arcade.dev/en/resources/contact-us" target="_blank">Contact Us</a>
 
 # Arcade MCP Server Framework
 
 * **To see example servers built with Arcade MCP Server Framework (this repo), check out our [examples](examples/)**
 
-* **To learn more about the Arcade MCP Server Framework (this repo), check out our [Arcade MCP documentation](https://docs.arcade.dev/en/home/build-tools/create-a-mcp-server)**
+* **To learn more about the Arcade MCP Server Framework (this repo), check out our [Arcade MCP documentation](https://docs.arcade.dev/en/guides/create-tools/tool-basics/build-mcp-server)**
 
-* **To learn more about other offerings from Arcade.dev, check out our [documentation](https://docs.arcade.dev/home).**
+* **To learn more about other offerings from Arcade.dev, check out our [documentation](https://docs.arcade.dev/en/home).**
 
 _Pst. hey, you, give us a star if you like it!_
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,4 +2,4 @@
 
 ## Arcade's Security Reaserch Program
 
-Learn more about Arcade's security resaerch program at https://docs.arcade.dev/home/security
+Learn more about Arcade's security resaerch program at https://docs.arcade.dev/en/guides/security/security-research-program

--- a/contrib/crewai/README.md
+++ b/contrib/crewai/README.md
@@ -17,7 +17,7 @@
 
 <p align="center">
     <a href="https://docs.arcade.dev" target="_blank">Docs</a> •
-    <a href="https://docs.arcade.dev/mcp-servers" target="_blank">Servers</a> •
+    <a href="https://docs.arcade.dev/en/resources/integrations" target="_blank">Servers</a> •
     <a href="https://github.com/ArcadeAI/arcade-py" target="_blank">Python Client</a> •
     <a href="https://github.com/ArcadeAI/arcade-js" target="_blank">JavaScript Client</a>
 </p>

--- a/contrib/langchain/README.md
+++ b/contrib/langchain/README.md
@@ -20,7 +20,7 @@
 
 <p align="center">
     <a href="https://docs.arcade.dev" target="_blank">Arcade Documentation</a> •
-    <a href="https://docs.arcade.dev/mcp-servers" target="_blank">Servers</a> •
+    <a href="https://docs.arcade.dev/en/resources/integrations" target="_blank">Servers</a> •
     <a href="https://github.com/ArcadeAI/arcade-py" target="_blank">Python Client</a> •
     <a href="https://github.com/ArcadeAI/arcade-js" target="_blank">JavaScript Client</a>
 </p>
@@ -168,7 +168,7 @@ Arcade provides many toolkits including:
 -   `X`: Posting and reading tweets on X
 -   And many more
 
-For a complete list, see the [Arcade Toolkits documentation](https://docs.arcade.dev/toolkits).
+For a complete list, see the [Arcade Toolkits documentation](https://docs.arcade.dev/en/resources/integrations).
 
 ## More Examples
 

--- a/libs/arcade-cli/arcade_cli/templates/full/{{ toolkit_name }}/README.md
+++ b/libs/arcade-cli/arcade_cli/templates/full/{{ toolkit_name }}/README.md
@@ -37,4 +37,4 @@
 
 ## Development
 
-Read the docs on how to create a toolkit [here](https://docs.arcade.dev/home/build-tools/create-a-toolkit)
+Read the docs on how to create a toolkit [here](https://docs.arcade.dev/en/guides/create-tools/tool-basics/build-mcp-server)

--- a/libs/arcade-mcp-server/arcade_mcp_server/server.py
+++ b/libs/arcade-mcp-server/arcade_mcp_server/server.py
@@ -1005,7 +1005,7 @@ class MCPServer:
                     and (requirements.authorization or requirements.secrets)
                     and not is_authenticated
                 ):
-                    documentation_url = "https://docs.arcade.dev/en/home/compare-server-types"
+                    documentation_url = "https://docs.arcade.dev/en/guides/create-tools/tool-basics/compare-server-types"
                     user_message = "✗ Unsupported transport\n\n"
                     user_message += f"  Tool '{tool_name}' cannot run over HTTP transport for security reasons.\n"
                     user_message += f"  This tool requires {'authorization' if requirements.authorization else 'secrets'}.\n\n"

--- a/libs/arcade-mcp-server/pyproject.toml
+++ b/libs/arcade-mcp-server/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "arcade-mcp-server"
-version = "1.14.0"
+version = "1.14.1"
 description = "Model Context Protocol (MCP) server framework for Arcade.dev"
 readme = "README.md"
 authors = [{ name = "Arcade.dev" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "arcade-mcp"
-version = "1.7.1"
+version = "1.7.2"
 description = "Arcade.dev - Tool Calling platform for Agents"
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
https://github.com/ArcadeAI/docs/pull/622 moved a lot of files to new URLs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates references to Arcade docs after site restructure and bumps package versions.
> 
> - Update docs URLs in `README.md`, `SECURITY.md`, contrib READMEs (CrewAI, LangChain), and CLI template README to new `/en/...` paths
> - Update `documentation_url` in `arcade_mcp_server/server.py` error message to the new "compare server types" doc
> - Bump versions: `arcade-mcp-server` to `1.14.1` and root `arcade-mcp` to `1.7.2`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 673b1ee7c2e5be6885ffd64914e7600b4685aaac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->