### PR TITLE
Remove secret hints from CLI

### DIFF
--- a/libs/arcade-cli/arcade_cli/secret.py
+++ b/libs/arcade-cli/arcade_cli/secret.py
@@ -166,7 +166,6 @@ def print_secret_table(secrets: list[dict]) -> None:
     table.add_column("Key", style="cyan")
     table.add_column("Type", style="green")
     table.add_column("Description", style="green")
-    table.add_column("Hint", style="green")
     table.add_column("Last Accessed", style="green")
     table.add_column("Created At", style="green")
     for secret in secrets:
@@ -174,7 +173,6 @@ def print_secret_table(secrets: list[dict]) -> None:
             secret["key"],
             secret["binding"]["type"],
             secret["description"],
-            "..." + secret["hint"] if secret["hint"] else "-",
             secret["last_accessed_at"] if secret["last_accessed_at"] else "Never",
             secret["created_at"],
         )

--- a/libs/tests/cli/test_secret.py
+++ b/libs/tests/cli/test_secret.py
@@ -24,6 +24,32 @@ class TestPrintSecretTable:
         captured = capsys.readouterr()
         assert "Tool Secrets" in captured.out
 
+    def test_print_secret_table_with_secrets(self, capsys):
+        """Test printing a table with secrets (no hint field)."""
+        secrets = [
+            {
+                "key": "MY_API_KEY",
+                "binding": {"type": "env"},
+                "description": "API key for testing",
+                "last_accessed_at": "2026-01-15T10:00:00Z",
+                "created_at": "2026-01-01T00:00:00Z",
+            },
+            {
+                "key": "DB_PASSWORD",
+                "binding": {"type": "env"},
+                "description": "Database password",
+                "last_accessed_at": None,
+                "created_at": "2026-01-02T00:00:00Z",
+            },
+        ]
+        print_secret_table(secrets)
+
+        captured = capsys.readouterr()
+        assert "MY_API_KEY" in captured.out
+        assert "DB_PASSWORD" in captured.out
+        assert "Never" in captured.out
+        assert "Hint" not in captured.out
+
 
 class TestLoadEnvFile:
     """Tests for load_env_file function."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "arcade-mcp"
-version = "1.10.0"
+version = "1.11.0"
 description = "Arcade.dev - Tool Calling platform for Agents"
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## Summary
- Removes the `Hint` column from `arcade secret list` table output — secret hints were removed from the API in [monorepo#322](https://github.com/ArcadeAI/monorepo/pull/322), causing a `KeyError: 'hint'` crash
- Adds a test for `print_secret_table` with populated secrets (verifying no hint column)
- Bumps version from 1.10.0 → 1.11.0

Closes TOO-444

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CLI output change plus a targeted test and version bump; no changes to secret storage or network calls.
> 
> **Overview**
> `arcade secret list` no longer renders a `Hint` column or reads `secret["hint"]`, preventing crashes when the API omits that field.
> 
> Adds a regression test ensuring secrets render without hints (including `Never` for missing last-accessed), and bumps the project version to `1.11.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cee714d785bb865a1e2c1d6f3afae74e22aced9d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->