### PR TITLE
Langchain core vulnerability

### DIFF
--- a/contrib/examples/langchain-ts/package.json
+++ b/contrib/examples/langchain-ts/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@arcadeai/arcadejs": "latest",
     "@langchain/community": "^1.0.5",
-    "@langchain/core": "^1.1.0",
+    "@langchain/core": "^1.1.8",
     "@langchain/langgraph": "^1.0.2",
     "@langchain/openai": "^1.1.3"
   },

--- a/contrib/examples/langchain-ts/pnpm-lock.yaml
+++ b/contrib/examples/langchain-ts/pnpm-lock.yaml
@@ -13,16 +13,16 @@ importers:
         version: 1.14.0
       '@langchain/community':
         specifier: ^1.0.5
-        version: 1.0.5(@browserbasehq/sdk@2.5.0)(@browserbasehq/stagehand@1.14.0(@playwright/test@1.52.0)(deepmerge@4.3.1)(dotenv@16.5.0)(openai@6.9.1(ws@8.18.2)(zod@4.1.13))(zod@4.1.13))(@ibm-cloud/watsonx-ai@1.6.5)(@langchain/core@1.1.0(openai@6.9.1(ws@8.18.2)(zod@4.1.13)))(ibm-cloud-sdk-core@5.3.2)(jsonwebtoken@9.0.2)(openai@6.9.1(ws@8.18.2)(zod@4.1.13))(playwright@1.52.0)(ws@8.18.2)
+        version: 1.0.5(@browserbasehq/sdk@2.5.0)(@browserbasehq/stagehand@1.14.0(@playwright/test@1.52.0)(deepmerge@4.3.1)(dotenv@16.5.0)(openai@6.9.1(ws@8.18.2)(zod@4.1.13))(zod@4.1.13))(@ibm-cloud/watsonx-ai@1.6.5)(@langchain/core@1.1.16(openai@6.9.1(ws@8.18.2)(zod@4.1.13)))(ibm-cloud-sdk-core@5.3.2)(jsonwebtoken@9.0.2)(openai@6.9.1(ws@8.18.2)(zod@4.1.13))(playwright@1.52.0)(ws@8.18.2)
       '@langchain/core':
-        specifier: ^1.1.0
-        version: 1.1.0(openai@6.9.1(ws@8.18.2)(zod@4.1.13))
+        specifier: ^1.1.8
+        version: 1.1.16(openai@6.9.1(ws@8.18.2)(zod@4.1.13))
       '@langchain/langgraph':
         specifier: ^1.0.2
-        version: 1.0.2(@langchain/core@1.1.0(openai@6.9.1(ws@8.18.2)(zod@4.1.13)))(zod-to-json-schema@3.24.5(zod@4.1.13))(zod@4.1.13)
+        version: 1.0.2(@langchain/core@1.1.16(openai@6.9.1(ws@8.18.2)(zod@4.1.13)))(zod-to-json-schema@3.24.5(zod@4.1.13))(zod@4.1.13)
       '@langchain/openai':
         specifier: ^1.1.3
-        version: 1.1.3(@langchain/core@1.1.0(openai@6.9.1(ws@8.18.2)(zod@4.1.13)))(ws@8.18.2)
+        version: 1.1.3(@langchain/core@1.1.16(openai@6.9.1(ws@8.18.2)(zod@4.1.13)))(ws@8.18.2)
     devDependencies:
       '@types/node':
         specifier: ^24.10.1
@@ -433,8 +433,8 @@ packages:
       youtubei.js:
         optional: true
 
-  '@langchain/core@1.1.0':
-    resolution: {integrity: sha512-yJ6JHcU9psjnQbzRFkXjIdNTA+3074dA+2pHdH8ewvQCSleSk6JcjkCMIb5+NASjeMoi1ZuntlLKVsNqF38YxA==}
+  '@langchain/core@1.1.16':
+    resolution: {integrity: sha512-2XKQKxvQdeQiuIo0tacAmDVojhSVAci8D2WDdmmyN+6CqDusLHEHyIDaOt4o+UBvpkyHXbCdrljzDTQY/AKeqg==}
     engines: {node: '>=20'}
 
   '@langchain/langgraph-checkpoint@1.0.0':
@@ -751,6 +751,23 @@ packages:
 
   langsmith@0.3.81:
     resolution: {integrity: sha512-NFmp7TDrrbCE6TIfHqutN9xhdgvx0EOhULVo8bDW+ib5idprwjMTvmS0S1n9uVFwjN03zU2zVEWViXnwy5XPrw==}
