### PR TITLE
chore: Bump langchain-core version

### DIFF
--- a/contrib/langchain/pyproject.toml
+++ b/contrib/langchain/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langchain-arcade"
-version = "1.4.4"
+version = "1.4.5"
 description = "An integration package connecting Arcade and Langchain/LangGraph"
 readme = "README.md"
 repository = "https://github.com/arcadeai/arcade-mcp/tree/main/contrib/langchain"


### PR DESCRIPTION
Bumping `langchain-core` to get bugfixes from that project.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates dependency and package version for the LangChain integration.
> 
> - Bumps `langchain-core` requirement to `>=0.3.80,<0.4`
> - Increments `langchain-arcade` package version to `1.4.5` in `pyproject.toml`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ede8c67dbe88061f39bfe5466f157b36ae21bb1b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->