### PR TITLE
Arcade-mcp npm-qs vulnerability

### DIFF
--- a/contrib/examples/openai-agents-ts/package-lock.json
+++ b/contrib/examples/openai-agents-ts/package-lock.json
@@ -1147,9 +1147,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "version": "6.14.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
+      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
       "license": "BSD-3-Clause",
       "optional": true,
       "dependencies": {

--- a/contrib/examples/openai-agents-ts/package.json
+++ b/contrib/examples/openai-agents-ts/package.json
@@ -13,5 +13,8 @@
   "dependencies": {
     "@arcadeai/arcadejs": "1.14.0",
     "@openai/agents": "^0.3.3"
+  },
+  "overrides": {
+    "qs": ">=6.14.1"
   }
 }


### PR DESCRIPTION
Remediate CVE-2025-15284 by updating the `qs` package to `6.14.1` and enforcing it via `overrides`.

---
Linear Issue: [TOO-344](https://linear.app/arcadedev/issue/TOO-344/vanta-remediate-high-vulnerabilities-identified-in-packages-are)

<a href="https://cursor.com/background-agent?bcId=bc-b85d0ff6-18ee-41ef-86ad-78fc0e658395"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b85d0ff6-18ee-41ef-86ad-78fc0e658395"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Addresses `qs` vulnerability by pinning the minimum version and updating the lockfile.
> 
> - Adds `overrides` in `contrib/examples/openai-agents-ts/package.json` to enforce `qs >= 6.14.1`
> - Bumps `qs` in `package-lock.json` from `6.14.0` to `6.14.1`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ec6da44e03444308c1f90741d75227201f11036b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->