+    peerDependencies:
+      '@opentelemetry/api': '*'
+      '@opentelemetry/exporter-trace-otlp-proto': '*'
+      '@opentelemetry/sdk-trace-base': '*'
+      openai: '*'
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@opentelemetry/exporter-trace-otlp-proto':
+        optional: true
+      '@opentelemetry/sdk-trace-base':
+        optional: true
+      openai:
+        optional: true
+
+  langsmith@0.4.7:
+    resolution: {integrity: sha512-Esv5g/J8wwRwbGQr10PB9+bLsNk0mWbrXc7nnEreQDhh0azbU57I7epSnT7GC4sS4EOWavhbxk+6p8PTXtreHw==}
     peerDependencies:
       '@opentelemetry/api': '*'
       '@opentelemetry/exporter-trace-otlp-proto': '*'
@@ -1085,11 +1102,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@langchain/classic@1.0.5(@langchain/core@1.1.0(openai@6.9.1(ws@8.18.2)(zod@4.1.13)))(openai@6.9.1(ws@8.18.2)(zod@4.1.13))(ws@8.18.2)':
+  '@langchain/classic@1.0.5(@langchain/core@1.1.16(openai@6.9.1(ws@8.18.2)(zod@4.1.13)))(openai@6.9.1(ws@8.18.2)(zod@4.1.13))(ws@8.18.2)':
     dependencies:
-      '@langchain/core': 1.1.0(openai@6.9.1(ws@8.18.2)(zod@4.1.13))
-      '@langchain/openai': 1.1.3(@langchain/core@1.1.0(openai@6.9.1(ws@8.18.2)(zod@4.1.13)))(ws@8.18.2)
-      '@langchain/textsplitters': 1.0.1(@langchain/core@1.1.0(openai@6.9.1(ws@8.18.2)(zod@4.1.13)))
+      '@langchain/core': 1.1.16(openai@6.9.1(ws@8.18.2)(zod@4.1.13))
+      '@langchain/openai': 1.1.3(@langchain/core@1.1.16(openai@6.9.1(ws@8.18.2)(zod@4.1.13)))(ws@8.18.2)
+      '@langchain/textsplitters': 1.0.1(@langchain/core@1.1.16(openai@6.9.1(ws@8.18.2)(zod@4.1.13)))
       handlebars: 4.7.8
       js-yaml: 4.1.1
       jsonpointer: 5.0.1
@@ -1107,13 +1124,13 @@ snapshots:
       - openai
       - ws
 
-  '@langchain/community@1.0.5(@browserbasehq/sdk@2.5.0)(@browserbasehq/stagehand@1.14.0(@playwright/test@1.52.0)(deepmerge@4.3.1)(dotenv@16.5.0)(openai@6.9.1(ws@8.18.2)(zod@4.1.13))(zod@4.1.13))(@ibm-cloud/watsonx-ai@1.6.5)(@langchain/core@1.1.0(openai@6.9.1(ws@8.18.2)(zod@4.1.13)))(ibm-cloud-sdk-core@5.3.2)(jsonwebtoken@9.0.2)(openai@6.9.1(ws@8.18.2)(zod@4.1.13))(playwright@1.52.0)(ws@8.18.2)':
+  '@langchain/community@1.0.5(@browserbasehq/sdk@2.5.0)(@browserbasehq/stagehand@1.14.0(@playwright/test@1.52.0)(deepmerge@4.3.1)(dotenv@16.5.0)(openai@6.9.1(ws@8.18.2)(zod@4.1.13))(zod@4.1.13))(@ibm-cloud/watsonx-ai@1.6.5)(@langchain/core@1.1.16(openai@6.9.1(ws@8.18.2)(zod@4.1.13)))(ibm-cloud-sdk-core@5.3.2)(jsonwebtoken@9.0.2)(openai@6.9.1(ws@8.18.2)(zod@4.1.13))(playwright@1.52.0)(ws@8.18.2)':
     dependencies:
       '@browserbasehq/stagehand': 1.14.0(@playwright/test@1.52.0)(deepmerge@4.3.1)(dotenv@16.5.0)(openai@6.9.1(ws@8.18.2)(zod@4.1.13))(zod@4.1.13)
       '@ibm-cloud/watsonx-ai': 1.6.5
