### PR TITLE
Bump authlib dep

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "arcade-mcp"
-version = "1.12.0"
+version = "1.12.1"
 description = "Arcade.dev - Tool Calling platform for Agents"
 readme = "README.md"
 license = { file = "LICENSE" }
@@ -24,7 +24,7 @@ dependencies = [
     "typer==0.10.0",
     "rich>=14.0.0,<15.0.0",
     "Jinja2==3.1.6",
-    "authlib==1.6.6",
+    "authlib==1.6.9",
     "arcadepy==1.8.0",
     "tqdm==4.67.1",
     "click==8.1.8",


### PR DESCRIPTION
Updated authlib==1.6.6 to authlib==1.6.9 in the CLI's pyproject.toml. The breaking changes in 1.6.7–1.6.9 are all in the JWT/JOSE/OIDC modules, which the CLI doesn't use. The only authlib import is OAuth2Client from authlib.integrations.httpx_client (in libs/arcade-cli/arcade_cli/authn.py), used for OAuth 2.0 + PKCE. That module is unaffected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency/version bump; only affects the CLI’s OAuth2 `OAuth2Client` usage and does not change runtime code paths beyond pulling in the newer library.
> 
> **Overview**
> Bumps the package version from `1.12.0` to `1.12.1` and upgrades the pinned `authlib` dependency from `1.6.6` to `1.6.9` in `pyproject.toml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f55973deb75f6388b286eca0ca7c16948518e64f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->