### PR TITLE
chore(arcade-core): update PostHog project token

### DIFF
--- a/libs/arcade-core/arcade_core/usage/usage_service.py
+++ b/libs/arcade-core/arcade_core/usage/usage_service.py
@@ -19,7 +19,7 @@ from arcade_core.usage.utils import is_tracking_enabled
 
 class UsageService:
     def __init__(self) -> None:
-        self.api_key = "phc_hIqUQyJpf2TP4COePO5jEpkGeUXipa7KqTEyDeRsTmB"
+        self.api_key = "phc_zNHKkPFsrKVSpd7y85jnxW8jNVW6AQD6AwqE4nWjwpXg"
         self.host = "https://us.i.posthog.com"
 
     def alias(self, previous_id: str, distinct_id: str) -> None:


### PR DESCRIPTION

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only rotates the PostHog project API key used for CLI telemetry; main risk is misconfiguration causing events to be sent to the wrong project or dropped.
> 
> **Overview**
> Updates `UsageService` to use a new PostHog project API key for CLI usage telemetry, redirecting all `alias` and background `capture` events to the new PostHog project.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8cb1c7f1cc5bccd22cb2c73469848d88a703f27e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->