-      '@langchain/classic': 1.0.5(@langchain/core@1.1.0(openai@6.9.1(ws@8.18.2)(zod@4.1.13)))(openai@6.9.1(ws@8.18.2)(zod@4.1.13))(ws@8.18.2)
-      '@langchain/core': 1.1.0(openai@6.9.1(ws@8.18.2)(zod@4.1.13))
-      '@langchain/openai': 1.1.3(@langchain/core@1.1.0(openai@6.9.1(ws@8.18.2)(zod@4.1.13)))(ws@8.18.2)
+      '@langchain/classic': 1.0.5(@langchain/core@1.1.16(openai@6.9.1(ws@8.18.2)(zod@4.1.13)))(openai@6.9.1(ws@8.18.2)(zod@4.1.13))(ws@8.18.2)
+      '@langchain/core': 1.1.16(openai@6.9.1(ws@8.18.2)(zod@4.1.13))
+      '@langchain/openai': 1.1.3(@langchain/core@1.1.16(openai@6.9.1(ws@8.18.2)(zod@4.1.13)))(ws@8.18.2)
       binary-extensions: 2.3.0
       flat: 5.0.2
       ibm-cloud-sdk-core: 5.3.2
@@ -1133,17 +1150,16 @@ snapshots:
       - '@opentelemetry/sdk-trace-base'
       - peggy
 
-  '@langchain/core@1.1.0(openai@6.9.1(ws@8.18.2)(zod@4.1.13))':
+  '@langchain/core@1.1.16(openai@6.9.1(ws@8.18.2)(zod@4.1.13))':
     dependencies:
       '@cfworker/json-schema': 4.1.1
       ansi-styles: 5.2.0
       camelcase: 6.3.0
       decamelize: 1.2.0
       js-tiktoken: 1.0.20
-      langsmith: 0.3.81(openai@6.9.1(ws@8.18.2)(zod@4.1.13))
+      langsmith: 0.4.7(openai@6.9.1(ws@8.18.2)(zod@4.1.13))
       mustache: 4.2.0
       p-queue: 6.6.2
-      p-retry: 7.1.0
       uuid: 10.0.0
       zod: 4.1.13
     transitivePeerDependencies:
@@ -1152,24 +1168,24 @@ snapshots:
       - '@opentelemetry/sdk-trace-base'
       - openai
 
-  '@langchain/langgraph-checkpoint@1.0.0(@langchain/core@1.1.0(openai@6.9.1(ws@8.18.2)(zod@4.1.13)))':
+  '@langchain/langgraph-checkpoint@1.0.0(@langchain/core@1.1.16(openai@6.9.1(ws@8.18.2)(zod@4.1.13)))':
     dependencies:
-      '@langchain/core': 1.1.0(openai@6.9.1(ws@8.18.2)(zod@4.1.13))
+      '@langchain/core': 1.1.16(openai@6.9.1(ws@8.18.2)(zod@4.1.13))
       uuid: 10.0.0
 
-  '@langchain/langgraph-sdk@1.0.2(@langchain/core@1.1.0(openai@6.9.1(ws@8.18.2)(zod@4.1.13)))':
+  '@langchain/langgraph-sdk@1.0.2(@langchain/core@1.1.16(openai@6.9.1(ws@8.18.2)(zod@4.1.13)))':
     dependencies:
       p-queue: 6.6.2
       p-retry: 4.6.2
       uuid: 9.0.1
     optionalDependencies:
-      '@langchain/core': 1.1.0(openai@6.9.1(ws@8.18.2)(zod@4.1.13))
+      '@langchain/core': 1.1.16(openai@6.9.1(ws@8.18.2)(zod@4.1.13))
 
-  '@langchain/langgraph@1.0.2(@langchain/core@1.1.0(openai@6.9.1(ws@8.18.2)(zod@4.1.13)))(zod-to-json-schema@3.24.5(zod@4.1.13))(zod@4.1.13)':
+  '@langchain/langgraph@1.0.2(@langchain/core@1.1.16(openai@6.9.1(ws@8.18.2)(zod@4.1.13)))(zod-to-json-schema@3.24.5(zod@4.1.13))(zod@4.1.13)':
     dependencies:
-      '@langchain/core': 1.1.0(openai@6.9.1(ws@8.18.2)(zod@4.1.13))
-      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@1.1.0(openai@6.9.1(ws@8.18.2)(zod@4.1.13)))
-      '@langchain/langgraph-sdk': 1.0.2(@langchain/core@1.1.0(openai@6.9.1(ws@8.18.2)(zod@4.1.13)))
+      '@langchain/core': 1.1.16(openai@6.9.1(ws@8.18.2)(zod@4.1.13))
+      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@1.1.16(openai@6.9.1(ws@8.18.2)(zod@4.1.13)))
+      '@langchain/langgraph-sdk': 1.0.2(@langchain/core@1.1.16(openai@6.9.1(ws@8.18.2)(zod@4.1.13)))
       uuid: 10.0.0
       zod: 4.1.13
     optionalDependencies:
