### PR TITLE
Fix dateutil dependency issue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "arcade-mcp"
-version = "1.8.1"
+version = "1.8.2"
 description = "Arcade.dev - Tool Calling platform for Agents"
 readme = "README.md"
 license = { file = "LICENSE" }
@@ -28,6 +28,7 @@ dependencies = [
     "arcadepy==1.8.0",
     "tqdm==4.67.1",
     "click==8.1.8",
+    "python-dateutil>=2.8.2",
 ]
 
 [project.optional-dependencies]
@@ -41,7 +42,6 @@ all = [
     "numpy>=2.0.0",
     "scikit-learn>=1.5.0",
     "pytz>=2024.1",
-    "python-dateutil>=2.8.2",
     # mcp server
     "arcade-mcp-server>=1.14.0,<2.0.0",
     # serve
@@ -60,7 +60,6 @@ evals = [
     "numpy>=2.0.0",
     "scikit-learn>=1.5.0",
     "pytz>=2024.1",
-    "python-dateutil>=2.8.2",
 ]
 
 [tool.uv]


### PR DESCRIPTION
This is the quick fix for placing the dateutil as a required dep instead of as an 'extra' dep.

This is the second time that a missing dependency has bitten us. I've created a ticket (TOO-317) to catch this class of bugs in our CI pipeline.