### PR TITLE
Add CLAUDE.md with project guidance for Claude Code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,6 @@ Transports: `stdio` (default) and `http` (tools that require auth or secrets nee
 - `libs/arcade-*/` — Core libraries. Most have their own `pyproject.toml`. libs/arcade-cli and arcade-evals use the top-level `pyproject.toml`.
 - `libs/tests/` — All library tests, grouped by component (core, cli, arcade_mcp_server, tool, sdk, worker)
 - `examples/mcp_servers/` — Example MCP server implementations
-- `contrib/` — Community integrations (e.g., crewai)
 
 ## Development Rules
 


### PR DESCRIPTION
## Summary
- Adds `CLAUDE.md` with project overview, common commands, library dependency graph, versioning rules, key code patterns, project layout, and code quality notes
- Documents that `uv` must always be used (never bare `pip`/`python`)
- Documents that all changes must have tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or build behavior modifications.
> 
> **Overview**
> Adds a new `CLAUDE.md` developer guidance document for Claude Code, summarizing repo purpose, common `make`/`uv` commands, library dependency relationships, and an example `MCPApp` tool pattern.
> 
> Also documents contribution expectations (tests/TDD), versioning bump rules, project layout, and code-quality tooling/CI conventions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cf0f2fc56f418882e8eeac8f7c0127b0673cef52. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->