@@ -1178,18 +1194,18 @@ snapshots:
       - react
       - react-dom
 
-  '@langchain/openai@1.1.3(@langchain/core@1.1.0(openai@6.9.1(ws@8.18.2)(zod@4.1.13)))(ws@8.18.2)':
+  '@langchain/openai@1.1.3(@langchain/core@1.1.16(openai@6.9.1(ws@8.18.2)(zod@4.1.13)))(ws@8.18.2)':
     dependencies:
-      '@langchain/core': 1.1.0(openai@6.9.1(ws@8.18.2)(zod@4.1.13))
+      '@langchain/core': 1.1.16(openai@6.9.1(ws@8.18.2)(zod@4.1.13))
       js-tiktoken: 1.0.20
       openai: 6.9.1(ws@8.18.2)(zod@4.1.13)
       zod: 4.1.13
     transitivePeerDependencies:
       - ws
 
-  '@langchain/textsplitters@1.0.1(@langchain/core@1.1.0(openai@6.9.1(ws@8.18.2)(zod@4.1.13)))':
+  '@langchain/textsplitters@1.0.1(@langchain/core@1.1.16(openai@6.9.1(ws@8.18.2)(zod@4.1.13)))':
     dependencies:
-      '@langchain/core': 1.1.0(openai@6.9.1(ws@8.18.2)(zod@4.1.13))
+      '@langchain/core': 1.1.16(openai@6.9.1(ws@8.18.2)(zod@4.1.13))
       js-tiktoken: 1.0.20
 
   '@playwright/test@1.52.0':
@@ -1428,7 +1444,7 @@ snapshots:
       isstream: 0.1.2
       jsonwebtoken: 9.0.2
       mime-types: 2.1.35
-      retry-axios: 2.6.0(axios@1.9.0(debug@4.4.1))
+      retry-axios: 2.6.0(axios@1.9.0)
       tough-cookie: 4.1.4
     transitivePeerDependencies:
       - supports-color
@@ -1480,6 +1496,18 @@ snapshots:
       console-table-printer: 2.12.1
       p-queue: 6.6.2
       p-retry: 4.6.2
+      semver: 7.7.2
+      uuid: 10.0.0
+    optionalDependencies:
+      openai: 6.9.1(ws@8.18.2)(zod@4.1.13)
+    optional: true
+
+  langsmith@0.4.7(openai@6.9.1(ws@8.18.2)(zod@4.1.13)):
+    dependencies:
+      '@types/uuid': 10.0.0
+      chalk: 4.1.2
+      console-table-printer: 2.12.1
+      p-queue: 6.6.2
       semver: 7.7.2
       uuid: 10.0.0
     optionalDependencies:
@@ -1586,7 +1614,7 @@ snapshots:
 
   requires-port@1.0.0: {}
 
-  retry-axios@2.6.0(axios@1.9.0(debug@4.4.1)):
+  retry-axios@2.6.0(axios@1.9.0):
     dependencies:
       axios: 1.9.0(debug@4.4.1)
 


### PR DESCRIPTION
Update `@langchain/core` to resolve a high severity vulnerability (CVE-2025-68665).

---
Linear Issue: [TOO-341](https://linear.app/arcadedev/issue/TOO-341/vanta-remediate-high-vulnerabilities-identified-in-packages-are)

<a href="https://cursor.com/background-agent?bcId=bc-5f534ae8-bd45-4ba8-9958-1aa725a37fb4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5f534ae8-bd45-4ba8-9958-1aa725a37fb4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the LangChain example to newer core and synced dependencies.
> 
> - Bumps `@langchain/core` to `^1.1.8` in `contrib/examples/langchain-ts/package.json`
> - Regenerates `pnpm-lock.yaml`, resolving to `@langchain/core@1.1.16` and aligning related packages (`@langchain/community`, `@langchain/openai`, `@langchain/langgraph`, `langsmith`, etc.)
> - Minor lockfile adjustments (e.g., `langsmith` optional flag, cleaned `retry-axios` spec)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fe23eb14f2e5ea208c6725214c44d6027852ae20. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->