### PR TITLE
Add pctx Code Mode with eval suite with ProjectTracker example

### DIFF
--- a/examples/evals/eval_pctx_code_mode.py
+++ b/examples/evals/eval_pctx_code_mode.py
@@ -1,0 +1,401 @@
+"""
+ProjectTracker Code Mode evaluations.
+
+Uses pctx Code Mode: the LLM writes TypeScript executed in the pctx sandbox.
+Tool calls within the TypeScript are captured via ExecutionTrace and evaluated
+using arcade-evals critics and rubrics.
+
+Unlike the standard arcade-evals runner (which captures LLM tool calls directly),
+Code Mode requires a custom execution loop:
+  LLM generates TypeScript → pctx executes it → trace.events extracted as tool calls
+  → EvalCase.evaluate() scores against expected calls using critics and rubrics.
+
+Requires:
+  - pctx server running: pctx start
+  - OpenRouter (or OpenAI) key: OPENROUTER_API_KEY or OPENAI_API_KEY
+
+Run:
+    uv run --directory examples/mcp_servers/pctx_code_mode examples/evals/eval_pctx_code_mode.py
+"""
+
+import asyncio
+import json
+import os
+import re
+import sys
+from typing import Any
+
+sys.path.insert(
+    0,
+    os.path.join(os.path.dirname(__file__), "../mcp_servers/pctx_code_mode/src"),
+)
+
+from arcade_evals import BinaryCritic, EvalRubric, SimilarityCritic
+from arcade_evals.eval import EvalCase, EvaluationResult, NamedExpectedToolCall
+from openai import AsyncOpenAI
+from pctx_client import Pctx
+from pctx_client.models import CallbackInvocationEvent
+from pctx_code_mode.server import pctx_tools
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+PCTX_URL = os.environ.get("PCTX_URL", "http://127.0.0.1:8080")
+OPENROUTER_API_KEY = os.environ.get("OPENROUTER_API_KEY", "")
+OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY", "")
+_USING_OPENROUTER = bool(OPENROUTER_API_KEY)
+MODEL = os.environ.get("EVAL_MODEL", "openai/gpt-4o" if _USING_OPENROUTER else "gpt-4o")
+
+
+def _llm_client() -> AsyncOpenAI:
+    if _USING_OPENROUTER:
+        return AsyncOpenAI(
+            api_key=OPENROUTER_API_KEY,
+            base_url="https://openrouter.ai/api/v1",
+        )
+    return AsyncOpenAI(api_key=OPENAI_API_KEY)
+
+
+# ---------------------------------------------------------------------------
+# System prompt
+# ---------------------------------------------------------------------------
+
+
+def _build_system_prompt(declarations: str) -> str:
+    return f"""You are a project-management assistant operating in Code Mode.
+
+You have access to the following TypeScript functions via the `Tools` namespace:
+```typescript
+{declarations}
+```
+
+To complete tasks you MUST write a TypeScript function called `run()` and wrap
+it in a JSON object with key "typescript".
+
+The code must follow this exact template:
+```
+async function run() {{
+  // your code here — call Tools.functionName({{...}})
+  return {{ ... }};  // always return a plain object or array
+}}
+```
+
+Rules:
+- Always return a value from run() — return the full result object, not a sub-field
+- Do not import anything — Tools is globally available
+- For multi-step tasks, chain the calls inside a single run() function
+
+Respond ONLY with valid JSON: {{"typescript": "<the full TypeScript code>"}}
+"""
+
+
+# ---------------------------------------------------------------------------
+# Rubric — soft failures: code mode may call helper fns in addition to main ones
+# ---------------------------------------------------------------------------
+
+rubric = EvalRubric(
+    fail_threshold=0.7,
+    warn_threshold=0.9,
+    fail_on_tool_selection=False,  # score via cost matrix, don't hard-fail
+    fail_on_tool_call_quantity=False,  # code may make extra/fewer calls
+    tool_selection_weight=1.0,
+)
+
+# ---------------------------------------------------------------------------
+# Eval cases
+# Expected tool names are camelCase TypeScript names from the Tools.* namespace.
+# CallbackInvocationEvent.id is the function identifier from pctx trace events.
+# ---------------------------------------------------------------------------
+
+_PLACEHOLDER_SYSTEM = ""  # replaced at runtime by _build_system_prompt(declarations)
+
+CASES: list[EvalCase] = [
+    EvalCase(
+        name="List active projects",
+        system_message=_PLACEHOLDER_SYSTEM,
+        user_message="List all active projects and return their names and IDs.",
+        expected_tool_calls=[
+            NamedExpectedToolCall("tools__list_projects", {}),
+        ],
+        rubric=rubric,
+    ),
+    EvalCase(
+        name="Get sprint details",
+        system_message=_PLACEHOLDER_SYSTEM,
+        user_message="Get the details of sprint spr_001 and return its name, status, and goals.",
+        expected_tool_calls=[
+            NamedExpectedToolCall("tools__get_sprint", {"sprint_id": "spr_001"}),
+        ],
+        critics=[BinaryCritic("sprint_id", 1.0)],
+        rubric=rubric,
+    ),
+    EvalCase(
+        name="Create a project",
+        system_message=_PLACEHOLDER_SYSTEM,
+        user_message=(
+            "Create a new project called 'Eval Test Project' owned by user_eval. "
+            "Return the project_id."
+        ),
+        expected_tool_calls=[
+            NamedExpectedToolCall(
+                "tools__create_project", {"name": "Eval Test Project", "owner_id": "user_eval"}
+            ),
+        ],
+        critics=[
+            SimilarityCritic("name", 0.5),
+            BinaryCritic("owner_id", 0.5),
+        ],
+        rubric=rubric,
+    ),
+    EvalCase(
+        name="Task lifecycle — get then update",
+        system_message=_PLACEHOLDER_SYSTEM,
+        user_message=(
+            "Get task task_001, then update its status to in_review. "
+            "Return the updated task's status."
+        ),
+        expected_tool_calls=[
+            NamedExpectedToolCall("tools__get_task", {"task_id": "task_001"}),
+            NamedExpectedToolCall(
+                "tools__update_task", {"task_id": "task_001", "status": "in_review"}
+            ),
+        ],
+        critics=[
+            BinaryCritic("task_id", 0.5),
+            BinaryCritic("status", 0.5),
+        ],
+        rubric=rubric,
+    ),
+    EvalCase(
+        name="Sprint metrics",
+        system_message=_PLACEHOLDER_SYSTEM,
+        user_message=(
+            "Get sprint metrics for spr_001 with burndown and task breakdown. "
+            "Return the completion_rate and total_tasks."
+        ),
+        expected_tool_calls=[
+            NamedExpectedToolCall(
+                "tools__get_sprint_metrics",
+                {"sprint_id": "spr_001", "include_burndown": True, "include_task_breakdown": True},
+            ),
+        ],
+        critics=[BinaryCritic("sprint_id", 1.0)],
+        rubric=rubric,
+    ),
+    EvalCase(
+        name="Search critical tasks",
+        system_message=_PLACEHOLDER_SYSTEM,
+        user_message="Search for all critical-priority tasks and return their IDs and titles.",
+        expected_tool_calls=[
+            NamedExpectedToolCall("tools__search_tasks", {"priority": "critical"}),
+        ],
+        critics=[BinaryCritic("priority", 1.0)],
+        rubric=rubric,
+    ),
+    EvalCase(
+        name="Multi-step: create project + sprint + task",
+        system_message=_PLACEHOLDER_SYSTEM,
+        user_message=(
+            "Do these three steps in sequence:\n"
+            "1. Create a project called 'Pipeline Eval' owned by user_pipeline\n"
+            "2. Create a sprint called 'Sprint 1' in that project, "
+            "   starting 2025-06-01 ending 2025-06-14, capacity 40 hours\n"
+            "3. Create a high-priority task 'Build ingestion layer' in that sprint\n"
+            "Return the task_id of the created task."
+        ),
+        expected_tool_calls=[
+            NamedExpectedToolCall(
+                "tools__create_project", {"name": "Pipeline Eval", "owner_id": "user_pipeline"}
+            ),
+            NamedExpectedToolCall(
+                "tools__create_sprint",
+                {
+                    "name": "Sprint 1",
+                    "start_date": "2025-06-01",
+                    "end_date": "2025-06-14",
+                    "capacity_hours": 40,
+                },
+            ),
+            NamedExpectedToolCall(
+                "tools__create_task",
+                {"title": "Build ingestion layer", "priority": "high"},
+            ),
+        ],
+        critics=[
+            SimilarityCritic("name", 0.4),
+            SimilarityCritic("title", 0.3),
+            BinaryCritic("priority", 0.3),
+        ],
+        rubric=rubric,
+    ),
+]
+
+
+# ---------------------------------------------------------------------------
+# Execution helpers
+# ---------------------------------------------------------------------------
+
+
+def _extract_typescript(raw: str) -> str | None:
+    """Extract TypeScript code from LLM response (JSON or markdown fallback)."""
+    cleaned = raw.strip()
+    try:
+        inner = cleaned
+        if cleaned.startswith("```"):
+            inner = "\n".join(cleaned.split("\n")[1:])
+            inner = inner.rsplit("```", 1)[0].strip()
+        payload = json.loads(inner)
+        return payload.get("typescript") or payload.get("code")
+    except (json.JSONDecodeError, AttributeError):
+        pass
+
+    # Fallback: extract from markdown code fence
+    m = re.search(r"```(?:typescript|ts)?\n(.*?)```", raw, re.DOTALL)
+    return m.group(1).strip() if m else None
+
+
+def _extract_tool_calls(result: Any) -> list[tuple[str, dict[str, Any]]]:
+    """Extract (name, args) pairs from CallbackInvocationEvent entries in trace.
+
+    pctx reports callback ids as "namespace__snake_case_name" (e.g. "tools__list_projects").
+    """
+    calls = []
+    for event in result.trace.events:
+        if isinstance(event, CallbackInvocationEvent):
+            args = event.args if isinstance(event.args, dict) else {}
+            calls.append((event.id, args))
+    return calls
+
+
+# ---------------------------------------------------------------------------
+# Case runner
+# ---------------------------------------------------------------------------
+
+
+async def _run_case(
+    case: EvalCase,
+    pctx: Pctx,
+    client: AsyncOpenAI,
+    system_prompt: str,
+) -> tuple[EvaluationResult, list[tuple[str, dict[str, Any]]], str | None]:
+    """
+    Returns (evaluation_result, actual_calls, failure_detail).
+    failure_detail is non-None when execution failed before evaluate() could run.
+    """
+    response = await client.chat.completions.create(
+        model=MODEL,
+        messages=[
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": case.user_message},
+        ],
+        temperature=0,
+    )
+
+    raw = response.choices[0].message.content or ""
+    ts_code = _extract_typescript(raw)
+
+    if not ts_code:
+        err = f"Could not extract TypeScript from LLM response.\nRaw: {raw[:300]}"
+        empty = EvaluationResult(score=0.0, passed=False, failure_reason=err)
+        return empty, [], err
+
+    try:
+        result = await pctx.execute_typescript(ts_code)
+    except Exception as exc:
+        err = f"execute_typescript failed: {exc}"
+        empty = EvaluationResult(score=0.0, passed=False, failure_reason=err)
+        return empty, [], err
+
+    if not result.success:
+        err = f"execution error:\n{result.stderr}\ncode:\n{ts_code}"
+        empty = EvaluationResult(score=0.0, passed=False, failure_reason=err)
+        return empty, [], err
+
+    actual_calls = _extract_tool_calls(result)
+    evaluation = case.evaluate(actual_calls)
+    return evaluation, actual_calls, None
+
+
+# ---------------------------------------------------------------------------
+# Suite runner + reporting
+# ---------------------------------------------------------------------------
+
+
+def _fmt_calls(calls: list[tuple[str, dict[str, Any]]]) -> str:
+    if not calls:
+        return "(none)"
+    return ", ".join(f"{name}({json.dumps(args, separators=(',', ':'))})" for name, args in calls)
+
+
+def _fmt_expected(case: EvalCase) -> str:
+    return ", ".join(
+        f"{tc.name}({json.dumps(tc.args, separators=(',', ':'))})"
+        for tc in case.expected_tool_calls
+    )
+
+
+async def run_suite(pctx: Pctx, client: AsyncOpenAI, system_prompt: str) -> None:
+    total = len(CASES)
+    passed = warned = failed = 0
+
+    print(f"\n{'=' * 60}")
+    print(f"  Code Mode Eval  ({total} cases, model={MODEL})")
+    print(f"{'=' * 60}\n")
+
+    for i, case in enumerate(CASES, 1):
+        evaluation, actual_calls, pre_error = await _run_case(case, pctx, client, system_prompt)
+
+        if evaluation.passed:
+            status = "PASS"
+            passed += 1
+        elif evaluation.warning:
+            status = "WARN"
+            warned += 1
+        else:
+            status = "FAIL"
+            failed += 1
+
+        score_pct = f"{evaluation.score * 100:.0f}%"
+        print(f"[{status}] {i}/{total} · {case.name}  (score={score_pct})")
+
+        if status != "PASS":
+            reason = evaluation.failure_reason or pre_error or "score below threshold"
+            print(f"       reason : {reason}")
+            print(f"       expected: {_fmt_expected(case)}")
+            print(f"       actual  : {_fmt_calls(actual_calls)}")
+        else:
+            print(f"       calls   : {_fmt_calls(actual_calls)}")
+
+        print()
+
+    print(f"{'=' * 60}")
+    print(f"  Results: {passed} passed / {warned} warned / {failed} failed  ({total} total)")
+    print(f"  Rubric : fail<{rubric.fail_threshold:.0%}  warn<{rubric.warn_threshold:.0%}")
+    print(f"{'=' * 60}\n")
+
+    sys.exit(0 if failed == 0 else 1)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+async def main() -> None:
+    print(f"Connecting to pctx at {PCTX_URL} …")
+    client = _llm_client()
+
+    async with Pctx(tools=pctx_tools, url=PCTX_URL) as pctx:
+        fns = await pctx.list_functions()
+        print(f"  {len(fns.functions)} functions registered")
+        all_names = [f"{f.namespace}.{f.name}" for f in fns.functions]
+        details = await pctx.get_function_details(all_names)
+        declarations = details.code
+        print(f"  type declarations: {len(declarations)} chars\n")
+
+        await run_suite(pctx, client, _build_system_prompt(declarations))
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/evals/eval_project_tracker_mcp.py
+++ b/examples/evals/eval_project_tracker_mcp.py
@@ -1,0 +1,1580 @@
+"""
+ProjectTracker MCP tool-selection evaluations (direct MCP — no Code Mode).
+
+Tests that an LLM picks the correct MCP tool and arguments across chains of
+1–8 steps. This benchmark does NOT use pctx Code Mode; the model calls tools
+directly. For the Code Mode benchmark see eval_pctx_code_mode_live.py.
+
+Workflows:
+  1. project_setup       – 3 steps: create project → sprint → task
+  2. task_lifecycle      – 5 steps: get → comment → log time → review → done
+  3. sprint_management   – 6 steps: list → get sprint → create → move → metrics → search
+  4. full_sprint_cycle   – 8 steps: full lifecycle using every tool
+
+Run:
+    OPENAI_BASE_URL=https://openrouter.ai/api/v1 \\
+    arcade evals examples/evals/eval_project_tracker_mcp.py \\
+        -p openai:gpt-4o \\
+        -k openai:YOUR_KEY \\
+        -d
+"""
+
+import asyncio
+import json
+import os
+
+from arcade_evals import (
+    BinaryCritic,
+    EvalRubric,
+    EvalSuite,
+    ExpectedMCPToolCall,
+    NumericCritic,
+    SimilarityCritic,
+    tool_eval,
+)
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+EXAMPLES_DIR = os.path.dirname(os.path.dirname(__file__))
+SERVER_PATH = os.path.join(EXAMPLES_DIR, "mcp_servers", "pctx_code_mode")
+SERVER_COMMAND = ["uv", "run", "--directory", SERVER_PATH, "src/pctx_code_mode/server.py"]
+
+rubric = EvalRubric(
+    fail_threshold=0.7,
+    warn_threshold=0.9,
+    fail_on_tool_selection=True,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers – compact JSON strings for additional_messages tool responses
+# ---------------------------------------------------------------------------
+
+
+def _j(obj: dict) -> str:
+    return json.dumps(obj)
+
+
+# Fixed fake IDs used across suites (stable across runs)
+_PROJ_PIPE = "proj_pipe_9f3a1b2c"
+_SPR_PIPE = "spr_pipe_4d5e6f7a"
+
+_PROJ_AUTH = "proj_auth_aa1122bb"
+_SPR_AUTH = "spr_auth_cc3344dd"
+_TASK_JWT = "task_jwt_ee5566ff"
+_TASK_SUB = "task_sub_gg7788hh"
+
+
+async def _load_server(suite: EvalSuite) -> bool:
+    try:
+        await asyncio.wait_for(
+            suite.add_mcp_stdio_server(
+                command=SERVER_COMMAND,
+                env={"PYTHONUNBUFFERED": "1"},
+            ),
+            timeout=20.0,
+        )
+        print("  ✓ ProjectTracker MCP server loaded")
+        return True
+    except asyncio.TimeoutError:
+        print("  ✗ Server load timed out")
+    except Exception as exc:
+        print(f"  ✗ Server load failed: {type(exc).__name__}: {exc}")
+    return False
+
+
+# ===========================================================================
+# Suite 1 – Project Setup  (3-step chain)
+# ===========================================================================
+
+
+@tool_eval()
+async def eval_project_setup() -> EvalSuite:
+    """Create a project, a sprint inside it, then a task inside the sprint."""
+    suite = EvalSuite(
+        name="Project Setup (3-step chain)",
+        system_message=(
+            "You are a project-management assistant. "
+            "Use the ProjectTracker tools to set up new projects and sprints."
+        ),
+        rubric=rubric,
+    )
+    if not await _load_server(suite):
+        return suite
+
+    # ------------------------------------------------------------------
+    # Step 1 – create the project
+    # ------------------------------------------------------------------
+    suite.add_case(
+        name="1/3 · Create project",
+        user_message=(
+            "Create a new project called 'Data Pipeline v2' owned by user_carol. "
+            "Add tags: data,etl,infra. Set sprint length to 7 days in the settings."
+        ),
+        expected_tool_calls=[
+            ExpectedMCPToolCall(
+                tool_name="ProjectTracker_CreateProject",
+                args={
+                    "name": "Data Pipeline v2",
+                    "owner_id": "user_carol",
+                    "tags": "data,etl,infra",
+                    "settings": '{"sprint_length_days": 7}',
+                },
+            )
+        ],
+        critics=[
+            BinaryCritic(critic_field="name", weight=0.3),
+            BinaryCritic(critic_field="owner_id", weight=0.3),
+            SimilarityCritic(critic_field="tags", weight=0.2),
+            SimilarityCritic(critic_field="settings", weight=0.2),
+        ],
+    )
+
+    # ------------------------------------------------------------------
+    # Step 2 – create a sprint in the newly created project
+    # ------------------------------------------------------------------
+    proj_response = _j({
+        "project_id": _PROJ_PIPE,
+        "name": "Data Pipeline v2",
+        "owner_id": "user_carol",
+        "status": "planning",
+        "tags": ["data", "etl", "infra"],
+        "settings": {"sprint_length_days": 7},
+        "sprint_count": 0,
+        "created_at": "2025-04-01T09:00:00+00:00",
+    })
+
+    suite.add_case(
+        name="2/3 · Create sprint in new project",
+        user_message=(
+            f"Now create Sprint 1 in project {_PROJ_PIPE} "
+            "running from 2025-04-07 to 2025-04-14 with 40 hours capacity. "
+            "Goals: 'Build Kafka ingestion layer,Deploy to staging'."
+        ),
+        additional_messages=[
+            {
+                "role": "user",
+                "content": "Create a new project called 'Data Pipeline v2' owned by user_carol with tags data,etl,infra.",
+            },
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_s1_1",
+                        "type": "function",
+                        "function": {
+                            "name": "ProjectTracker_CreateProject",
+                            "arguments": '{"name":"Data Pipeline v2","owner_id":"user_carol","tags":"data,etl,infra","settings":"{\\"sprint_length_days\\":7}"}',
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "content": proj_response,
+                "tool_call_id": "call_s1_1",
+                "name": "ProjectTracker_CreateProject",
+            },
+            {"role": "assistant", "content": f"Project created with ID `{_PROJ_PIPE}`."},
+        ],
+        expected_tool_calls=[
+            ExpectedMCPToolCall(
+                tool_name="ProjectTracker_CreateSprint",
+                args={
+                    "project_id": _PROJ_PIPE,
+                    "name": "Sprint 1",
+                    "start_date": "2025-04-07",
+                    "end_date": "2025-04-14",
+                    "capacity_hours": 40.0,
+                    "goals": "Build Kafka ingestion layer,Deploy to staging",
+                },
+            )
+        ],
+        critics=[
+            BinaryCritic(critic_field="project_id", weight=0.3),
+            BinaryCritic(critic_field="start_date", weight=0.15),
+            BinaryCritic(critic_field="end_date", weight=0.15),
+            NumericCritic(critic_field="capacity_hours", weight=0.2, value_range=(35.0, 45.0)),
+            SimilarityCritic(critic_field="goals", weight=0.2),
+        ],
+    )
+
+    # ------------------------------------------------------------------
+    # Step 3 – create a task inside the new sprint
+    # ------------------------------------------------------------------
+    sprint_response = _j({
+        "sprint_id": _SPR_PIPE,
+        "project_id": _PROJ_PIPE,
+        "name": "Sprint 1",
+        "status": "planning",
+        "start_date": "2025-04-07",
+        "end_date": "2025-04-14",
+        "goals": ["Build Kafka ingestion layer", "Deploy to staging"],
+        "capacity_hours": 40.0,
+        "task_count": 0,
+    })
+
+    suite.add_case(
+        name="3/3 · Create first task in sprint",
+        user_message=(
+            f"Add a high-priority task 'Implement Kafka consumer' to sprint {_SPR_PIPE}, "
+            "assigned to user_dave, 6-hour estimate, labels: backend,kafka."
+        ),
+        additional_messages=[
+            {
+                "role": "user",
+                "content": "Create a new project called 'Data Pipeline v2' owned by user_carol.",
+            },
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_s1_1",
+                        "type": "function",
+                        "function": {
+                            "name": "ProjectTracker_CreateProject",
+                            "arguments": '{"name":"Data Pipeline v2","owner_id":"user_carol"}',
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "content": proj_response,
+                "tool_call_id": "call_s1_1",
+                "name": "ProjectTracker_CreateProject",
+            },
+            {"role": "assistant", "content": f"Project `{_PROJ_PIPE}` created."},
+            {
+                "role": "user",
+                "content": f"Create Sprint 1 in {_PROJ_PIPE} from 2025-04-07 to 2025-04-14.",
+            },
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_s1_2",
+                        "type": "function",
+                        "function": {
+                            "name": "ProjectTracker_CreateSprint",
+                            "arguments": f'{{"project_id":"{_PROJ_PIPE}","name":"Sprint 1","start_date":"2025-04-07","end_date":"2025-04-14","capacity_hours":40.0}}',
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "content": sprint_response,
+                "tool_call_id": "call_s1_2",
+                "name": "ProjectTracker_CreateSprint",
+            },
+            {"role": "assistant", "content": f"Sprint `{_SPR_PIPE}` created."},
+        ],
+        expected_tool_calls=[
+            ExpectedMCPToolCall(
+                tool_name="ProjectTracker_CreateTask",
+                args={
+                    "sprint_id": _SPR_PIPE,
+                    "title": "Implement Kafka consumer",
+                    "priority": "high",
+                    "assignee_id": "user_dave",
+                    "estimate_hours": 6.0,
+                    "labels": "backend,kafka",
+                },
+            )
+        ],
+        critics=[
+            BinaryCritic(critic_field="sprint_id", weight=0.25),
+            SimilarityCritic(critic_field="title", weight=0.2),
+            BinaryCritic(critic_field="priority", weight=0.2),
+            BinaryCritic(critic_field="assignee_id", weight=0.2),
+            NumericCritic(critic_field="estimate_hours", weight=0.15, value_range=(5.0, 7.0)),
+        ],
+    )
+
+    return suite
+
+
+# ===========================================================================
+# Suite 2 – Task Lifecycle  (5-step chain)
+# ===========================================================================
+
+
+@tool_eval()
+async def eval_task_lifecycle() -> EvalSuite:
+    """
+    Work a task from in_progress through review to done using the seeded
+    task_001 (Design hero section) in sprint spr_001.
+    """
+    suite = EvalSuite(
+        name="Task Lifecycle (5-step chain)",
+        system_message=(
+            "You are a project-management assistant. "
+            "Help move tasks through their workflow using ProjectTracker tools."
+        ),
+        rubric=rubric,
+    )
+    if not await _load_server(suite):
+        return suite
+
+    task_001 = _j({
+        "task_id": "task_001",
+        "sprint_id": "spr_001",
+        "project_id": "proj_webapp_001",
+        "title": "Design hero section",
+        "status": "in_progress",
+        "priority": "high",
+        "assignee_id": "user_alice",
+        "labels": ["design", "frontend", "wcag"],
+        "estimate_hours": 8.0,
+        "logged_hours": 3.5,
+        "acceptance_criteria": [
+            "Hero renders correctly at 320px, 768px, and 1440px",
+            "CTA button has focus ring",
+        ],
+        "subtask_count": 0,
+        "comment_count": 0,
+        "time_log": {"total_logged_hours": 3.5, "entry_count": 1, "entries": []},
+    })
+
+    # ------------------------------------------------------------------
+    # Step 1 – inspect the task
+    # ------------------------------------------------------------------
+    suite.add_case(
+        name="1/5 · Fetch task details",
+        user_message="Show me the full details of task task_001.",
+        expected_tool_calls=[
+            ExpectedMCPToolCall(tool_name="ProjectTracker_GetTask", args={"task_id": "task_001"})
+        ],
+        critics=[BinaryCritic(critic_field="task_id", weight=1.0)],
+    )
+
+    # ------------------------------------------------------------------
+    # Step 2 – leave a progress comment
+    # ------------------------------------------------------------------
+    suite.add_case(
+        name="2/5 · Add progress comment",
+        user_message=(
+            "Add a comment on task_001 from user_alice: "
+            "'Wireframes approved by design team. Starting implementation today.'"
+        ),
+        additional_messages=[
+            {"role": "user", "content": "Show me the full details of task task_001."},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_s2_1",
+                        "type": "function",
+                        "function": {
+                            "name": "ProjectTracker_GetTask",
+                            "arguments": '{"task_id":"task_001"}',
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "content": task_001,
+                "tool_call_id": "call_s2_1",
+                "name": "ProjectTracker_GetTask",
+            },
+            {
+                "role": "assistant",
+                "content": "task_001 is 'Design hero section', currently in_progress, assigned to user_alice with 3.5h logged.",
+            },
+        ],
+        expected_tool_calls=[
+            ExpectedMCPToolCall(
+                tool_name="ProjectTracker_AddComment",
+                args={
+                    "task_id": "task_001",
+                    "author_id": "user_alice",
+                    "body": "Wireframes approved by design team. Starting implementation today.",
+                },
+            )
+        ],
+        critics=[
+            BinaryCritic(critic_field="task_id", weight=0.35),
+            BinaryCritic(critic_field="author_id", weight=0.3),
+            SimilarityCritic(critic_field="body", weight=0.35),
+        ],
+    )
+
+    comment_response = _j({
+        "comment": {
+            "comment_id": "cmt_aabb1122",
+            "task_id": "task_001",
+            "author_id": "user_alice",
+            "body": "Wireframes approved by design team. Starting implementation today.",
+        },
+        "task_comment_count": 1,
+    })
+
+    # ------------------------------------------------------------------
+    # Step 3 – log 4 hours of implementation work
+    # ------------------------------------------------------------------
+    suite.add_case(
+        name="3/5 · Log implementation hours",
+        user_message=(
+            "Log 4 hours on task_001 for user_alice today (2025-01-16). "
+            "Description: 'Implemented hero layout and responsive breakpoints'."
+        ),
+        additional_messages=[
+            {"role": "user", "content": "Show me task_001."},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_s2_1",
+                        "type": "function",
+                        "function": {
+                            "name": "ProjectTracker_GetTask",
+                            "arguments": '{"task_id":"task_001"}',
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "content": task_001,
+                "tool_call_id": "call_s2_1",
+                "name": "ProjectTracker_GetTask",
+            },
+            {"role": "assistant", "content": "task_001 is in_progress."},
+            {"role": "user", "content": "Add a comment from user_alice: 'Wireframes approved.'"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_s2_2",
+                        "type": "function",
+                        "function": {
+                            "name": "ProjectTracker_AddComment",
+                            "arguments": '{"task_id":"task_001","author_id":"user_alice","body":"Wireframes approved."}',
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "content": comment_response,
+                "tool_call_id": "call_s2_2",
+                "name": "ProjectTracker_AddComment",
+            },
+            {"role": "assistant", "content": "Comment added."},
+        ],
+        expected_tool_calls=[
+            ExpectedMCPToolCall(
+                tool_name="ProjectTracker_LogTime",
+                args={
+                    "task_id": "task_001",
+                    "user_id": "user_alice",
+                    "hours": 4.0,
+                    "work_date": "2025-01-16",
+                    "description": "Implemented hero layout and responsive breakpoints",
+                },
+            )
+        ],
+        critics=[
+            BinaryCritic(critic_field="task_id", weight=0.25),
+            BinaryCritic(critic_field="user_id", weight=0.2),
+            NumericCritic(critic_field="hours", weight=0.25, value_range=(3.5, 4.5)),
+            BinaryCritic(critic_field="work_date", weight=0.15),
+            SimilarityCritic(critic_field="description", weight=0.15),
+        ],
+    )
+
+    log_response = _j({
+        "entry": {"entry_id": "te_aabb1122", "task_id": "task_001", "hours": 4.0},
+        "task_total_logged_hours": 7.5,
+        "sprint_total_logged_hours": 9.5,
+    })
+
+    # ------------------------------------------------------------------
+    # Step 4 – move to in_review
+    # ------------------------------------------------------------------
+    suite.add_case(
+        name="4/5 · Move task to in_review",
+        user_message="task_001 is ready for review. Update its status to in_review.",
+        additional_messages=[
+            {"role": "user", "content": "Show me task_001."},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_s2_1",
+                        "type": "function",
+                        "function": {
+                            "name": "ProjectTracker_GetTask",
+                            "arguments": '{"task_id":"task_001"}',
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "content": task_001,
+                "tool_call_id": "call_s2_1",
+                "name": "ProjectTracker_GetTask",
+            },
+            {"role": "assistant", "content": "task_001 is in_progress."},
+            {"role": "user", "content": "Add a comment."},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_s2_2",
+                        "type": "function",
+                        "function": {
+                            "name": "ProjectTracker_AddComment",
+                            "arguments": '{"task_id":"task_001","author_id":"user_alice","body":"Wireframes approved."}',
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "content": comment_response,
+                "tool_call_id": "call_s2_2",
+                "name": "ProjectTracker_AddComment",
+            },
+            {"role": "assistant", "content": "Comment added."},
+            {"role": "user", "content": "Log 4 hours."},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_s2_3",
+                        "type": "function",
+                        "function": {
+                            "name": "ProjectTracker_LogTime",
+                            "arguments": '{"task_id":"task_001","user_id":"user_alice","hours":4.0,"work_date":"2025-01-16","description":"Implemented hero layout"}',
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "content": log_response,
+                "tool_call_id": "call_s2_3",
+                "name": "ProjectTracker_LogTime",
+            },
+            {"role": "assistant", "content": "4 hours logged. Total: 7.5h."},
+        ],
+        expected_tool_calls=[
+            ExpectedMCPToolCall(
+                tool_name="ProjectTracker_UpdateTask",
+                args={"task_id": "task_001", "status": "in_review"},
+            )
+        ],
+        critics=[
+            BinaryCritic(critic_field="task_id", weight=0.5),
+            BinaryCritic(critic_field="status", weight=0.5),
+        ],
+    )
+
+    review_response = _j({
+        "task": {"task_id": "task_001", "status": "in_review", "logged_hours": 7.5},
+        "changes": {"status": {"from": "in_progress", "to": "in_review"}},
+    })
+
+    # ------------------------------------------------------------------
+    # Step 5 – mark done after review passes
+    # ------------------------------------------------------------------
+    suite.add_case(
+        name="5/5 · Mark task done",
+        user_message="The review passed. Mark task_001 as done.",
+        additional_messages=[
+            {"role": "user", "content": "Show me task_001."},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_s2_1",
+                        "type": "function",
+                        "function": {
+                            "name": "ProjectTracker_GetTask",
+                            "arguments": '{"task_id":"task_001"}',
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "content": task_001,
+                "tool_call_id": "call_s2_1",
+                "name": "ProjectTracker_GetTask",
+            },
+            {"role": "assistant", "content": "task_001 is in_progress."},
+            {"role": "user", "content": "Add a comment, log time, then move to in_review."},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_s2_2",
+                        "type": "function",
+                        "function": {
+                            "name": "ProjectTracker_AddComment",
+                            "arguments": '{"task_id":"task_001","author_id":"user_alice","body":"Wireframes approved."}',
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "content": comment_response,
+                "tool_call_id": "call_s2_2",
+                "name": "ProjectTracker_AddComment",
+            },
+            {"role": "assistant", "content": "Comment added."},
+            {"role": "user", "content": "Log 4 hours."},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_s2_3",
+                        "type": "function",
+                        "function": {
+                            "name": "ProjectTracker_LogTime",
+                            "arguments": '{"task_id":"task_001","user_id":"user_alice","hours":4.0,"work_date":"2025-01-16","description":"Hero layout"}',
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "content": log_response,
+                "tool_call_id": "call_s2_3",
+                "name": "ProjectTracker_LogTime",
+            },
+            {"role": "assistant", "content": "Logged."},
+            {"role": "user", "content": "Move to in_review."},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_s2_4",
+                        "type": "function",
+                        "function": {
+                            "name": "ProjectTracker_UpdateTask",
+                            "arguments": '{"task_id":"task_001","status":"in_review"}',
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "content": review_response,
+                "tool_call_id": "call_s2_4",
+                "name": "ProjectTracker_UpdateTask",
+            },
+            {"role": "assistant", "content": "task_001 is now in_review."},
+        ],
+        expected_tool_calls=[
+            ExpectedMCPToolCall(
+                tool_name="ProjectTracker_UpdateTask",
+                args={"task_id": "task_001", "status": "done"},
+            )
+        ],
+        critics=[
+            BinaryCritic(critic_field="task_id", weight=0.5),
+            BinaryCritic(critic_field="status", weight=0.5),
+        ],
+    )
+
+    return suite
+
+
+# ===========================================================================
+# Suite 3 – Sprint Management  (6-step chain)
+# ===========================================================================
+
+
+@tool_eval()
+async def eval_sprint_management() -> EvalSuite:
+    """
+    Manage an active sprint: list projects, inspect the sprint, add a task,
+    move an existing task, pull metrics, then search for high-priority work.
+    Uses the seeded data (proj_webapp_001 / spr_001).
+    """
+    suite = EvalSuite(
+        name="Sprint Management (6-step chain)",
+        system_message=(
+            "You are a project-management assistant. "
+            "Use ProjectTracker tools to manage sprint work."
+        ),
+        rubric=rubric,
+    )
+    if not await _load_server(suite):
+        return suite
+
+    projects_response = _j({
+        "projects": [
+            {
+                "project_id": "proj_webapp_001",
+                "name": "WebApp Redesign",
+                "status": "active",
+                "owner_id": "user_alice",
+                "sprint_count": 1,
+                "tags": ["frontend", "ux"],
+            }
+        ],
+        "total": 1,
+    })
+    sprint_response = _j({
+        "sprint_id": "spr_001",
+        "project_id": "proj_webapp_001",
+        "name": "Sprint 1 — Foundation",
+        "status": "active",
+        "start_date": "2025-01-13",
+        "end_date": "2025-01-26",
+        "goals": ["Deliver responsive navigation", "Complete hero section"],
+        "capacity_hours": 80.0,
+        "task_count": 4,
+        "task_ids": ["task_001", "task_002", "task_003", "task_004"],
+    })
+
+    # ------------------------------------------------------------------
+    # Step 1
+    # ------------------------------------------------------------------
+    suite.add_case(
+        name="1/6 · List active projects",
+        user_message="List all active projects.",
+        expected_tool_calls=[
+            ExpectedMCPToolCall(
+                tool_name="ProjectTracker_ListProjects",
+                args={"status_filter": "active"},
+            )
+        ],
+        critics=[BinaryCritic(critic_field="status_filter", weight=1.0)],
+    )
+
+    # ------------------------------------------------------------------
+    # Step 2
+    # ------------------------------------------------------------------
+    suite.add_case(
+        name="2/6 · Get sprint details",
+        user_message="Get the details of sprint spr_001.",
+        additional_messages=[
+            {"role": "user", "content": "List all active projects."},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_s3_1",
+                        "type": "function",
+                        "function": {
+                            "name": "ProjectTracker_ListProjects",
+                            "arguments": '{"status_filter":"active"}',
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "content": projects_response,
+                "tool_call_id": "call_s3_1",
+                "name": "ProjectTracker_ListProjects",
+            },
+            {
+                "role": "assistant",
+                "content": "Found 1 active project: proj_webapp_001 (WebApp Redesign).",
+            },
+        ],
+        expected_tool_calls=[
+            ExpectedMCPToolCall(tool_name="ProjectTracker_GetSprint", args={"sprint_id": "spr_001"})
+        ],
+        critics=[BinaryCritic(critic_field="sprint_id", weight=1.0)],
+    )
+
+    # ------------------------------------------------------------------
+    # Step 3 – add a new critical task to the sprint
+    # ------------------------------------------------------------------
+    suite.add_case(
+        name="3/6 · Add critical task to sprint",
+        user_message=(
+            "Add a critical task 'Set up Sentry error monitoring' to sprint spr_001. "
+            "Labels: ops,monitoring. Estimate 4 hours."
+        ),
+        additional_messages=[
+            {"role": "user", "content": "List active projects."},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_s3_1",
+                        "type": "function",
+                        "function": {
+                            "name": "ProjectTracker_ListProjects",
+                            "arguments": '{"status_filter":"active"}',
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "content": projects_response,
+                "tool_call_id": "call_s3_1",
+                "name": "ProjectTracker_ListProjects",
+            },
+            {"role": "assistant", "content": "proj_webapp_001 is active."},
+            {"role": "user", "content": "Get sprint spr_001."},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_s3_2",
+                        "type": "function",
+                        "function": {
+                            "name": "ProjectTracker_GetSprint",
+                            "arguments": '{"sprint_id":"spr_001"}',
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "content": sprint_response,
+                "tool_call_id": "call_s3_2",
+                "name": "ProjectTracker_GetSprint",
+            },
+            {"role": "assistant", "content": "spr_001 is active with 4 tasks, ending 2025-01-26."},
+        ],
+        expected_tool_calls=[
+            ExpectedMCPToolCall(
+                tool_name="ProjectTracker_CreateTask",
+                args={
+                    "sprint_id": "spr_001",
+                    "priority": "critical",
+                    "estimate_hours": 4.0,
+                    "labels": "ops,monitoring",
+                },
+            )
+        ],
+        critics=[
+            BinaryCritic(critic_field="sprint_id", weight=0.3),
+            BinaryCritic(critic_field="priority", weight=0.3),
+            NumericCritic(critic_field="estimate_hours", weight=0.2, value_range=(3.0, 5.0)),
+            SimilarityCritic(critic_field="labels", weight=0.2),
+        ],
+    )
+
+    new_task_response = _j({
+        "task_id": "task_sentry_00ff1122",
+        "sprint_id": "spr_001",
+        "title": "Set up Sentry error monitoring",
+        "status": "backlog",
+        "priority": "critical",
+    })
+
+    # ------------------------------------------------------------------
+    # Step 4 – pull task_003 from backlog into the sprint
+    # ------------------------------------------------------------------
+    suite.add_case(
+        name="4/6 · Move backlog task into sprint",
+        user_message="Move task_003 into sprint spr_001 and set its status to todo.",
+        additional_messages=[
+            {"role": "user", "content": "List active projects."},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_s3_1",
+                        "type": "function",
+                        "function": {
+                            "name": "ProjectTracker_ListProjects",
+                            "arguments": '{"status_filter":"active"}',
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "content": projects_response,
+                "tool_call_id": "call_s3_1",
+                "name": "ProjectTracker_ListProjects",
+            },
+            {"role": "assistant", "content": "proj_webapp_001 is active."},
+            {"role": "user", "content": "Get sprint spr_001."},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_s3_2",
+                        "type": "function",
+                        "function": {
+                            "name": "ProjectTracker_GetSprint",
+                            "arguments": '{"sprint_id":"spr_001"}',
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "content": sprint_response,
+                "tool_call_id": "call_s3_2",
+                "name": "ProjectTracker_GetSprint",
+            },
+            {"role": "assistant", "content": "spr_001 active."},
+            {"role": "user", "content": "Add critical Sentry task."},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_s3_3",
+                        "type": "function",
+                        "function": {
+                            "name": "ProjectTracker_CreateTask",
+                            "arguments": '{"sprint_id":"spr_001","title":"Set up Sentry","priority":"critical","estimate_hours":4.0}',
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "content": new_task_response,
+                "tool_call_id": "call_s3_3",
+                "name": "ProjectTracker_CreateTask",
+            },
+            {"role": "assistant", "content": "Critical Sentry task created."},
+        ],
+        expected_tool_calls=[
+            ExpectedMCPToolCall(
+                tool_name="ProjectTracker_MoveTask",
+                args={"task_id": "task_003", "target_sprint_id": "spr_001", "new_status": "todo"},
+            )
+        ],
+        critics=[
+            BinaryCritic(critic_field="task_id", weight=0.35),
+            BinaryCritic(critic_field="target_sprint_id", weight=0.35),
+            BinaryCritic(critic_field="new_status", weight=0.3),
+        ],
+    )
+
+    move_response = _j({
+        "task": {"task_id": "task_003", "sprint_id": "spr_001", "status": "todo"},
+        "moved_from": None,
+        "moved_to": "spr_001",
+    })
+
+    # ------------------------------------------------------------------
+    # Step 5 – pull sprint metrics
+    # ------------------------------------------------------------------
+    suite.add_case(
+        name="5/6 · Get sprint metrics",
+        user_message=("Get sprint metrics for spr_001, including burndown and task breakdown."),
+        additional_messages=[
+            {"role": "user", "content": "List active projects then manage spr_001."},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_s3_1",
+                        "type": "function",
+                        "function": {
+                            "name": "ProjectTracker_ListProjects",
+                            "arguments": '{"status_filter":"active"}',
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "content": projects_response,
+                "tool_call_id": "call_s3_1",
+                "name": "ProjectTracker_ListProjects",
+            },
+            {"role": "assistant", "content": "Found proj_webapp_001."},
+            {"role": "user", "content": "Get spr_001."},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_s3_2",
+                        "type": "function",
+                        "function": {
+                            "name": "ProjectTracker_GetSprint",
+                            "arguments": '{"sprint_id":"spr_001"}',
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "content": sprint_response,
+                "tool_call_id": "call_s3_2",
+                "name": "ProjectTracker_GetSprint",
+            },
+            {"role": "assistant", "content": "Sprint active."},
+            {"role": "user", "content": "Add Sentry task, move task_003."},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_s3_3",
+                        "type": "function",
+                        "function": {
+                            "name": "ProjectTracker_CreateTask",
+                            "arguments": '{"sprint_id":"spr_001","title":"Sentry","priority":"critical"}',
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "content": new_task_response,
+                "tool_call_id": "call_s3_3",
+                "name": "ProjectTracker_CreateTask",
+            },
+            {"role": "assistant", "content": "Sentry task added."},
+            {"role": "user", "content": "Move task_003 into spr_001 as todo."},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_s3_4",
+                        "type": "function",
+                        "function": {
+                            "name": "ProjectTracker_MoveTask",
+                            "arguments": '{"task_id":"task_003","target_sprint_id":"spr_001","new_status":"todo"}',
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "content": move_response,
+                "tool_call_id": "call_s3_4",
+                "name": "ProjectTracker_MoveTask",
+            },
+            {"role": "assistant", "content": "task_003 moved to spr_001."},
+        ],
+        expected_tool_calls=[
+            ExpectedMCPToolCall(
+                tool_name="ProjectTracker_GetSprintMetrics",
+                args={
+                    "sprint_id": "spr_001",
+                    "include_burndown": True,
+                    "include_task_breakdown": True,
+                },
+            )
+        ],
+        critics=[
+            BinaryCritic(critic_field="sprint_id", weight=0.5),
+            BinaryCritic(critic_field="include_burndown", weight=0.25),
+            BinaryCritic(critic_field="include_task_breakdown", weight=0.25),
+        ],
+    )
+
+    metrics_response = _j({
+        "sprint_id": "spr_001",
+        "total_tasks": 6,
+        "completed_tasks": 1,
+        "completion_rate": 0.1667,
+        "hours_estimated": 30.0,
+        "hours_logged": 5.5,
+        "velocity": 5.5,
+        "task_breakdown": {
+            "by_status": {"in_progress": 1, "todo": 2, "backlog": 2, "in_review": 1},
+            "by_priority": {"critical": 2, "high": 2, "medium": 1, "low": 0},
+        },
+    })
+
+    # ------------------------------------------------------------------
+    # Step 6 – search for high/critical open tasks
+    # ------------------------------------------------------------------
+    suite.add_case(
+        name="6/6 · Search high-priority open tasks",
+        user_message=(
+            "Search for all high and critical tasks in spr_001 that are in_progress "
+            "or in_review, sorted by priority."
+        ),
+        additional_messages=[
+            {"role": "user", "content": "List active projects then get spr_001 details."},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_s3_1",
+                        "type": "function",
+                        "function": {
+                            "name": "ProjectTracker_ListProjects",
+                            "arguments": '{"status_filter":"active"}',
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "content": projects_response,
+                "tool_call_id": "call_s3_1",
+                "name": "ProjectTracker_ListProjects",
+            },
+            {"role": "assistant", "content": "Found proj_webapp_001."},
+            {"role": "user", "content": "Get spr_001."},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_s3_2",
+                        "type": "function",
+                        "function": {
+                            "name": "ProjectTracker_GetSprint",
+                            "arguments": '{"sprint_id":"spr_001"}',
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "content": sprint_response,
+                "tool_call_id": "call_s3_2",
+                "name": "ProjectTracker_GetSprint",
+            },
+            {"role": "assistant", "content": "Sprint active."},
+            {"role": "user", "content": "Add Sentry task and move task_003."},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_s3_3",
+                        "type": "function",
+                        "function": {
+                            "name": "ProjectTracker_MoveTask",
+                            "arguments": '{"task_id":"task_003","target_sprint_id":"spr_001","new_status":"todo"}',
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "content": move_response,
+                "tool_call_id": "call_s3_3",
+                "name": "ProjectTracker_MoveTask",
+            },
+            {"role": "assistant", "content": "Done."},
+            {"role": "user", "content": "Get metrics for spr_001."},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_s3_4",
+                        "type": "function",
+                        "function": {
+                            "name": "ProjectTracker_GetSprintMetrics",
+                            "arguments": '{"sprint_id":"spr_001","include_burndown":true,"include_task_breakdown":true}',
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "content": metrics_response,
+                "tool_call_id": "call_s3_4",
+                "name": "ProjectTracker_GetSprintMetrics",
+            },
+            {"role": "assistant", "content": "Sprint is 16.7% complete. 2 critical tasks, 2 high."},
+        ],
+        expected_tool_calls=[
+            ExpectedMCPToolCall(
+                tool_name="ProjectTracker_SearchTasks",
+                args={
+                    "sprint_id": "spr_001",
+                    "priority": "high,critical",
+                    "status": "in_progress,in_review",
+                    "sort_by": "priority",
+                },
+            )
+        ],
+        critics=[
+            BinaryCritic(critic_field="sprint_id", weight=0.3),
+            SimilarityCritic(critic_field="priority", weight=0.25),
+            SimilarityCritic(critic_field="status", weight=0.25),
+            BinaryCritic(critic_field="sort_by", weight=0.2),
+        ],
+    )
+
+    return suite
+
+
+# ===========================================================================
+# Suite 4 – Full Sprint Cycle  (8-step chain)
+# ===========================================================================
+
+
+@tool_eval()
+async def eval_full_sprint_cycle() -> EvalSuite:
+    """
+    Complete sprint lifecycle using every tool category:
+    create project → sprint → task → subtask → log time → done → close sprint → metrics.
+    """
+    suite = EvalSuite(
+        name="Full Sprint Cycle (8-step chain)",
+        system_message=(
+            "You are a project-management assistant. "
+            "Use ProjectTracker tools to execute a complete sprint lifecycle."
+        ),
+        rubric=rubric,
+    )
+    if not await _load_server(suite):
+        return suite
+
+    # Pre-built fake responses for each prior step
+    proj_r = _j({
+        "project_id": _PROJ_AUTH,
+        "name": "Auth Service Rewrite",
+        "owner_id": "user_eve",
+        "status": "planning",
+        "tags": ["security", "backend"],
+    })
+    spr_r = _j({
+        "sprint_id": _SPR_AUTH,
+        "project_id": _PROJ_AUTH,
+        "name": "Sprint 1",
+        "status": "planning",
+        "start_date": "2025-05-01",
+        "end_date": "2025-05-14",
+        "capacity_hours": 60.0,
+        "task_count": 0,
+    })
+    task_r = _j({
+        "task_id": _TASK_JWT,
+        "sprint_id": _SPR_AUTH,
+        "project_id": _PROJ_AUTH,
+        "title": "Replace jsonwebtoken with jose",
+        "status": "backlog",
+        "priority": "high",
+        "assignee_id": "user_eve",
+        "estimate_hours": 8.0,
+        "labels": ["security", "backend"],
+    })
+    subtask_r = _j({
+        "subtask": {
+            "task_id": _TASK_SUB,
+            "parent_task_id": _TASK_JWT,
+            "title": "Update token verification middleware",
+            "status": "backlog",
+        },
+        "parent_task_id": _TASK_JWT,
+    })
+    log_r = _j({
+        "entry": {"entry_id": "te_ee5566ff", "hours": 5.0},
+        "task_total_logged_hours": 5.0,
+        "sprint_total_logged_hours": 5.0,
+    })
+    done_r = _j({
+        "task": {"task_id": _TASK_JWT, "status": "done", "logged_hours": 5.0},
+        "changes": {"status": {"from": "in_progress", "to": "done"}},
+    })
+    close_r = _j({
+        "sprint": {"sprint_id": _SPR_AUTH, "status": "completed"},
+        "summary": {
+            "total_tasks": 2,
+            "completed_tasks": 1,
+            "carried_over_tasks": 1,
+            "completion_rate": 0.5,
+        },
+        "carry_over_task_ids": [_TASK_SUB],
+    })
+
+    def _prior(steps: list[tuple[str, str, str, str]]) -> list[dict]:
+        """Build additional_messages from [(user_msg, tool_name, args_json, response_json)]."""
+        msgs: list[dict] = []
+        for i, (user_msg, tool_name, args_str, resp_str) in enumerate(steps):
+            call_id = f"call_s4_{i + 1}"
+            msgs.append({"role": "user", "content": user_msg})
+            msgs.append({
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": call_id,
+                        "type": "function",
+                        "function": {"name": tool_name, "arguments": args_str},
+                    }
+                ],
+            })
+            msgs.append({
+                "role": "tool",
+                "content": resp_str,
+                "tool_call_id": call_id,
+                "name": tool_name,
+            })
+            msgs.append({"role": "assistant", "content": "Done."})
+        return msgs
+
+    steps_history = [
+        (
+            "Create Auth Service Rewrite project owned by user_eve.",
+            "ProjectTracker_CreateProject",
+            '{"name":"Auth Service Rewrite","owner_id":"user_eve","tags":"security,backend"}',
+            proj_r,
+        ),
+        (
+            f"Create Sprint 1 in {_PROJ_AUTH} May 1–14 with 60h capacity.",
+            "ProjectTracker_CreateSprint",
+            f'{{"project_id":"{_PROJ_AUTH}","name":"Sprint 1","start_date":"2025-05-01","end_date":"2025-05-14","capacity_hours":60.0}}',
+            spr_r,
+        ),
+        (
+            f"Create high-priority task 'Replace jsonwebtoken with jose' in {_SPR_AUTH} assigned to user_eve.",
+            "ProjectTracker_CreateTask",
+            f'{{"sprint_id":"{_SPR_AUTH}","title":"Replace jsonwebtoken with jose","priority":"high","assignee_id":"user_eve","estimate_hours":8.0,"labels":"security,backend"}}',
+            task_r,
+        ),
+        (
+            f"Add subtask 'Update token verification middleware' under {_TASK_JWT}.",
+            "ProjectTracker_AddSubtask",
+            f'{{"parent_task_id":"{_TASK_JWT}","title":"Update token verification middleware","assignee_id":"user_eve","estimate_hours":2.0}}',
+            subtask_r,
+        ),
+        (
+            f"Log 5 hours on {_TASK_JWT} for user_eve: 'Migrated to jose, updated signing'.",
+            "ProjectTracker_LogTime",
+            f'{{"task_id":"{_TASK_JWT}","user_id":"user_eve","hours":5.0,"description":"Migrated to jose, updated signing","work_date":"2025-05-05"}}',
+            log_r,
+        ),
+        (
+            f"Mark {_TASK_JWT} as done.",
+            "ProjectTracker_UpdateTask",
+            f'{{"task_id":"{_TASK_JWT}","status":"done"}}',
+            done_r,
+        ),
+        (
+            f"Close sprint {_SPR_AUTH}, carry incomplete tasks to backlog. Retro: 'Breaking changes need more lead time.'",
+            "ProjectTracker_CloseSprint",
+            f'{{"sprint_id":"{_SPR_AUTH}","carry_over_policy":"backlog","retrospective_notes":"Breaking changes need more lead time."}}',
+            close_r,
+        ),
+    ]
+
+    # ------------------------------------------------------------------
+    # Step 1
+    # ------------------------------------------------------------------
+    suite.add_case(
+        name="1/8 · Create project",
+        user_message="Create a project called 'Auth Service Rewrite' owned by user_eve. Tags: security,backend,breaking-change.",
+        expected_tool_calls=[
+            ExpectedMCPToolCall(
+                tool_name="ProjectTracker_CreateProject",
+                args={
+                    "name": "Auth Service Rewrite",
+                    "owner_id": "user_eve",
+                    "tags": "security,backend,breaking-change",
+                },
+            )
+        ],
+        critics=[
+            SimilarityCritic(critic_field="name", weight=0.35),
+            BinaryCritic(critic_field="owner_id", weight=0.35),
+            SimilarityCritic(critic_field="tags", weight=0.3),
+        ],
+    )
+
+    # ------------------------------------------------------------------
+    # Step 2
+    # ------------------------------------------------------------------
+    suite.add_case(
+        name="2/8 · Create sprint",
+        user_message=f"Create Sprint 1 in project {_PROJ_AUTH} running 2025-05-01 to 2025-05-14 with 60 hour capacity. Goals: 'Replace JWT library,Add refresh token rotation'.",
+        additional_messages=_prior(steps_history[:1]),
+        expected_tool_calls=[
+            ExpectedMCPToolCall(
+                tool_name="ProjectTracker_CreateSprint",
+                args={
+                    "project_id": _PROJ_AUTH,
+                    "name": "Sprint 1",
+                    "start_date": "2025-05-01",
+                    "end_date": "2025-05-14",
+                    "capacity_hours": 60.0,
+                },
+            )
+        ],
+        critics=[
+            BinaryCritic(critic_field="project_id", weight=0.3),
+            BinaryCritic(critic_field="start_date", weight=0.2),
+            BinaryCritic(critic_field="end_date", weight=0.2),
+            NumericCritic(critic_field="capacity_hours", weight=0.3, value_range=(55.0, 65.0)),
+        ],
+    )
+
+    # ------------------------------------------------------------------
+    # Step 3
+    # ------------------------------------------------------------------
+    suite.add_case(
+        name="3/8 · Create JWT replacement task",
+        user_message=f"In sprint {_SPR_AUTH}, create a high-priority task 'Replace jsonwebtoken with jose', assigned to user_eve, 8h estimate, labels: security,backend,breaking-change.",
+        additional_messages=_prior(steps_history[:2]),
+        expected_tool_calls=[
+            ExpectedMCPToolCall(
+                tool_name="ProjectTracker_CreateTask",
+                args={
+                    "sprint_id": _SPR_AUTH,
+                    "priority": "high",
+                    "assignee_id": "user_eve",
+                    "estimate_hours": 8.0,
+                },
+            )
+        ],
+        critics=[
+            BinaryCritic(critic_field="sprint_id", weight=0.3),
+            BinaryCritic(critic_field="priority", weight=0.25),
+            BinaryCritic(critic_field="assignee_id", weight=0.25),
+            NumericCritic(critic_field="estimate_hours", weight=0.2, value_range=(7.0, 9.0)),
+        ],
+    )
+
+    # ------------------------------------------------------------------
+    # Step 4
+    # ------------------------------------------------------------------
+    suite.add_case(
+        name="4/8 · Add subtask for middleware update",
+        user_message=f"Add a subtask 'Update token verification middleware' under task {_TASK_JWT}, assigned to user_eve, 2h estimate.",
+        additional_messages=_prior(steps_history[:3]),
+        expected_tool_calls=[
+            ExpectedMCPToolCall(
+                tool_name="ProjectTracker_AddSubtask",
+                args={
+                    "parent_task_id": _TASK_JWT,
+                    "title": "Update token verification middleware",
+                    "assignee_id": "user_eve",
+                    "estimate_hours": 2.0,
+                },
+            )
+        ],
+        critics=[
+            BinaryCritic(critic_field="parent_task_id", weight=0.35),
+            SimilarityCritic(critic_field="title", weight=0.3),
+            BinaryCritic(critic_field="assignee_id", weight=0.2),
+            NumericCritic(critic_field="estimate_hours", weight=0.15, value_range=(1.5, 2.5)),
+        ],
+    )
+
+    # ------------------------------------------------------------------
+    # Step 5
+    # ------------------------------------------------------------------
+    suite.add_case(
+        name="5/8 · Log implementation hours",
+        user_message=f"Log 5 hours on task {_TASK_JWT} for user_eve on 2025-05-05. Description: 'Migrated to jose library, updated signing and verification'.",
+        additional_messages=_prior(steps_history[:4]),
+        expected_tool_calls=[
+            ExpectedMCPToolCall(
+                tool_name="ProjectTracker_LogTime",
+                args={
+                    "task_id": _TASK_JWT,
+                    "user_id": "user_eve",
+                    "hours": 5.0,
+                    "work_date": "2025-05-05",
+                },
+            )
+        ],
+        critics=[
+            BinaryCritic(critic_field="task_id", weight=0.3),
+            BinaryCritic(critic_field="user_id", weight=0.25),
+            NumericCritic(critic_field="hours", weight=0.3, value_range=(4.5, 5.5)),
+            BinaryCritic(critic_field="work_date", weight=0.15),
+        ],
+    )
+
+    # ------------------------------------------------------------------
+    # Step 6
+    # ------------------------------------------------------------------
+    suite.add_case(
+        name="6/8 · Mark task done",
+        user_message=f"Task {_TASK_JWT} is complete. Mark it as done.",
+        additional_messages=_prior(steps_history[:5]),
+        expected_tool_calls=[
+            ExpectedMCPToolCall(
+                tool_name="ProjectTracker_UpdateTask",
+                args={"task_id": _TASK_JWT, "status": "done"},
+            )
+        ],
+        critics=[
+            BinaryCritic(critic_field="task_id", weight=0.5),
+            BinaryCritic(critic_field="status", weight=0.5),
+        ],
+    )
+
+    # ------------------------------------------------------------------
+    # Step 7
+    # ------------------------------------------------------------------
+    suite.add_case(
+        name="7/8 · Close the sprint",
+        user_message=(
+            f"Close sprint {_SPR_AUTH}. Carry any incomplete tasks to the backlog. "
+            "Retrospective notes: 'Breaking changes need more lead time. "
+            "Add changelog entries next sprint.'"
+        ),
+        additional_messages=_prior(steps_history[:6]),
+        expected_tool_calls=[
+            ExpectedMCPToolCall(
+                tool_name="ProjectTracker_CloseSprint",
+                args={
+                    "sprint_id": _SPR_AUTH,
+                    "carry_over_policy": "backlog",
+                    "retrospective_notes": "Breaking changes need more lead time. Add changelog entries next sprint.",
+                },
+            )
+        ],
+        critics=[
+            BinaryCritic(critic_field="sprint_id", weight=0.35),
+            BinaryCritic(critic_field="carry_over_policy", weight=0.35),
+            SimilarityCritic(critic_field="retrospective_notes", weight=0.3),
+        ],
+    )
+
+    # ------------------------------------------------------------------
+    # Step 8
+    # ------------------------------------------------------------------
+    suite.add_case(
+        name="8/8 · Pull final sprint metrics",
+        user_message=f"Pull the final metrics for sprint {_SPR_AUTH} with burndown and task breakdown.",
+        additional_messages=_prior(steps_history[:7]),
+        expected_tool_calls=[
+            ExpectedMCPToolCall(
+                tool_name="ProjectTracker_GetSprintMetrics",
+                args={
+                    "sprint_id": _SPR_AUTH,
+                    "include_burndown": True,
+                    "include_task_breakdown": True,
+                },
+            )
+        ],
+        critics=[
+            BinaryCritic(critic_field="sprint_id", weight=0.5),
+            BinaryCritic(critic_field="include_burndown", weight=0.25),
+            BinaryCritic(critic_field="include_task_breakdown", weight=0.25),
+        ],
+    )
+
+    return suite

