### PR TITLE
feat(evals): add InferenceBackend protocol for provider-agnostic eval runs

### DIFF
--- a/libs/arcade-evals/arcade_evals/__init__.py
+++ b/libs/arcade-evals/arcade_evals/__init__.py
@@ -1,3 +1,4 @@
+from ._evalsuite._backend import AnthropicBackend, InferenceBackend, OpenAICompatBackend
 from ._evalsuite._providers import ProviderName
 from ._evalsuite._tool_registry import MCPToolDefinition
 from .capture import CapturedCase, CapturedRun, CapturedToolCall, CaptureResult
@@ -21,6 +22,7 @@ from .loaders import (
 from .weights import FuzzyWeight, Weight, validate_and_normalize_critic_weights
 
 __all__ = [
+    "AnthropicBackend",
     "AnyExpectedToolCall",
     "BinaryCritic",
     "CaptureResult",
@@ -31,12 +33,14 @@ __all__ = [
     "EvalRubric",
     "EvalSuite",
     "ExpectedMCPToolCall",
+    "InferenceBackend",
     "ExpectedToolCall",
     "FuzzyWeight",
     "MCPToolDefinition",
     "NamedExpectedToolCall",
     "NoneCritic",
     "NumericCritic",
+    "OpenAICompatBackend",
     "ProviderName",
     "SimilarityCritic",
     "Weight",

--- a/libs/arcade-evals/arcade_evals/_evalsuite/_backend.py
+++ b/libs/arcade-evals/arcade_evals/_evalsuite/_backend.py
@@ -1,0 +1,200 @@
+"""Provider-agnostic inference backends for arcade_evals.
+
+``EvalSuite.run()`` supports ``provider="openai"`` and ``provider="anthropic"``
+via a closed enum. This module introduces an ``InferenceBackend`` Protocol that
+enables running evals against *any* LLM provider -- Google Gemini, Together AI,
+Groq, Fireworks, local Ollama, or any other OpenAI-compatible endpoint.
+
+Quick start::
+
+    from openai import AsyncOpenAI
+    from arcade_evals import OpenAICompatBackend
+
+    client = AsyncOpenAI(
+        api_key=os.environ["GOOGLE_API_KEY"],
+        base_url="https://generativelanguage.googleapis.com/v1beta/openai/",
+    )
+    backend = OpenAICompatBackend(client, model="gemini-2.5-flash", seed=None, strict=False)
+    results = await suite.run(backend=backend)
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, Protocol, runtime_checkable
+
+from arcade_evals._evalsuite._tool_registry import EvalSuiteToolRegistry
+
+
+@runtime_checkable
+class InferenceBackend(Protocol):
+    """Interface for LLM inference providers used in evals.
+
+    Each backend is responsible for:
+
+    * Converting tool definitions to the provider's expected format
+    * Sending the chat completion request with appropriate parameters
+    * Parsing tool calls from the provider's response format
+
+    Tool name resolution (e.g. ``Google_Search`` -> ``Google.Search``) is
+    handled by ``EvalSuiteToolRegistry.process_tool_call()`` after the
+    backend returns, so backends should return raw tool names from the
+    provider's response.
+    """
+
+    @property
+    def model_name(self) -> str:
+        """The model identifier for results tracking."""
+        ...
+
+    async def call_with_tools(
+        self,
+        messages: list[dict[str, Any]],
+        registry: EvalSuiteToolRegistry,
+    ) -> list[tuple[str, dict[str, Any]]]:
+        """Send a chat completion request with tools and return parsed tool calls.
+
+        Args:
+            messages: Conversation messages in OpenAI format
+                (system/user/assistant roles).
+            registry: The tool registry. Use
+                ``registry.list_tools_for_model(tool_format=...)``
+                to get provider-appropriate schemas.
+
+        Returns:
+            List of ``(tool_name, arguments)`` tuples as returned by the
+            provider. Name resolution is handled by the caller.
+        """
+        ...
+
+
+@dataclass
+class OpenAICompatBackend:
+    """Backend for any OpenAI-compatible endpoint.
+
+    Works with OpenAI, Google Gemini, Together AI, Groq, Fireworks,
+    local Ollama, and any provider exposing ``/chat/completions``
+    with tool calling support.
+
+    Provider-specific behavior is controlled via constructor parameters::
+
+        # OpenAI (defaults)
+        OpenAICompatBackend(client, model="gpt-4o")
+
+        # Gemini (no seed, no strict)
+        OpenAICompatBackend(client, model="gemini-2.5-flash", seed=None, strict=False)
+
+        # Together / Groq
+        OpenAICompatBackend(client, model="meta-llama/...", seed=None)
+
+    Args:
+        client: An ``AsyncOpenAI``-compatible client instance.
+        model: The model identifier string.
+        seed: Seed for reproducibility. ``None`` to omit (for providers
+            that don't support it).
+        strict: Whether to keep ``strict: true`` and
+            ``additionalProperties: false`` in tool schemas.
+            Set ``False`` for providers that reject strict-mode artifacts.
+        user: Optional user identifier for audit logging.
+    """
+
+    client: Any
+    model: str
+    seed: int | None = 42
+    strict: bool = True
+    user: str | None = "eval_user"
+
+    @property
+    def model_name(self) -> str:
+        return self.model
+
+    async def call_with_tools(
+        self,
+        messages: list[dict[str, Any]],
+        registry: EvalSuiteToolRegistry,
+    ) -> list[tuple[str, dict[str, Any]]]:
+        tools = registry.list_tools_for_model(tool_format="openai")
+
+        if not self.strict:
+            for schema in tools:
+                func = schema.get("function", {})
+                func.pop("strict", None)
+                params = func.get("parameters", {})
+                params.pop("additionalProperties", None)
+
+        kwargs: dict[str, Any] = {
+            "model": self.model,
+            "messages": messages,
+            "tool_choice": "auto",
+            "tools": tools,
+            "stream": False,
+        }
+        if self.seed is not None:
+            kwargs["seed"] = self.seed
+        if self.user is not None:
+            kwargs["user"] = self.user
+
+        response = await self.client.chat.completions.create(**kwargs)
+
+        # Parse OpenAI-format response
+        tool_calls: list[tuple[str, dict[str, Any]]] = []
+        message = response.choices[0].message
+        if message.tool_calls:
+            for tc in message.tool_calls:
+                tool_calls.append((tc.function.name, json.loads(tc.function.arguments)))
+        return tool_calls
+
+
+@dataclass
+class AnthropicBackend:
+    """Backend for the Anthropic Messages API.
+
+    Converts tool schemas to Anthropic's format and parses
+    ``tool_use`` content blocks from the response.
+
+    Args:
+        client: An ``AsyncAnthropic`` client instance.
+        model: The model identifier string.
+        max_tokens: Maximum tokens for the response.
+    """
+
+    client: Any
+    model: str
+    max_tokens: int = 4096
+
+    @property
+    def model_name(self) -> str:
+        return self.model
+
+    async def call_with_tools(
+        self,
+        messages: list[dict[str, Any]],
+        registry: EvalSuiteToolRegistry,
+    ) -> list[tuple[str, dict[str, Any]]]:
+        from arcade_evals._evalsuite._providers import convert_messages_to_anthropic
+
+        tools = registry.list_tools_for_model(tool_format="anthropic")
+
+        # Extract system message (Anthropic takes it as a separate parameter)
+        system_message = ""
+        api_messages = messages
+        if messages and messages[0].get("role") == "system":
+            system_message = messages[0]["content"]
+            api_messages = messages[1:]
+
+        anthropic_messages = convert_messages_to_anthropic(api_messages)
+
+        response = await self.client.messages.create(
+            model=self.model,
+            max_tokens=self.max_tokens,
+            system=system_message,
+            messages=anthropic_messages,
+            tools=tools,
+        )
+
+        tool_calls: list[tuple[str, dict[str, Any]]] = []
+        for block in response.content:
+            if block.type == "tool_use":
+                tool_calls.append((block.name, block.input))
+        return tool_calls


### PR DESCRIPTION
## Summary

- Adds `InferenceBackend` runtime-checkable Protocol to `arcade_evals`
- Adds `OpenAICompatBackend` for any OpenAI-compatible endpoint (OpenAI, Gemini, Together, Groq, Ollama, etc.)
- Adds `AnthropicBackend` wrapping the Anthropic Messages API
- Extends `EvalSuite.run()` with a keyword-only `backend=` parameter
- **100% backwards compatible**: existing `suite.run(client, model)` works unchanged

## Motivation

`arcade_evals` currently supports two inference providers via a closed enum (`"openai" | "anthropic"`). Agent developers who evaluate against other providers — Google Gemini, Together AI, Groq, local models via Ollama — have no way to plug into the eval framework without monkey-patching `EvalSuite.run()` or reimplementing the evaluation loop.

This came up while building an incident response agent that uses Gemini via Google's OpenAI-compatible endpoint. The built-in OpenAI path's assumptions (`seed=42`, `strict: true` in schemas) broke against Gemini's endpoint. Each provider has its own quirks:

| Provider | `seed` | `strict` | `additionalProperties` |
|----------|--------|----------|----------------------|
| OpenAI | Yes | Yes | Yes |
| Gemini | No | No | No |
| Together | No | Yes | Yes |
| Anthropic | N/A | N/A | N/A |

Rather than adding provider-specific branches to `run()`, this PR introduces a Protocol that lets each provider handle its own quirks.

## Usage

```python
from openai import AsyncOpenAI
from arcade_evals import EvalSuite, OpenAICompatBackend

# Gemini (no seed, no strict)
client = AsyncOpenAI(
    api_key=os.environ["GOOGLE_API_KEY"],
    base_url="https://generativelanguage.googleapis.com/v1beta/openai/",
)
backend = OpenAICompatBackend(client, model="gemini-2.5-flash", seed=None, strict=False)
results = await suite.run(backend=backend)

# Standard OpenAI (defaults work)
backend = OpenAICompatBackend(AsyncOpenAI(), model="gpt-4o")
results = await suite.run(backend=backend)

# Anthropic
from anthropic import AsyncAnthropic
from arcade_evals import AnthropicBackend

backend = AnthropicBackend(AsyncAnthropic(), model="claude-sonnet-4-20250514")
results = await suite.run(backend=backend)

# Custom provider
class MyBackend:
    @property
    def model_name(self) -> str:
        return "my-model"

    async def call_with_tools(self, messages, registry):
        # Your inference logic here
        ...

results = await suite.run(backend=MyBackend())
```

## Design Decisions

**Protocol over ABC.** Uses `typing.Protocol` with `@runtime_checkable` so users can implement backends without inheriting from an arcade_evals base class. Duck typing > class hierarchies.

**Single `OpenAICompatBackend` with knobs.** Instead of separate `OpenAIBackend`, `GeminiBackend`, `TogetherBackend` classes, one configurable dataclass handles all OpenAI-compatible providers. The `seed` and `strict` parameters capture the meaningful differences.

**Keyword-only `backend=`.** Added as keyword-only to avoid ambiguity with the existing positional `client` and `model` parameters. When `backend` is provided, the built-in provider logic is bypassed entirely.

**Registry-based.** Backends receive `EvalSuiteToolRegistry` rather than raw tool lists, aligning with the unified registry pattern. Backends call `registry.list_tools_for_model(tool_format=...)` to get provider-appropriate schemas.

## Files Changed

| File | Change |
|------|--------|
| `arcade_evals/_evalsuite/_backend.py` | **NEW** — Protocol, OpenAICompatBackend, AnthropicBackend (~200 lines) |
| `arcade_evals/eval.py` | Add `backend=` kwarg to `run()`, add `_run_with_backend()`, thread through `_run_case_with_stats()` |
| `arcade_evals/__init__.py` | Export `InferenceBackend`, `OpenAICompatBackend`, `AnthropicBackend` |

## Test Plan

- [ ] Existing tests pass unchanged (backwards compatibility)
- [ ] `OpenAICompatBackend` with mocked `AsyncOpenAI` returns correct tool calls
- [ ] `OpenAICompatBackend(seed=None, strict=False)` strips `seed` from request and `strict`/`additionalProperties` from schemas
- [ ] `AnthropicBackend` with mocked `AsyncAnthropic` parses `tool_use` blocks
- [ ] Custom class satisfying `InferenceBackend` protocol works with `suite.run(backend=...)`
- [ ] `suite.run()` with neither `client` nor `backend` raises `ValueError`
- [ ] `suite.run(backend=...)` returns same result shape as `suite.run(client, model)`

---

*Built while developing [BossBattle](https://github.com/pong-init/bossbattle), an AI incident response agent that uses Arcade's MCP Gateway with Gemini inference.*