### PR TITLE
Npm-qs security vulnerability

### DIFF
--- a/contrib/examples/openai-agents-ts/package-lock.json
+++ b/contrib/examples/openai-agents-ts/package-lock.json
@@ -1147,9 +1147,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "version": "6.14.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
+      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
       "license": "BSD-3-Clause",
       "optional": true,
       "dependencies": {


### PR DESCRIPTION
Update `qs` package to version 6.14.1 to resolve CVE-2025-15284 security vulnerability.

---
Linear Issue: [TOO-342](https://linear.app/arcadedev/issue/TOO-342/vanta-remediate-high-vulnerabilities-identified-in-packages-are)

<a href="https://cursor.com/background-agent?bcId=bc-26b76c23-e05d-49b6-97a3-460e50b351c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-26b76c23-e05d-49b6-97a3-460e50b351c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