--- a/examples/mcp_servers/pctx_code_mode/docker/Dockerfile
+++ b/examples/mcp_servers/pctx_code_mode/docker/Dockerfile
@@ -1,0 +1,19 @@
+FROM ghcr.io/astral-sh/uv:python3.11-bookworm-slim
+
+RUN useradd -m -u 1000 appuser
+
+WORKDIR /app
+
+COPY pyproject.toml uv.lock ./
+COPY src/ ./src/
+
+# Install dependencies (pctx-client resolves from PyPI, not local path)
+RUN uv sync --frozen --no-dev
+
+RUN chown -R appuser:appuser /app
+
+USER appuser
+
+EXPOSE 8001
+
+CMD uv run src/pctx_code_mode/server.py http

--- a/examples/mcp_servers/pctx_code_mode/docker/docker-compose.yml
+++ b/examples/mcp_servers/pctx_code_mode/docker/docker-compose.yml
@@ -1,0 +1,35 @@
+services:
+  pctx:
+    platform: linux/amd64
+    build:
+      context: ..
+      dockerfile_inline: |
+        FROM debian:bookworm-slim
+        RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates \
+         && rm -rf /var/lib/apt/lists/*
+        RUN curl --proto '=https' --tlsv1.2 -LsSf \
+            https://raw.githubusercontent.com/portofcontext/pctx/main/install.sh | sh
+        EXPOSE 8080
+        CMD ["pctx", "start"]
+    ports:
+      - "8082:8080"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+  mcp-server:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+    ports:
+      - "8001:8001"
+    environment:
+      - ARCADE_SERVER_TRANSPORT=http
+      - ARCADE_SERVER_HOST=0.0.0.0
+      - ARCADE_SERVER_PORT=8001
+      - PCTX_URL=http://pctx:8080
+    depends_on:
+      pctx:
+        condition: service_healthy

--- a/examples/mcp_servers/pctx_code_mode/pyproject.toml
+++ b/examples/mcp_servers/pctx_code_mode/pyproject.toml
@@ -1,0 +1,40 @@
+[project]
+name = "pctx_code_mode"
+version = "0.1.0"
+description = "pctx Code Mode MCP server — simulates the pctx execution layer with sessions, sandboxed TypeScript/bash execution, and a rich function catalog."
+requires-python = ">=3.10"
+dependencies = ["arcade-mcp-server>=1.17.4,<2.0.0", "pctx-client>=0.3.1"]
+
+[project.optional-dependencies]
+dev = [
+    "arcade-mcp[all]>=1.11.2,<2.0.0",
+    "openai>=1.0.0",
+    "pytest>=7.0.0",
+    "pytest-asyncio>=0.21.0",
+    "mypy>=1.0.0",
+    "ruff>=0.1.0",
+]
+
+[project.entry-points.arcade_toolkits]
+toolkit_name = "pctx_code_mode"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/pctx_code_mode"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py312"
+
+[tool.mypy]
+python_version = "3.12"
+warn_unused_configs = true
+disallow_untyped_defs = false
+
+[tool.uv.sources]
+# arcade-mcp = { path = "../../../", editable = true }
+# arcade-serve = { path = "../../../libs/arcade-serve/", editable = true }
+# arcade-mcp-server = { path = "../../../libs/arcade-mcp-server/", editable = true }

--- a/examples/mcp_servers/pctx_code_mode/src/pctx_code_mode/server.py
+++ b/examples/mcp_servers/pctx_code_mode/src/pctx_code_mode/server.py
@@ -1,0 +1,869 @@
+#!/usr/bin/env python3
+"""
+ProjectTracker MCP server.
+
+A project-management tool server with rich schemas: projects, sprints,
+tasks (with subtasks, acceptance criteria, labels), comments, time entries,
+and sprint velocity metrics.
+
+Usage:
+    uv run src/pctx_code_mode/server.py          # stdio (default)
+    uv run src/pctx_code_mode/server.py http     # HTTP streaming
+"""
+
+import json
+import sys
+from typing import Annotated
+
+from arcade_mcp_server import MCPApp
+from pctx_client import tool as pctx_tool
+
+from pctx_code_mode.store import get_store
+
+app = MCPApp(name="ProjectTracker", version="1.0.0", log_level="WARNING")
+
+
+# ---------------------------------------------------------------------------
+# Projects
+# ---------------------------------------------------------------------------
+
+
+@pctx_tool
+@app.tool
+def create_project(
+    name: Annotated[str, "Project name (1-120 characters)"],
+    description: Annotated[str, "Full project description including goals and scope"],
+    owner_id: Annotated[str, "User ID of the project owner"],
+    status: Annotated[
+        str,
+        "Initial project status: planning, active, on_hold, completed, archived",
+    ] = "planning",
+    tags: Annotated[
+        str,
+        "Comma-separated tags for categorisation (e.g. frontend,q1-2025,mobile)",
+    ] = "",
+    member_ids: Annotated[
+        str,
+        "Comma-separated user IDs of initial project members (owner is always included)",
+    ] = "",
+    settings: Annotated[
+        str,
+        (
+            "JSON object with project-level settings. "
+            'Supported keys: "velocity_unit" ("hours"|"points"), '
+            '"sprint_length_days" (int), '
+            '"default_priority" ("critical"|"high"|"medium"|"low"), '
+            '"require_estimate" (bool), '
+            '"review_required" (bool). '
+            'Example: {"velocity_unit":"hours","sprint_length_days":14}'
+        ),
+    ] = "{}",
+) -> dict:
+    """
+    Create a new project. Returns the full project record including the
+    generated project_id needed for subsequent sprint and task operations.
+    """
+    store = get_store()
+    tag_list = [t.strip() for t in tags.split(",") if t.strip()]
+    member_list = list({owner_id} | {m.strip() for m in member_ids.split(",") if m.strip()})
+    try:
+        settings_dict = json.loads(settings) if settings.strip() else {}
+    except json.JSONDecodeError as exc:
+        return {"error": f"Invalid settings JSON: {exc}"}
+
+    valid_statuses = {"planning", "active", "on_hold", "completed", "archived"}
+    if status not in valid_statuses:
+        return {"error": f"status must be one of {sorted(valid_statuses)}, got '{status}'"}
+
+    project = store.create_project(
+        name=name.strip(),
+        description=description.strip(),
+        owner_id=owner_id.strip(),
+        status=status,
+        tags=tag_list,
+        settings=settings_dict,
+        sprint_ids=[],
+        member_ids=member_list,
+    )
+    return project.to_dict()
+
+
+@pctx_tool
+@app.tool
+def get_project(
+    project_id: Annotated[str, "ID of the project to retrieve"],
+) -> dict:
+    """Retrieve full project details including sprint IDs, member list, and settings."""
+    store = get_store()
+    project = store.get_project(project_id)
+    if not project:
+        return {"error": f"Project '{project_id}' not found"}
+    return project.to_dict()
+
+
+@pctx_tool
+@app.tool
+def list_projects(
+    status_filter: Annotated[
+        str,
+        "Comma-separated statuses to include (e.g. active,planning). Empty = all statuses.",
+    ] = "",
+    owner_id: Annotated[str, "Filter to projects owned by this user ID. Empty = all owners."] = "",
+    tag: Annotated[str, "Return only projects that include this tag. Empty = no filter."] = "",
+    limit: Annotated[int, "Maximum number of projects to return (1-200)"] = 50,
+) -> dict:
+    """
+    List projects with optional filtering. Returns {projects: [...], total, returned, filters}.
+    Access the array via result.projects.
+    """
+    store = get_store()
+    projects = list(store.projects.values())
+
+    statuses = [s.strip() for s in status_filter.split(",") if s.strip()]
+    if statuses:
+        projects = [p for p in projects if p.status in statuses]
+    if owner_id.strip():
+        projects = [p for p in projects if p.owner_id == owner_id.strip()]
+    if tag.strip():
+        projects = [p for p in projects if tag.strip() in p.tags]
+
+    projects.sort(key=lambda p: p.updated_at, reverse=True)
+    total = len(projects)
+    projects = projects[:limit]
+
+    return {
+        "projects": [p.to_dict() for p in projects],
+        "total": total,
+        "returned": len(projects),
+        "filters": {
+            "status_filter": statuses or None,
+            "owner_id": owner_id or None,
+            "tag": tag or None,
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Sprints
+# ---------------------------------------------------------------------------
+
+
+@pctx_tool
+@app.tool
+def create_sprint(
+    project_id: Annotated[str, "ID of the parent project"],
+    name: Annotated[str, "Sprint name (e.g. 'Sprint 2', 'Q2 2025 Hardening')"],
+    start_date: Annotated[str, "Sprint start date in YYYY-MM-DD format"],
+    end_date: Annotated[str, "Sprint end date in YYYY-MM-DD format"],
+    goals: Annotated[
+        str,
+        "Comma-separated sprint goals. Each goal should be a concise, measurable outcome.",
+    ] = "",
+    capacity_hours: Annotated[
+        float,
+        "Total available team-hours for this sprint across all members. Used for utilisation metrics.",
+    ] = 0.0,
+) -> dict:
+    """
+    Create a new sprint inside an existing project. The sprint starts in
+    'planning' status. Returns the full sprint record including the
+    generated sprint_id needed for task creation.
+    """
+    store = get_store()
+    project = store.get_project(project_id)
+    if not project:
+        return {"error": f"Project '{project_id}' not found"}
+
+    goal_list = [g.strip() for g in goals.split(",") if g.strip()]
+    sprint = store.create_sprint(
+        project_id=project_id,
+        name=name.strip(),
+        status="planning",
+        start_date=start_date.strip(),
+        end_date=end_date.strip(),
+        goals=goal_list,
+        capacity_hours=max(0.0, capacity_hours),
+        task_ids=[],
+        retrospective_notes="",
+    )
+    return sprint.to_dict()
+
+
+@pctx_tool
+@app.tool
+def get_sprint(
+    sprint_id: Annotated[str, "ID of the sprint to retrieve"],
+) -> dict:
+    """Retrieve full sprint details including task IDs, goals, and status."""
+    store = get_store()
+    sprint = store.get_sprint(sprint_id)
+    if not sprint:
+        return {"error": f"Sprint '{sprint_id}' not found"}
+    return sprint.to_dict()
+
+
+@pctx_tool
+@app.tool
+def activate_sprint(
+    sprint_id: Annotated[str, "ID of the sprint to move from planning to active"],
+) -> dict:
+    """
+    Transition a sprint from 'planning' to 'active'. Only one sprint per
+    project should be active at a time. Returns the updated sprint record.
+    """
+    store = get_store()
+    sprint = store.get_sprint(sprint_id)
+    if not sprint:
+        return {"error": f"Sprint '{sprint_id}' not found"}
+    if sprint.status != "planning":
+        return {"error": f"Sprint is already '{sprint.status}', must be 'planning' to activate"}
+    result = store.update_task  # just touching the store instance
+    sprint.status = "active"
+    from pctx_code_mode.store import _now
+    sprint.updated_at = _now()
+    return sprint.to_dict()
+
+
+@pctx_tool
+@app.tool
+def close_sprint(
+    sprint_id: Annotated[str, "ID of the active sprint to close"],
+    carry_over_policy: Annotated[
+        str,
+        (
+            "What to do with incomplete (non-done, non-cancelled) tasks: "
+            "'next_sprint' moves them to another sprint, "
+            "'backlog' detaches them from any sprint, "
+            "'cancel' marks them as cancelled."
+        ),
+    ] = "backlog",
+    next_sprint_id: Annotated[
+        str,
+        "Sprint ID to receive carried-over tasks. Required when carry_over_policy='next_sprint'.",
+    ] = "",
+    retrospective_notes: Annotated[
+        str,
+        "Free-form retrospective text (what went well, what to improve, action items).",
+    ] = "",
+) -> dict:
+    """
+    Close a sprint and handle incomplete tasks per the carry-over policy.
+    Returns {sprint, summary: {total_tasks, completed_tasks, carried_over_tasks, cancelled_tasks, completion_rate}, carry_over_task_ids, carry_over_policy}.
+    """
+    store = get_store()
+    sprint = store.get_sprint(sprint_id)
+    if not sprint:
+        return {"error": f"Sprint '{sprint_id}' not found"}
+
+    valid_policies = {"next_sprint", "backlog", "cancel"}
+    if carry_over_policy not in valid_policies:
+        return {"error": f"carry_over_policy must be one of {sorted(valid_policies)}"}
+
+    if carry_over_policy == "next_sprint" and not next_sprint_id.strip():
+        return {"error": "next_sprint_id is required when carry_over_policy='next_sprint'"}
+
+    tasks = [store.tasks[tid] for tid in sprint.task_ids if tid in store.tasks]
+    incomplete = [t for t in tasks if t.status not in ("done", "cancelled")]
+    completed = [t for t in tasks if t.status == "done"]
+
+    from pctx_code_mode.store import _now
+    now = _now()
+
+    carry_over_ids: list[str] = []
+    for task in incomplete:
+        if carry_over_policy == "next_sprint":
+            target = store.sprints.get(next_sprint_id.strip())
+            if target and task.task_id not in target.task_ids:
+                target.task_ids.append(task.task_id)
+            task.sprint_id = next_sprint_id.strip() or None
+            carry_over_ids.append(task.task_id)
+        elif carry_over_policy == "backlog":
+            task.sprint_id = None
+            task.status = "backlog"
+            carry_over_ids.append(task.task_id)
+        else:  # cancel
+            task.status = "cancelled"
+
+        task.updated_at = now
+
+    sprint.status = "completed"
+    sprint.retrospective_notes = retrospective_notes
+    sprint.updated_at = now
+
+    return {
+        "sprint": sprint.to_dict(),
+        "summary": {
+            "total_tasks": len(tasks),
+            "completed_tasks": len(completed),
+            "carried_over_tasks": len(carry_over_ids),
+            "cancelled_tasks": len(incomplete) - len(carry_over_ids),
+            "completion_rate": round(len(completed) / len(tasks), 4) if tasks else 0.0,
+        },
+        "carry_over_task_ids": carry_over_ids,
+        "carry_over_policy": carry_over_policy,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tasks
+# ---------------------------------------------------------------------------
+
+
+@pctx_tool
+@app.tool
+def create_task(
+    sprint_id: Annotated[str, "ID of the sprint this task belongs to. Use 'backlog' to create an unsprinted task."],
+    title: Annotated[str, "Short, imperative task title (1-200 characters)"],
+    description: Annotated[
+        str,
+        "Detailed description including context, technical notes, and definition of done.",
+    ],
+    priority: Annotated[
+        str,
+        "Task priority: critical (P0), high (P1), medium (P2), low (P3)",
+    ] = "medium",
+    assignee_id: Annotated[
+        str,
+        "User ID to assign immediately. Leave empty to leave unassigned.",
+    ] = "",
+    labels: Annotated[
+        str,
+        "Comma-separated labels (e.g. bug,frontend,needs-design,blocked). Max 10 labels.",
+    ] = "",
+    estimate_hours: Annotated[
+        float,
+        "Hour estimate for completing the task. Use 0 if not yet estimated.",
+    ] = 0.0,
+    parent_task_id: Annotated[
+        str,
+        "ID of an existing task to nest this as a subtask under. Leave empty for a top-level task.",
+    ] = "",
+    acceptance_criteria: Annotated[
+        str,
+        (
+            "JSON array of acceptance-criteria strings. Each entry is a testable condition. "
+            'Example: ["API returns 200 on success", "Error state shows toast notification"]'
+        ),
+    ] = "[]",
+) -> dict:
+    """
+    Create a new task (or subtask) inside a sprint. Returns the full task
+    record including the generated task_id.
+    """
+    store = get_store()
+
+    valid_priorities = {"critical", "high", "medium", "low"}
+    if priority not in valid_priorities:
+        return {"error": f"priority must be one of {sorted(valid_priorities)}, got '{priority}'"}
+
+    actual_sprint_id: str | None = None
+    if sprint_id.strip() and sprint_id.strip() != "backlog":
+        sprint = store.get_sprint(sprint_id.strip())
+        if not sprint:
+            return {"error": f"Sprint '{sprint_id}' not found"}
+        actual_sprint_id = sprint_id.strip()
+        project_id = sprint.project_id
+    elif parent_task_id.strip():
+        parent = store.get_task(parent_task_id.strip())
+        if not parent:
+            return {"error": f"Parent task '{parent_task_id}' not found"}
+        project_id = parent.project_id
+        actual_sprint_id = parent.sprint_id
+    else:
+        return {"error": "Either a valid sprint_id or a parent_task_id is required"}
+
+    label_list = [lbl.strip() for lbl in labels.split(",") if lbl.strip()][:10]
+
+    try:
+        criteria = json.loads(acceptance_criteria) if acceptance_criteria.strip() else []
+        if not isinstance(criteria, list):
+            criteria = []
+    except json.JSONDecodeError:
+        criteria = []
+
+    task = store.create_task(
+        sprint_id=actual_sprint_id,
+        project_id=project_id,
+        title=title.strip(),
+        description=description.strip(),
+        status="backlog",
+        priority=priority,
+        assignee_id=assignee_id.strip() or None,
+        labels=label_list,
+        estimate_hours=max(0.0, estimate_hours),
+        parent_task_id=parent_task_id.strip() or None,
+        acceptance_criteria=criteria,
+    )
+    return task.to_dict()
+
+
+@pctx_tool
+@app.tool
+def get_task(
+    task_id: Annotated[str, "ID of the task to retrieve"],
+) -> dict:
+    """
+    Retrieve full task details including description, acceptance criteria,
+    subtask IDs, comment count, and time-log summary.
+    """
+    store = get_store()
+    task = store.get_task(task_id)
+    if not task:
+        return {"error": f"Task '{task_id}' not found"}
+    d = task.to_dict(include_full=True)
+    # Inline subtask summaries for convenience
+    d["subtasks"] = [
+        store.tasks[sid].to_dict(include_full=False)
+        for sid in task.subtask_ids
+        if sid in store.tasks
+    ]
+    # Inline recent comments (last 5)
+    d["recent_comments"] = [
+        store.comments[cid].to_dict()
+        for cid in task.comment_ids[-5:]
+        if cid in store.comments
+    ]
+    # Time entry summary
+    entries = [store.time_entries[eid] for eid in task.time_entry_ids if eid in store.time_entries]
+    d["time_log"] = {
+        "total_logged_hours": task.logged_hours,
+        "entry_count": len(entries),
+        "entries": [e.to_dict() for e in entries[-10:]],
+    }
+    return d
+
+
+@pctx_tool
+@app.tool
+def update_task(
+    task_id: Annotated[str, "ID of the task to update"],
+    title: Annotated[str, "New title. Empty string = no change."] = "",
+    description: Annotated[str, "New description. Empty string = no change."] = "",
+    status: Annotated[
+        str,
+        "New status: backlog, todo, in_progress, in_review, done, cancelled. Empty = no change.",
+    ] = "",
+    priority: Annotated[
+        str,
+        "New priority: critical, high, medium, low. Empty = no change.",
+    ] = "",
+    assignee_id: Annotated[
+        str,
+        "New assignee user ID. Pass 'unassign' to remove the current assignee. Empty = no change.",
+    ] = "",
+    labels: Annotated[
+        str,
+        "Replacement comma-separated labels. Overwrites existing labels. Empty = no change.",
+    ] = "",
+    estimate_hours: Annotated[
+        float,
+        "Updated hour estimate. Pass -1 to clear the estimate. 0 = no change.",
+    ] = 0.0,
+) -> dict:
+    """
+    Update one or more fields of an existing task. Only non-empty / non-zero
+    arguments are applied. Returns {task: <full task object>, changes: {field: {from, to}}}.
+    Access the updated task via result.task, e.g. result.task.status.
+    """
+    store = get_store()
+    task = store.get_task(task_id)
+    if not task:
+        return {"error": f"Task '{task_id}' not found"}
+
+    updates: dict = {}
+
+    if title.strip():
+        updates["title"] = title.strip()
+    if description.strip():
+        updates["description"] = description.strip()
+
+    valid_statuses = {"backlog", "todo", "in_progress", "in_review", "done", "cancelled"}
+    if status.strip():
+        if status.strip() not in valid_statuses:
+            return {"error": f"status must be one of {sorted(valid_statuses)}"}
+        updates["status"] = status.strip()
+
+    valid_priorities = {"critical", "high", "medium", "low"}
+    if priority.strip():
+        if priority.strip() not in valid_priorities:
+            return {"error": f"priority must be one of {sorted(valid_priorities)}"}
+        updates["priority"] = priority.strip()
+
+    if assignee_id.strip():
+        updates["assignee_id"] = None if assignee_id.strip() == "unassign" else assignee_id.strip()
+
+    if labels.strip():
+        updates["labels"] = [lbl.strip() for lbl in labels.split(",") if lbl.strip()][:10]
+
+    if estimate_hours == -1:
+        updates["estimate_hours"] = 0.0
+    elif estimate_hours > 0:
+        updates["estimate_hours"] = estimate_hours
+
+    if not updates:
+        return {"task": task.to_dict(), "changes": {}, "message": "No changes applied"}
+
+    result = store.update_task(task_id, updates)
+    if result is None:
+        return {"error": f"Task '{task_id}' disappeared during update"}
+
+    updated_task, changes = result
+    return {"task": updated_task.to_dict(), "changes": changes}
+
+
+@pctx_tool
+@app.tool
+def move_task(
+    task_id: Annotated[str, "ID of the task to relocate"],
+    target_sprint_id: Annotated[
+        str,
+        "Sprint ID to move the task into. Pass 'backlog' to detach from any sprint.",
+    ],
+    new_status: Annotated[
+        str,
+        "Optional new status after move: backlog, todo, in_progress, in_review, done, cancelled. Empty = keep current status.",
+    ] = "",
+) -> dict:
+    """
+    Move a task from its current sprint to a different sprint (or backlog).
+    Optionally update its status at the same time. Returns {task, moved_from, moved_to}.
+    """
+    store = get_store()
+    task = store.get_task(task_id)
+    if not task:
+        return {"error": f"Task '{task_id}' not found"}
+
+    old_sprint_id = task.sprint_id
+
+    if target_sprint_id.strip() == "backlog":
+        # Remove from current sprint
+        if old_sprint_id and old_sprint_id in store.sprints:
+            sprint = store.sprints[old_sprint_id]
+            sprint.task_ids = [tid for tid in sprint.task_ids if tid != task_id]
+        task.sprint_id = None
+    else:
+        target = store.get_sprint(target_sprint_id.strip())
+        if not target:
+            return {"error": f"Target sprint '{target_sprint_id}' not found"}
+        # Remove from old sprint
+        if old_sprint_id and old_sprint_id in store.sprints:
+            old_sprint = store.sprints[old_sprint_id]
+            old_sprint.task_ids = [tid for tid in old_sprint.task_ids if tid != task_id]
+        # Add to new sprint
+        if task_id not in target.task_ids:
+            target.task_ids.append(task_id)
+        task.sprint_id = target_sprint_id.strip()
+
+    updates: dict = {}
+    if new_status.strip():
+        valid = {"backlog", "todo", "in_progress", "in_review", "done", "cancelled"}
+        if new_status.strip() not in valid:
+            return {"error": f"new_status must be one of {sorted(valid)}"}
+        updates["status"] = new_status.strip()
+
+    from pctx_code_mode.store import _now
+    task.updated_at = _now()
+
+    if updates:
+        store.update_task(task_id, updates)
+
+    return {
+        "task": task.to_dict(),
+        "moved_from": old_sprint_id,
+        "moved_to": task.sprint_id,
+    }
+
+
+@pctx_tool
+@app.tool
+def add_subtask(
+    parent_task_id: Annotated[str, "ID of the parent task to attach this subtask to"],
+    title: Annotated[str, "Short subtask title"],
+    description: Annotated[str, "Subtask description"] = "",
+    assignee_id: Annotated[str, "User ID to assign this subtask to"] = "",
+    estimate_hours: Annotated[float, "Hour estimate for this subtask"] = 0.0,
+    priority: Annotated[str, "Priority: critical, high, medium, low"] = "medium",
+) -> dict:
+    """
+    Create a subtask nested under an existing task. The subtask inherits
+    the parent's sprint and project. Returns the full subtask record.
+    """
+    store = get_store()
+    parent = store.get_task(parent_task_id)
+    if not parent:
+        return {"error": f"Parent task '{parent_task_id}' not found"}
+
+    valid_priorities = {"critical", "high", "medium", "low"}
+    if priority not in valid_priorities:
+        return {"error": f"priority must be one of {sorted(valid_priorities)}"}
+
+    task = store.create_task(
+        sprint_id=parent.sprint_id,
+        project_id=parent.project_id,
+        title=title.strip(),
+        description=description.strip(),
+        status="backlog",
+        priority=priority,
+        assignee_id=assignee_id.strip() or None,
+        labels=[],
+        estimate_hours=max(0.0, estimate_hours),
+        parent_task_id=parent_task_id,
+        acceptance_criteria=[],
+    )
+    return {
+        "subtask": task.to_dict(),
+        "parent_task_id": parent_task_id,
+        "parent_subtask_count": len(parent.subtask_ids),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Comments
+# ---------------------------------------------------------------------------
+
+
+@pctx_tool
+@app.tool
+def add_comment(
+    task_id: Annotated[str, "ID of the task to comment on"],
+    author_id: Annotated[str, "User ID of the comment author"],
+    body: Annotated[str, "Comment body (Markdown supported)"],
+    attachments: Annotated[
+        str,
+        (
+            "JSON array of attachment objects. "
+            'Each object must have "name" (string) and "url" (string). '
+            'Example: [{"name": "screenshot.png", "url": "https://..."}]'
+        ),
+    ] = "[]",
+) -> dict:
+    """
+    Add a comment to a task. Returns the created comment record and the
+    updated comment count on the task.
+    """
+    store = get_store()
+    task = store.get_task(task_id)
+    if not task:
+        return {"error": f"Task '{task_id}' not found"}
+
+    try:
+        attachment_list = json.loads(attachments) if attachments.strip() else []
+        if not isinstance(attachment_list, list):
+            attachment_list = []
+    except json.JSONDecodeError as exc:
+        return {"error": f"Invalid attachments JSON: {exc}"}
+
+    comment = store.add_comment(
+        task_id=task_id,
+        author_id=author_id.strip(),
+        body=body.strip(),
+        attachments=attachment_list,
+    )
+    if comment is None:
+        return {"error": f"Task '{task_id}' not found"}
+
+    return {
+        "comment": comment.to_dict(),
+        "task_comment_count": len(task.comment_ids),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Time tracking
+# ---------------------------------------------------------------------------
+
+
+@pctx_tool
+@app.tool
+def log_time(
+    task_id: Annotated[str, "ID of the task to log time against"],
+    user_id: Annotated[str, "User ID performing the work"],
+    hours: Annotated[float, "Hours worked (e.g. 1.5 = 1 hour 30 minutes). Must be > 0."],
+    description: Annotated[str, "Brief description of the work done in this session"],
+    work_date: Annotated[
+        str,
+        "Date the work was performed in YYYY-MM-DD format. Use today's date if unsure.",
+    ] = "",
+) -> dict:
+    """
+    Record a time entry on a task. Accumulates into the task's logged_hours.
+    Returns the time entry and updated hour totals for the task and its sprint.
+    """
+    store = get_store()
+    task = store.get_task(task_id)
+    if not task:
+        return {"error": f"Task '{task_id}' not found"}
+    if hours <= 0:
+        return {"error": "hours must be greater than 0"}
+
+    from datetime import date
+    effective_date = work_date.strip() if work_date.strip() else date.today().isoformat()
+
+    entry = store.log_time(
+        task_id=task_id,
+        user_id=user_id.strip(),
+        hours=hours,
+        description=description.strip(),
+        work_date=effective_date,
+    )
+    if entry is None:
+        return {"error": f"Task '{task_id}' not found"}
+
+    # Sprint total
+    sprint_logged = 0.0
+    if task.sprint_id and task.sprint_id in store.sprints:
+        sprint = store.sprints[task.sprint_id]
+        sprint_tasks = [store.tasks[tid] for tid in sprint.task_ids if tid in store.tasks]
+        sprint_logged = sum(t.logged_hours for t in sprint_tasks)
+
+    return {
+        "entry": entry.to_dict(),
+        "task_total_logged_hours": task.logged_hours,
+        "sprint_total_logged_hours": round(sprint_logged, 2),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Metrics
+# ---------------------------------------------------------------------------
+
+
+@pctx_tool
+@app.tool
+def get_sprint_metrics(
+    sprint_id: Annotated[str, "ID of the sprint to analyse"],
+    include_burndown: Annotated[
+        bool,
+        "Include daily burndown data points (ideal vs actual remaining hours)",
+    ] = True,
+    include_task_breakdown: Annotated[
+        bool,
+        "Include task counts segmented by status and priority, plus top-contributor list",
+    ] = True,
+) -> dict:
+    """
+    Compute velocity, completion rate, utilisation, burndown, and task
+    breakdowns for a sprint. Ideal for generating progress reports or
+    deciding whether to close/extend a sprint.
+    """
+    store = get_store()
+    metrics = store.compute_sprint_metrics(
+        sprint_id=sprint_id,
+        include_burndown=include_burndown,
+        include_task_breakdown=include_task_breakdown,
+    )
+    if metrics is None:
+        return {"error": f"Sprint '{sprint_id}' not found"}
+    return metrics
+
+
+# ---------------------------------------------------------------------------
+# Search
+# ---------------------------------------------------------------------------
+
+
+@pctx_tool
+@app.tool
+def search_tasks(
+    query: Annotated[
+        str,
+        "Full-text search across task titles and descriptions. Leave empty for no text filter.",
+    ] = "",
+    project_id: Annotated[str, "Restrict to tasks in this project. Empty = all projects."] = "",
+    sprint_id: Annotated[str, "Restrict to tasks in this sprint. Empty = all sprints."] = "",
+    assignee_id: Annotated[str, "Only return tasks assigned to this user ID."] = "",
+    status: Annotated[
+        str,
+        "Comma-separated statuses to include (e.g. in_progress,in_review). Empty = all.",
+    ] = "",
+    priority: Annotated[
+        str,
+        "Comma-separated priorities to include (e.g. critical,high). Empty = all.",
+    ] = "",
+    labels: Annotated[
+        str,
+        "Comma-separated labels; returns tasks that have ALL of them. Empty = no label filter.",
+    ] = "",
+    has_estimate: Annotated[bool, "If True, only return tasks that have an estimate set (> 0)."] = False,
+    is_overdue: Annotated[
+        bool,
+        "If True, only return incomplete tasks whose sprint has passed its end_date.",
+    ] = False,
+    sort_by: Annotated[
+        str,
+        "Sort field: updated_at (default), created_at, priority, estimate_hours",
+    ] = "updated_at",
+    limit: Annotated[int, "Maximum results to return (1-100)"] = 20,
+) -> dict:
+    """
+    Search tasks across the entire store with fine-grained filters.
+    Returns a list of task summaries (without full description/criteria),
+    total count, and the filters that were applied.
+    """
+    store = get_store()
+
+    statuses = [s.strip() for s in status.split(",") if s.strip()]
+    priorities = [p.strip() for p in priority.split(",") if p.strip()]
+    label_list = [lbl.strip() for lbl in labels.split(",") if lbl.strip()]
+
+    valid_sort = {"updated_at", "created_at", "priority", "estimate_hours"}
+    if sort_by not in valid_sort:
+        sort_by = "updated_at"
+
+    return store.search_tasks(
+        query=query.strip(),
+        project_id=project_id.strip(),
+        sprint_id=sprint_id.strip(),
+        assignee_id=assignee_id.strip(),
+        statuses=statuses,
+        priorities=priorities,
+        labels=label_list,
+        has_estimate=has_estimate,
+        is_overdue=is_overdue,
+        sort_by=sort_by,
+        limit=max(1, min(100, limit)),
+    )
+
+
+# ---------------------------------------------------------------------------
+# pctx Tool registry
+#
+# All tools are decorated with @pctx_tool (above @app.tool), so each name
+# below is a pctx_client.Tool instance.  Consumers that want direct Code Mode
+# access without going through the MCP transport can do:
+#
+#   from pctx_code_mode.server import pctx_tools
+#   async with Pctx(tools=pctx_tools, url=...) as pctx:
+#       result = await pctx.execute_typescript("...")
+# ---------------------------------------------------------------------------
+
+pctx_tools = [
+    create_project,
+    get_project,
+    list_projects,
+    create_sprint,
+    get_sprint,
+    activate_sprint,
+    close_sprint,
+    create_task,
+    get_task,
+    update_task,
+    move_task,
+    add_subtask,
+    add_comment,
+    log_time,
+    get_sprint_metrics,
+    search_tasks,
+]
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    import os
+    transport = sys.argv[1] if len(sys.argv) > 1 else os.environ.get("ARCADE_SERVER_TRANSPORT", "stdio")
+    host = os.environ.get("ARCADE_SERVER_HOST", "127.0.0.1")
+    port = int(os.environ.get("ARCADE_SERVER_PORT", "8000"))
+    app.run(transport=transport, host=host, port=port)

--- a/examples/mcp_servers/pctx_code_mode/src/pctx_code_mode/store.py
+++ b/examples/mcp_servers/pctx_code_mode/src/pctx_code_mode/store.py
@@ -1,0 +1,650 @@
+"""
+In-memory store for the ProjectTracker MCP server.
+
+Seeded with stable demo data so evaluations can use predictable IDs.
+"""
+
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _uid(prefix: str) -> str:
+    return f"{prefix}_{uuid.uuid4().hex[:8]}"
+
+
+# ---------------------------------------------------------------------------
+# Data models
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Project:
+    project_id: str
+    name: str
+    description: str
+    owner_id: str
+    status: str  # planning | active | on_hold | completed | archived
+    tags: list[str]
+    settings: dict[str, Any]
+    sprint_ids: list[str]
+    member_ids: list[str]
+    created_at: str
+    updated_at: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "project_id": self.project_id,
+            "name": self.name,
+            "description": self.description,
+            "owner_id": self.owner_id,
+            "status": self.status,
+            "tags": self.tags,
+            "settings": self.settings,
+            "sprint_count": len(self.sprint_ids),
+            "member_ids": self.member_ids,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+        }
+
+
+@dataclass
+class Sprint:
+    sprint_id: str
+    project_id: str
+    name: str
+    status: str  # planning | active | completed
+    start_date: str
+    end_date: str
+    goals: list[str]
+    capacity_hours: float
+    task_ids: list[str]
+    retrospective_notes: str
+    created_at: str
+    updated_at: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "sprint_id": self.sprint_id,
+            "project_id": self.project_id,
+            "name": self.name,
+            "status": self.status,
+            "start_date": self.start_date,
+            "end_date": self.end_date,
+            "goals": self.goals,
+            "capacity_hours": self.capacity_hours,
+            "task_count": len(self.task_ids),
+            "task_ids": self.task_ids,
+            "retrospective_notes": self.retrospective_notes,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+        }
+
+
+@dataclass
+class Task:
+    task_id: str
+    sprint_id: str | None
+    project_id: str
+    title: str
+    description: str
+    status: str  # backlog | todo | in_progress | in_review | done | cancelled
+    priority: str  # critical | high | medium | low
+    assignee_id: str | None
+    labels: list[str]
+    estimate_hours: float
+    parent_task_id: str | None
+    subtask_ids: list[str]
+    acceptance_criteria: list[str]
+    comment_ids: list[str]
+    time_entry_ids: list[str]
+    logged_hours: float
+    created_at: str
+    updated_at: str
+
+    def to_dict(self, include_full: bool = True) -> dict[str, Any]:
+        d: dict[str, Any] = {
+            "task_id": self.task_id,
+            "sprint_id": self.sprint_id,
+            "project_id": self.project_id,
+            "title": self.title,
+            "status": self.status,
+            "priority": self.priority,
+            "assignee_id": self.assignee_id,
+            "labels": self.labels,
+            "estimate_hours": self.estimate_hours,
+            "logged_hours": self.logged_hours,
+            "parent_task_id": self.parent_task_id,
+            "subtask_count": len(self.subtask_ids),
+            "subtask_ids": self.subtask_ids,
+            "comment_count": len(self.comment_ids),
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+        }
+        if include_full:
+            d["description"] = self.description
+            d["acceptance_criteria"] = self.acceptance_criteria
+        return d
+
+
+@dataclass
+class Comment:
+    comment_id: str
+    task_id: str
+    author_id: str
+    body: str
+    attachments: list[dict[str, str]]
+    created_at: str
+    updated_at: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "comment_id": self.comment_id,
+            "task_id": self.task_id,
+            "author_id": self.author_id,
+            "body": self.body,
+            "attachments": self.attachments,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+        }
+
+
+@dataclass
+class TimeEntry:
+    entry_id: str
+    task_id: str
+    user_id: str
+    hours: float
+    description: str
+    work_date: str
+    created_at: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "entry_id": self.entry_id,
+            "task_id": self.task_id,
+            "user_id": self.user_id,
+            "hours": self.hours,
+            "description": self.description,
+            "work_date": self.work_date,
+            "created_at": self.created_at,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Store
+# ---------------------------------------------------------------------------
+
+
+class ProjectStore:
+    def __init__(self) -> None:
+        self.projects: dict[str, Project] = {}
+        self.sprints: dict[str, Sprint] = {}
+        self.tasks: dict[str, Task] = {}
+        self.comments: dict[str, Comment] = {}
+        self.time_entries: dict[str, TimeEntry] = {}
+        self._seed()
+
+    # ------------------------------------------------------------------
+    # Seed
+    # ------------------------------------------------------------------
+
+    def _seed(self) -> None:
+        """Pre-populate with stable demo data so evals have predictable IDs."""
+
+        proj = Project(
+            project_id="proj_webapp_001",
+            name="WebApp Redesign",
+            description=(
+                "Full redesign of the customer-facing web application focusing on "
+                "performance, accessibility (WCAG AA), and a modern design system."
+            ),
+            owner_id="user_alice",
+            status="active",
+            tags=["frontend", "ux", "q1-2025"],
+            settings={
+                "velocity_unit": "hours",
+                "sprint_length_days": 14,
+                "default_priority": "medium",
+                "require_estimate": False,
+                "review_required": True,
+            },
+            sprint_ids=["spr_001"],
+            member_ids=["user_alice", "user_bob", "user_carol"],
+            created_at="2025-01-01T09:00:00+00:00",
+            updated_at="2025-01-15T14:30:00+00:00",
+        )
+        self.projects["proj_webapp_001"] = proj
+
+        sprint = Sprint(
+            sprint_id="spr_001",
+            project_id="proj_webapp_001",
+            name="Sprint 1 — Foundation",
+            status="active",
+            start_date="2025-01-13",
+            end_date="2025-01-26",
+            goals=[
+                "Deliver responsive navigation component",
+                "Complete hero section design and implementation",
+                "Set up CI/CD pipeline",
+            ],
+            capacity_hours=80.0,
+            task_ids=["task_001", "task_002", "task_003", "task_004"],
+            retrospective_notes="",
+            created_at="2025-01-10T08:00:00+00:00",
+            updated_at="2025-01-13T09:00:00+00:00",
+        )
+        self.sprints["spr_001"] = sprint
+
+        seed_tasks = [
+            Task(
+                task_id="task_001",
+                sprint_id="spr_001",
+                project_id="proj_webapp_001",
+                title="Design hero section",
+                description=(
+                    "Create a responsive hero section with animated headline, "
+                    "CTA button, and background illustration. Must pass WCAG AA."
+                ),
+                status="in_progress",
+                priority="high",
+                assignee_id="user_alice",
+                labels=["design", "frontend", "wcag"],
+                estimate_hours=8.0,
+                parent_task_id=None,
+                subtask_ids=[],
+                acceptance_criteria=[
+                    "Hero renders correctly at 320px, 768px, and 1440px breakpoints",
+                    "CTA button has visible focus ring",
+                    "Background image has meaningful alt text",
+                    "Animation respects prefers-reduced-motion media query",
+                ],
+                comment_ids=[],
+                time_entry_ids=[],
+                logged_hours=3.5,
+                created_at="2025-01-13T09:30:00+00:00",
+                updated_at="2025-01-15T16:00:00+00:00",
+            ),
+            Task(
+                task_id="task_002",
+                sprint_id="spr_001",
+                project_id="proj_webapp_001",
+                title="Implement navigation component",
+                description=(
+                    "Build top navigation bar with responsive hamburger menu, "
+                    "active-link highlighting, and full keyboard navigation support."
+                ),
+                status="todo",
+                priority="medium",
+                assignee_id="user_bob",
+                labels=["frontend", "component", "a11y"],
+                estimate_hours=6.0,
+                parent_task_id=None,
+                subtask_ids=[],
+                acceptance_criteria=[
+                    "Tab order is logical and follows visual flow",
+                    "Hamburger menu closes on ESC key press",
+                    "Active route is visually indicated with aria-current",
+                ],
+                comment_ids=[],
+                time_entry_ids=[],
+                logged_hours=0.0,
+                created_at="2025-01-13T09:45:00+00:00",
+                updated_at="2025-01-13T09:45:00+00:00",
+            ),
+            Task(
+                task_id="task_003",
+                sprint_id="spr_001",
+                project_id="proj_webapp_001",
+                title="Write unit tests for auth module",
+                description=(
+                    "Add comprehensive unit tests covering login, logout, "
+                    "token refresh, session expiry, and all error states."
+                ),
+                status="backlog",
+                priority="high",
+                assignee_id=None,
+                labels=["testing", "auth", "backend"],
+                estimate_hours=5.0,
+                parent_task_id=None,
+                subtask_ids=[],
+                acceptance_criteria=[
+                    "Line coverage >= 90% on auth module",
+                    "All happy paths and error states covered",
+                    "Token expiry edge case explicitly tested",
+                ],
+                comment_ids=[],
+                time_entry_ids=[],
+                logged_hours=0.0,
+                created_at="2025-01-13T10:00:00+00:00",
+                updated_at="2025-01-13T10:00:00+00:00",
+            ),
+            Task(
+                task_id="task_004",
+                sprint_id="spr_001",
+                project_id="proj_webapp_001",
+                title="Fix mobile layout regression — Safari iOS",
+                description=(
+                    "Safari on iOS 17 clips the footer on pages with a sticky header. "
+                    "Root cause is an overflow issue with the sticky positioning context."
+                ),
+                status="in_review",
+                priority="critical",
+                assignee_id="user_alice",
+                labels=["bug", "mobile", "safari", "css"],
+                estimate_hours=3.0,
+                parent_task_id=None,
+                subtask_ids=[],
+                acceptance_criteria=[
+                    "Footer fully visible on iPhone 12, 13, and 14 viewport",
+                    "No horizontal scrollbar appears in Safari iOS",
+                    "Regression test added to E2E suite",
+                ],
+                comment_ids=[],
+                time_entry_ids=[],
+                logged_hours=2.0,
+                created_at="2025-01-14T11:00:00+00:00",
+                updated_at="2025-01-15T09:00:00+00:00",
+            ),
+        ]
+
+        for task in seed_tasks:
+            self.tasks[task.task_id] = task
+
+    # ------------------------------------------------------------------
+    # Project helpers
+    # ------------------------------------------------------------------
+
+    def create_project(self, **kwargs: Any) -> Project:
+        project_id = _uid("proj")
+        now = _now()
+        proj = Project(project_id=project_id, created_at=now, updated_at=now, **kwargs)
+        self.projects[project_id] = proj
+        return proj
+
+    def get_project(self, project_id: str) -> Project | None:
+        return self.projects.get(project_id)
+
+    # ------------------------------------------------------------------
+    # Sprint helpers
+    # ------------------------------------------------------------------
+
+    def create_sprint(self, **kwargs: Any) -> Sprint:
+        sprint_id = _uid("spr")
+        now = _now()
+        sprint = Sprint(sprint_id=sprint_id, created_at=now, updated_at=now, **kwargs)
+        self.sprints[sprint_id] = sprint
+        proj = self.projects.get(sprint.project_id)
+        if proj:
+            proj.sprint_ids.append(sprint_id)
+            proj.updated_at = now
+        return sprint
+
+    def get_sprint(self, sprint_id: str) -> Sprint | None:
+        return self.sprints.get(sprint_id)
+
+    # ------------------------------------------------------------------
+    # Task helpers
+    # ------------------------------------------------------------------
+
+    def create_task(self, **kwargs: Any) -> Task:
+        task_id = _uid("task")
+        now = _now()
+        task = Task(
+            task_id=task_id,
+            comment_ids=[],
+            time_entry_ids=[],
+            subtask_ids=[],
+            logged_hours=0.0,
+            created_at=now,
+            updated_at=now,
+            **kwargs,
+        )
+        self.tasks[task_id] = task
+        # Register in sprint
+        sprint = self.sprints.get(task.sprint_id or "")
+        if sprint:
+            sprint.task_ids.append(task_id)
+            sprint.updated_at = now
+        # Register as subtask on parent
+        if task.parent_task_id:
+            parent = self.tasks.get(task.parent_task_id)
+            if parent:
+                parent.subtask_ids.append(task_id)
+                parent.updated_at = now
+        return task
+
+    def get_task(self, task_id: str) -> Task | None:
+        return self.tasks.get(task_id)
+
+    def update_task(
+        self, task_id: str, updates: dict[str, Any]
+    ) -> tuple[Task, dict[str, Any]] | None:
+        task = self.tasks.get(task_id)
+        if not task:
+            return None
+        changes: dict[str, Any] = {}
+        for key, new_val in updates.items():
+            old_val = getattr(task, key, None)
+            if old_val != new_val:
+                changes[key] = {"from": old_val, "to": new_val}
+                setattr(task, key, new_val)
+        task.updated_at = _now()
+        return task, changes
+
+    # ------------------------------------------------------------------
+    # Comment helpers
+    # ------------------------------------------------------------------
+
+    def add_comment(
+        self, task_id: str, author_id: str, body: str, attachments: list[dict[str, str]]
+    ) -> Comment | None:
+        task = self.tasks.get(task_id)
+        if not task:
+            return None
+        comment_id = _uid("cmt")
+        now = _now()
+        comment = Comment(
+            comment_id=comment_id,
+            task_id=task_id,
+            author_id=author_id,
+            body=body,
+            attachments=attachments,
+            created_at=now,
+            updated_at=now,
+        )
+        self.comments[comment_id] = comment
+        task.comment_ids.append(comment_id)
+        task.updated_at = now
+        return comment
+
+    # ------------------------------------------------------------------
+    # Time tracking helpers
+    # ------------------------------------------------------------------
+
+    def log_time(
+        self, task_id: str, user_id: str, hours: float, description: str, work_date: str
+    ) -> TimeEntry | None:
+        task = self.tasks.get(task_id)
+        if not task:
+            return None
+        entry_id = _uid("te")
+        now = _now()
+        entry = TimeEntry(
+            entry_id=entry_id,
+            task_id=task_id,
+            user_id=user_id,
+            hours=hours,
+            description=description,
+            work_date=work_date,
+            created_at=now,
+        )
+        self.time_entries[entry_id] = entry
+        task.time_entry_ids.append(entry_id)
+        task.logged_hours += hours
+        task.updated_at = now
+        return entry
+
+    # ------------------------------------------------------------------
+    # Sprint metrics
+    # ------------------------------------------------------------------
+
+    def compute_sprint_metrics(
+        self, sprint_id: str, include_burndown: bool, include_task_breakdown: bool
+    ) -> dict[str, Any] | None:
+        sprint = self.sprints.get(sprint_id)
+        if not sprint:
+            return None
+
+        tasks = [self.tasks[tid] for tid in sprint.task_ids if tid in self.tasks]
+        total = len(tasks)
+        done = sum(1 for t in tasks if t.status == "done")
+        cancelled = sum(1 for t in tasks if t.status == "cancelled")
+        carry_over = total - done - cancelled
+        estimated = sum(t.estimate_hours for t in tasks)
+        logged = sum(t.logged_hours for t in tasks)
+
+        metrics: dict[str, Any] = {
+            "sprint_id": sprint_id,
+            "sprint_name": sprint.name,
+            "status": sprint.status,
+            "total_tasks": total,
+            "completed_tasks": done,
+            "cancelled_tasks": cancelled,
+            "carry_over_tasks": carry_over,
+            "completion_rate": round(done / total, 4) if total else 0.0,
+            "hours_estimated": estimated,
+            "hours_logged": logged,
+            "velocity": logged,
+            "capacity_hours": sprint.capacity_hours,
+            "utilization_rate": round(logged / sprint.capacity_hours, 4)
+            if sprint.capacity_hours
+            else 0.0,
+        }
+
+        if include_burndown:
+            # Synthetic burndown: linear ideal line vs stepwise actual
+            metrics["burndown"] = [
+                {
+                    "date": sprint.start_date,
+                    "remaining_ideal": estimated,
+                    "remaining_actual": estimated,
+                },
+                {
+                    "date": sprint.end_date,
+                    "remaining_ideal": 0.0,
+                    "remaining_actual": max(0.0, estimated - logged),
+                },
+            ]
+
+        if include_task_breakdown:
+            by_status: dict[str, int] = {}
+            by_priority: dict[str, int] = {}
+            for t in tasks:
+                by_status[t.status] = by_status.get(t.status, 0) + 1
+                by_priority[t.priority] = by_priority.get(t.priority, 0) + 1
+
+            # Contributor summary
+            contributor_hours: dict[str, float] = {}
+            contributor_done: dict[str, int] = {}
+            for t in tasks:
+                uid = t.assignee_id or "unassigned"
+                contributor_hours[uid] = contributor_hours.get(uid, 0.0) + t.logged_hours
+                if t.status == "done":
+                    contributor_done[uid] = contributor_done.get(uid, 0) + 1
+
+            metrics["task_breakdown"] = {
+                "by_status": by_status,
+                "by_priority": by_priority,
+            }
+            metrics["top_contributors"] = [
+                {
+                    "user_id": uid,
+                    "hours_logged": round(contributor_hours[uid], 2),
+                    "tasks_completed": contributor_done.get(uid, 0),
+                }
+                for uid in sorted(contributor_hours, key=lambda u: -contributor_hours[u])
+            ]
+
+        return metrics
+
+    # ------------------------------------------------------------------
+    # Search
+    # ------------------------------------------------------------------
+
+    def search_tasks(
+        self,
+        *,
+        query: str,
+        project_id: str,
+        sprint_id: str,
+        assignee_id: str,
+        statuses: list[str],
+        priorities: list[str],
+        labels: list[str],
+        has_estimate: bool,
+        is_overdue: bool,
+        sort_by: str,
+        limit: int,
+    ) -> dict[str, Any]:
+        results = list(self.tasks.values())
+
+        if project_id:
+            results = [t for t in results if t.project_id == project_id]
+        if sprint_id:
+            results = [t for t in results if t.sprint_id == sprint_id]
+        if assignee_id:
+            results = [t for t in results if t.assignee_id == assignee_id]
+        if statuses:
+            results = [t for t in results if t.status in statuses]
+        if priorities:
+            results = [t for t in results if t.priority in priorities]
+        if labels:
+            results = [t for t in results if all(lbl in t.labels for lbl in labels)]
+        if has_estimate:
+            results = [t for t in results if t.estimate_hours > 0]
+        if is_overdue:
+            results = [t for t in results if t.status not in ("done", "cancelled")]
+        if query:
+            q = query.lower()
+            results = [t for t in results if q in t.title.lower() or q in t.description.lower()]
+
+        priority_order = {"critical": 0, "high": 1, "medium": 2, "low": 3}
+        if sort_by == "priority":
+            results.sort(key=lambda t: priority_order.get(t.priority, 99))
+        elif sort_by == "estimate_hours":
+            results.sort(key=lambda t: -t.estimate_hours)
+        elif sort_by == "created_at":
+            results.sort(key=lambda t: t.created_at, reverse=True)
+        else:
+            results.sort(key=lambda t: t.updated_at, reverse=True)
+
+        total = len(results)
+        results = results[:limit]
+
+        return {
+            "tasks": [t.to_dict(include_full=False) for t in results],
+            "total": total,
+            "returned": len(results),
+            "filters_applied": {
+                "project_id": project_id or None,
+                "sprint_id": sprint_id or None,
+                "assignee_id": assignee_id or None,
+                "statuses": statuses or None,
+                "priorities": priorities or None,
+                "labels": labels or None,
+            },
+        }
+
+
+# Module-level singleton so all tool calls share the same state
+_store = ProjectStore()
+
+
+def get_store() -> ProjectStore:
+    return _store


### PR DESCRIPTION
Adds examples/evals/eval_pctx_code_mode.py, an evaluation suite for the pctx Code Mode MCP server example. Unlike the standard arcade-evals runner (which scores LLM tool calls directly), Code Mode requires a custom execution loop: the LLM generates TypeScript, pctx executes it in a sandbox, and tool invocations are extracted from the ExecutionTrace and scored against expected calls using arcade-evals critics and rubrics.

**What's included:**

- 7 eval cases covering the full ProjectTracker API: listing projects, getting/creating projects and sprints, task lifecycle, sprint metrics, search, and a multi-step chained workflow
- Soft rubric (fail_threshold=0.7) that scores via cost matrix rather than hard-failing on tool selection or call count, since Code Mode may inject extra helper calls
- `_build_system_prompt(declarations)` — system prompt is constructed at runtime from pctx.get_function_details(), injecting the actual TypeScript function signatures rather than hardcoding calling conventions; this keeps the prompt accurate as the tool surface evolves
- Supports OpenRouter or OpenAI via OPENROUTER_API_KEY / OPENAI_API_KEY, with model override via EVAL_MODEL


To run:

`pctx start
uv run --directory examples/mcp_servers/pctx_code_mode examples/evals/eval_pctx_code_mode.py`