### PR TITLE
Fix deprecation warning

### DIFF
--- a/.github/actions/setup-uv-env/action.yml
+++ b/.github/actions/setup-uv-env/action.yml
@@ -50,5 +50,5 @@ runs:
 
     - name: Install libs dependencies
       if: inputs.is-toolkit != 'true'
-      run: uv sync --dev --extra all
+      run: uv sync --extra all --extra dev
       shell: bash

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -33,7 +33,7 @@ jobs:
 
             - name: Install dependencies
               run: |
-                  uv sync --dev
+                  uv sync --extra all --extra dev
 
             - name: Install arcade-mcp from source
               run: |

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 .PHONY: install
 install: ## Install the uv environment and all packages with dependencies
 	@echo "🚀 Creating virtual environment and installing all packages using uv workspace"
-	@uv sync --dev --extra all
+	@uv sync --extra all --extra dev
 	@uv run pre-commit install
 	@echo "✅ All packages and dependencies installed via uv workspace"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,8 +62,7 @@ evals = [
     "pytz>=2024.1",
 ]
 
-[tool.uv]
-dev-dependencies = [
+dev = [
     # Test framework
     "pytest>=8.1.2",
     "pytest-cov>=4.0.0",


### PR DESCRIPTION
`[tool.uv]`'s `dev-dependencies` is deprecated. I got tired of seeing the warning.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk build/CI tooling change, but it may affect environment setup if `uv sync` extra resolution differs from the old `--dev` behavior.
> 
> **Overview**
> Removes the deprecated `dev-dependencies` config and instead defines development requirements as a `dev` optional-dependency extra in `pyproject.toml`.
> 
> Updates local/CI install paths (Makefile, composite action, and install-test workflow) to install dev requirements via `uv sync --extra all --extra dev` rather than `uv sync --dev`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 472ab6e5e498b69d88ac8f08ba8414e901272f26. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- BUGBOT_STATUS --><sup><a href="https://cursor.com/dashboard?tab=bugbot">Cursor Bugbot</a> found 1 potential issue for commit <u>472ab6e</u></sup><!-- /BUGBOT_STATUS -->