### PR TITLE
Better error message

### DIFF
--- a/libs/arcade-cli/arcade_cli/configure.py
+++ b/libs/arcade-cli/arcade_cli/configure.py
@@ -526,6 +526,12 @@ def configure_client(
         server_name = Path.cwd().name
 
     if transport == "stdio":
+        if "/" in entrypoint_file or "\\" in entrypoint_file:
+            raise ValueError(
+                f"Entrypoint file '{entrypoint_file}' must be a filename in the current "
+                f"directory, not a path"
+            )
+
         if not (Path.cwd() / entrypoint_file).exists():
             raise ValueError(f"Entrypoint file '{entrypoint_file}' is not in the current directory")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "arcade-mcp"
-version = "1.13.0"
+version = "1.13.1"
 description = "Arcade.dev - Tool Calling platform for Agents"
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
We should be checking if the entrypoint file is in the current directory before we validate that it's a valid python file. Otherwise, the error message will be "invalid name for python file" when someone provides a path to a valid python file.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts input validation/error messaging for `arcade configure` stdio entrypoints and bumps the package patch version.
> 
> **Overview**
> Improves `arcade configure` stdio entrypoint validation by **rejecting path-like values** (e.g., containing `/` or `\\`) before checking filename format, producing a clearer error when users pass a path instead of a file in the current directory.
> 
> Bumps the project version from `1.13.0` to `1.13.1`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4d02ee947740f839fd46d9faf62cfa766d5dae47. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->