### PR TITLE
Adress comments

### DIFF
--- a/libs/arcade-cli/arcade_cli/new.py
+++ b/libs/arcade-cli/arcade_cli/new.py
@@ -3,9 +3,7 @@ import shutil
 from datetime import datetime
 from importlib.metadata import version as get_version
 from pathlib import Path
-from typing import Optional
 
-import typer
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 
 from arcade_cli.console import console
@@ -22,40 +20,6 @@ except Exception as e:
 
 ARCADE_MCP_SERVER_MIN_VERSION = "1.17.0"
 ARCADE_MCP_SERVER_MAX_VERSION = "2.0.0"
-
-
-def ask_question(question: str, default: Optional[str] = None) -> str:
-    """
-    Ask a question via input() and return the answer.
-    """
-    answer = typer.prompt(question, default=default, show_default=False)
-    if not answer and default:
-        return default
-    return str(answer)
-
-
-def ask_yes_no_question(question: str, default: bool = True) -> bool:
-    """
-    Ask a yes/no question via input() and return the bool answer.
-    """
-    default_str = "Y/n" if default else "y/N"
-    answer = typer.prompt(
-        f"{question} ({default_str})", default="y" if default else "n", show_default=False
-    )
-    return answer.lower() in [
-        "y",
-        "y/",
-        "yes",
-        "true",
-        "1",
-        "ye",
-        "yes",
-        "yeah",
-        "yep",
-        "sure",
-        "ok",
-        "yup",
-    ]
 
 
 def render_template(env: Environment, template_string: str, context: dict) -> str:

--- a/libs/arcade-cli/arcade_cli/templates/full/{{ toolkit_name }}/Makefile
+++ b/libs/arcade-cli/arcade_cli/templates/full/{{ toolkit_name }}/Makefile
@@ -7,6 +7,7 @@ help: ## Show this help message
 
 install: ## Install dependencies, then overlay any ../.local-overrides
 	uv sync --all-extras
+	uv run pre-commit install
 	@if [ -f ../.local-overrides ]; then \
 		while IFS= read -r pkg || [ -n "$$pkg" ]; do \
 			case "$$pkg" in \#*|"") continue ;; esac; \


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: removes unused prompt helpers from `new.py` and adds `pre-commit` hook installation to the generated toolkit Makefile; minimal runtime impact beyond developer setup behavior.
> 
> **Overview**
> Simplifies `arcade_cli/new.py` by removing the unused `typer`-based `ask_question`/`ask_yes_no_question` helpers and their related imports.
> 
> Updates the full toolkit template `Makefile` so `make install` also runs `uv run pre-commit install`, ensuring git hooks are set up during dependency installation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ac27861106eade1d89115a29880b673808614cab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->