### PR TITLE
Add Perplexity Search toolkit

### DIFF
--- a/toolkits/perplexity/.pre-commit-config.yaml
+++ b/toolkits/perplexity/.pre-commit-config.yaml
@@ -1,0 +1,18 @@
+files: ^arcade_perplexity/.*
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: "v4.4.0"
+    hooks:
+      - id: check-case-conflict
+      - id: check-merge-conflict
+      - id: check-toml
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.6.7
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format

--- a/toolkits/perplexity/.ruff.toml
+++ b/toolkits/perplexity/.ruff.toml
@@ -1,0 +1,44 @@
+target-version = "py310"
+line-length = 100
+fix = true
+
+[lint]
+select = [
+    # flake8-2020
+    "YTT",
+    # flake8-bandit
+    "S",
+    # flake8-bugbear
+    "B",
+    # flake8-builtins
+    "A",
+    # flake8-comprehensions
+    "C4",
+    # flake8-debugger
+    "T10",
+    # flake8-simplify
+    "SIM",
+    # isort
+    "I",
+    # mccabe
+    "C90",
+    # pycodestyle
+    "E", "W",
+    # pyflakes
+    "F",
+    # pygrep-hooks
+    "PGH",
+    # pyupgrade
+    "UP",
+    # ruff
+    "RUF",
+    # tryceratops
+    "TRY",
+]
+
+[lint.per-file-ignores]
+"**/tests/*" = ["S101"]
+
+[format]
+preview = true
+skip-magic-trailing-comma = false

--- a/toolkits/perplexity/LICENSE
+++ b/toolkits/perplexity/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026, Arcade AI
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/toolkits/perplexity/Makefile
+++ b/toolkits/perplexity/Makefile
@@ -1,0 +1,55 @@
+.PHONY: help
+
+help:
+	@echo "🛠️ perplexity Commands:\n"
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+.PHONY: install
+install: ## Install the uv environment and install all packages with dependencies
+	@echo "🚀 Creating virtual environment and installing all packages using uv"
+	@uv sync --active --all-extras --no-sources
+	@if [ -f .pre-commit-config.yaml ]; then uv run --no-sources pre-commit install; fi
+	@echo "✅ All packages and dependencies installed via uv"
+
+.PHONY: install-local
+install-local: ## Install the uv environment and install all packages with dependencies with local Arcade sources
+	@echo "🚀 Creating virtual environment and installing all packages using uv"
+	@uv sync --active --all-extras
+	@if [ -f .pre-commit-config.yaml ]; then uv run pre-commit install; fi
+	@echo "✅ All packages and dependencies installed via uv"
+
+.PHONY: build
+build: clean-build ## Build wheel file
+	@echo "🚀 Creating wheel file"
+	uv build
+
+.PHONY: clean-build
+clean-build: ## clean build artifacts
+	@echo "🗑️ Cleaning dist directory"
+	rm -rf dist
+
+.PHONY: test
+test: ## Test the code with pytest
+	@echo "🚀 Testing code: Running pytest"
+	@uv run --no-sources pytest -W ignore -v --cov --cov-config=pyproject.toml --cov-report=xml
+
+.PHONY: coverage
+coverage: ## Generate coverage report
+	@echo "coverage report"
+	@uv run --no-sources coverage report
+	@echo "Generating coverage report"
+	@uv run --no-sources coverage html
+
+.PHONY: bump-version
+bump-version: ## Bump the version in the pyproject.toml file by a patch version
+	@echo "🚀 Bumping version in pyproject.toml"
+	uv version --no-sources --bump patch
+
+.PHONY: check
+check: ## Run code quality tools.
+	@if [ -f .pre-commit-config.yaml ]; then\
+		echo "🚀 Linting code: Running pre-commit";\
+		uv run --no-sources pre-commit run -a;\
+	fi
+	@echo "🚀 Static type checking: Running mypy"
+	@uv run --no-sources mypy --config-file=pyproject.toml

--- a/toolkits/perplexity/README.md
+++ b/toolkits/perplexity/README.md
@@ -1,0 +1,45 @@
+# Arcade Perplexity Toolkit
+
+Arcade.dev LLM tools for searching the web with the
+[Perplexity Search API](https://docs.perplexity.ai/api-reference/search-post).
+
+## Tools
+
+- `search` — issue a query against `POST https://api.perplexity.ai/search`
+  and return a list of results, each containing `title`, `url`, and
+  `snippet`.
+
+## Configuration
+
+The toolkit requires a single secret:
+
+| Secret | Description |
+| --- | --- |
+| `PERPLEXITY_API_KEY` | Your Perplexity API key (sent as `Authorization: Bearer ...`). |
+
+Every outgoing request includes an `X-Pplx-Integration: arcade/<version>`
+header so Perplexity can attribute traffic to this integration.
+
+## Inputs
+
+| Field | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `query` | string | — | The search query. |
+| `max_results` | int | `5` | Clamped to `[1, 20]`. |
+| `search_recency_filter` | enum | — | One of `hour`, `day`, `week`, `month`, `year`. |
+
+## Output
+
+```python
+[
+    {"title": "...", "url": "https://...", "snippet": "..."},
+    ...
+]
+```
+
+## Development
+
+```bash
+make install-local
+make test
+```

--- a/toolkits/perplexity/arcade_perplexity/__init__.py
+++ b/toolkits/perplexity/arcade_perplexity/__init__.py
@@ -1,0 +1,3 @@
+from arcade_perplexity.tools import search
+
+__all__ = ["search"]

--- a/toolkits/perplexity/arcade_perplexity/__main__.py
+++ b/toolkits/perplexity/arcade_perplexity/__main__.py
@@ -1,0 +1,28 @@
+import sys
+from typing import cast
+
+from arcade_mcp_server import MCPApp
+from arcade_mcp_server.mcp_app import TransportType
+
+import arcade_perplexity
+
+app = MCPApp(
+    name="Perplexity",
+    instructions=(
+        "Use this server to search the web with Perplexity's Search API. "
+        "Returns ranked results with title, URL, and snippet."
+    ),
+)
+
+app.add_tools_from_module(arcade_perplexity)
+
+
+def main() -> None:
+    transport = sys.argv[1] if len(sys.argv) > 1 else "stdio"
+    host = sys.argv[2] if len(sys.argv) > 2 else "127.0.0.1"
+    port = int(sys.argv[3]) if len(sys.argv) > 3 else 8000
+    app.run(transport=cast(TransportType, transport), host=host, port=port)
+
+
+if __name__ == "__main__":
+    main()

--- a/toolkits/perplexity/arcade_perplexity/tools/__init__.py
+++ b/toolkits/perplexity/arcade_perplexity/tools/__init__.py
@@ -1,0 +1,3 @@
+from arcade_perplexity.tools.search import search
+
+__all__ = ["search"]

--- a/toolkits/perplexity/arcade_perplexity/tools/search.py
+++ b/toolkits/perplexity/arcade_perplexity/tools/search.py
@@ -1,0 +1,92 @@
+import importlib.metadata
+from enum import Enum
+from typing import Annotated
+
+import httpx
+from arcade_mcp_server import Context, tool
+
+PERPLEXITY_SEARCH_URL = "https://api.perplexity.ai/search"
+INTEGRATION_SLUG = "arcade"
+PACKAGE_NAME = "arcade_perplexity"
+DEFAULT_MAX_RESULTS = 5
+MAX_RESULTS_LIMIT = 20
+
+
+class SearchRecencyFilter(str, Enum):
+    HOUR = "hour"
+    DAY = "day"
+    WEEK = "week"
+    MONTH = "month"
+    YEAR = "year"
+
+
+def _integration_header() -> str:
+    try:
+        version = importlib.metadata.version(PACKAGE_NAME)
+    except importlib.metadata.PackageNotFoundError:
+        version = "unknown"
+    return f"{INTEGRATION_SLUG}/{version}"
+
+
+@tool(requires_secrets=["PERPLEXITY_API_KEY"])
+async def search(
+    context: Context,
+    query: Annotated[str, "The search query to send to Perplexity."],
+    max_results: Annotated[
+        int,
+        "Maximum number of results to return (1-20). Defaults to 5.",
+    ] = DEFAULT_MAX_RESULTS,
+    search_recency_filter: Annotated[
+        SearchRecencyFilter | None,
+        "Restrict results to content published within the given recency window.",
+    ] = None,
+) -> Annotated[
+    list[dict[str, str]],
+    "List of search results, each with 'title', 'url', and 'snippet'.",
+]:
+    """Search the web using the Perplexity Search API.
+
+    Returns a list of ranked results with the page title, URL, and a short
+    snippet of the most relevant content from each page.
+    """
+    api_key = context.get_secret("PERPLEXITY_API_KEY")
+
+    bounded_max_results = max(1, min(int(max_results), MAX_RESULTS_LIMIT))
+
+    payload: dict[str, object] = {
+        "query": query,
+        "max_results": bounded_max_results,
+    }
+    if search_recency_filter is not None:
+        recency = (
+            search_recency_filter.value
+            if isinstance(search_recency_filter, SearchRecencyFilter)
+            else str(search_recency_filter)
+        )
+        payload["search_recency_filter"] = recency
+
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+        "X-Pplx-Integration": _integration_header(),
+    }
+
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            PERPLEXITY_SEARCH_URL,
+            headers=headers,
+            json=payload,
+            timeout=30.0,
+        )
+        response.raise_for_status()
+        data = response.json()
+
+    results = data.get("results", []) if isinstance(data, dict) else []
+    return [
+        {
+            "title": str(item.get("title", "")),
+            "url": str(item.get("url", "")),
+            "snippet": str(item.get("snippet", "")),
+        }
+        for item in results
+    ]

--- a/toolkits/perplexity/pyproject.toml
+++ b/toolkits/perplexity/pyproject.toml
@@ -1,0 +1,63 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "arcade_perplexity"
+version = "0.1.0"
+description = "Arcade.dev LLM tools for Perplexity Search"
+requires-python = ">=3.10"
+dependencies = [
+    "arcade-mcp-server>=1.17.0,<2.0.0",
+    "httpx>=0.28.0,<1.0.0",
+]
+[[project.authors]]
+name = "Arcade"
+email = "dev@arcade.dev"
+
+[project.scripts]
+arcade-perplexity = "arcade_perplexity.__main__:main"
+arcade_perplexity = "arcade_perplexity.__main__:main"
+
+[project.optional-dependencies]
+dev = [
+    "arcade-mcp[all]>=1.4.0,<2.0.0",
+    "pytest>=8.3.0,<8.4.0",
+    "pytest-cov>=4.0.0,<4.1.0",
+    "pytest-mock>=3.11.1,<3.12.0",
+    "pytest-asyncio>=0.24.0,<0.25.0",
+    "mypy>=1.5.1,<1.6.0",
+    "pre-commit>=3.4.0,<3.5.0",
+    "ruff>=0.7.4,<0.8.0",
+    "respx>=0.21.0,<0.22.0",
+]
+
+# Tell Arcade.dev that this package is a toolkit
+[project.entry-points.arcade_toolkits]
+toolkit_name = "arcade_perplexity"
+
+[tool.uv.sources]
+arcade-mcp = { path = "../../", editable = true }
+arcade-mcp-server = { path = "../../libs/arcade-mcp-server/", editable = true }
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+asyncio_mode = "auto"
+
+[tool.coverage.report]
+skip_empty = true
+
+[tool.mypy]
+files = ["arcade_perplexity/**/*.py"]
+python_version = "3.10"
+disallow_untyped_defs = "True"
+disallow_any_unimported = "True"
+no_implicit_optional = "True"
+check_untyped_defs = "True"
+warn_return_any = "True"
+warn_unused_ignores = "True"
+show_error_codes = "True"
+ignore_missing_imports = "True"
+
+[tool.hatch.build.targets.wheel]
+packages = ["arcade_perplexity"]

--- a/toolkits/perplexity/tests/test_search.py
+++ b/toolkits/perplexity/tests/test_search.py
@@ -1,0 +1,156 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+from arcade_mcp_server import Context
+
+from arcade_perplexity.tools.search import (
+    PERPLEXITY_SEARCH_URL,
+    SearchRecencyFilter,
+    search,
+)
+
+
+@pytest.fixture
+def mock_context() -> Context:
+    context = MagicMock(spec=Context)
+    context.get_secret = MagicMock(return_value="test-api-key")
+    return context
+
+
+def _make_async_client_patch(json_payload: dict | None = None, status_code: int = 200):
+    """Patch httpx.AsyncClient so that .post returns a configured response.
+
+    Returns a tuple of (patcher, post_mock) so tests can inspect the call.
+    """
+    json_payload = json_payload if json_payload is not None else {"results": []}
+
+    response = MagicMock(spec=httpx.Response)
+    response.status_code = status_code
+    response.json = MagicMock(return_value=json_payload)
+    response.raise_for_status = MagicMock()
+
+    post_mock = AsyncMock(return_value=response)
+
+    async_client = MagicMock()
+    async_client.post = post_mock
+    async_client.__aenter__ = AsyncMock(return_value=async_client)
+    async_client.__aexit__ = AsyncMock(return_value=None)
+
+    patcher = patch(
+        "arcade_perplexity.tools.search.httpx.AsyncClient",
+        return_value=async_client,
+    )
+    return patcher, post_mock
+
+
+@pytest.mark.asyncio
+async def test_search_happy_path_returns_normalized_results(mock_context: Context) -> None:
+    api_payload = {
+        "results": [
+            {
+                "title": "Result One",
+                "url": "https://example.com/one",
+                "snippet": "First snippet",
+                "date": "2026-01-01",
+            },
+            {
+                "title": "Result Two",
+                "url": "https://example.com/two",
+                "snippet": "Second snippet",
+            },
+        ],
+        "id": "abc",
+    }
+    patcher, post_mock = _make_async_client_patch(json_payload=api_payload)
+    with patcher:
+        results = await search(mock_context, query="who is ada lovelace?")
+
+    assert results == [
+        {
+            "title": "Result One",
+            "url": "https://example.com/one",
+            "snippet": "First snippet",
+        },
+        {
+            "title": "Result Two",
+            "url": "https://example.com/two",
+            "snippet": "Second snippet",
+        },
+    ]
+
+    post_mock.assert_awaited_once()
+    call_args = post_mock.await_args
+    assert call_args.args[0] == PERPLEXITY_SEARCH_URL
+    body = call_args.kwargs["json"]
+    assert body["query"] == "who is ada lovelace?"
+    assert body["max_results"] == 5
+    assert "search_recency_filter" not in body
+
+
+@pytest.mark.asyncio
+async def test_search_sends_required_auth_and_attribution_headers(
+    mock_context: Context,
+) -> None:
+    patcher, post_mock = _make_async_client_patch()
+    with patcher:
+        await search(mock_context, query="test")
+
+    headers = post_mock.await_args.kwargs["headers"]
+    assert headers["Authorization"] == "Bearer test-api-key"
+    assert headers["Content-Type"] == "application/json"
+    assert "X-Pplx-Integration" in headers
+    integration = headers["X-Pplx-Integration"]
+    assert integration.startswith("arcade/")
+    # ensure slug is exactly "arcade" (not e.g. "arcade-ai" or "arcade-mcp")
+    assert integration.split("/", 1)[0] == "arcade"
+
+
+@pytest.mark.asyncio
+async def test_search_clamps_max_results_to_upper_bound(mock_context: Context) -> None:
+    patcher, post_mock = _make_async_client_patch()
+    with patcher:
+        await search(mock_context, query="test", max_results=999)
+
+    assert post_mock.await_args.kwargs["json"]["max_results"] == 20
+
+
+@pytest.mark.asyncio
+async def test_search_passes_recency_filter(mock_context: Context) -> None:
+    patcher, post_mock = _make_async_client_patch()
+    with patcher:
+        await search(
+            mock_context,
+            query="latest news",
+            search_recency_filter=SearchRecencyFilter.WEEK,
+        )
+
+    body = post_mock.await_args.kwargs["json"]
+    assert body["search_recency_filter"] == "week"
+
+
+@pytest.mark.asyncio
+async def test_search_raises_on_http_error(mock_context: Context) -> None:
+    request = httpx.Request("POST", PERPLEXITY_SEARCH_URL)
+    response = httpx.Response(status_code=401, request=request)
+    error = httpx.HTTPStatusError("unauthorized", request=request, response=response)
+
+    bad_response = MagicMock(spec=httpx.Response)
+    bad_response.status_code = 401
+    bad_response.raise_for_status = MagicMock(side_effect=error)
+    bad_response.json = MagicMock(return_value={})
+
+    post_mock = AsyncMock(return_value=bad_response)
+    async_client = MagicMock()
+    async_client.post = post_mock
+    async_client.__aenter__ = AsyncMock(return_value=async_client)
+    async_client.__aexit__ = AsyncMock(return_value=None)
+
+    with (
+        patch(
+            "arcade_perplexity.tools.search.httpx.AsyncClient",
+            return_value=async_client,
+        ),
+        pytest.raises(Exception),  # noqa: B017
+    ):
+        await search(mock_context, query="test")


### PR DESCRIPTION
## Summary

Adds a new `toolkits/perplexity/` package exposing a single `search` tool that calls the [Perplexity Search API](https://docs.perplexity.ai/api-reference/search-post) (`POST https://api.perplexity.ai/search`) directly via `httpx`.

- Auth: `PERPLEXITY_API_KEY` (Arcade secrets pattern — `context.get_secret(...)`).
- Sends `X-Pplx-Integration: arcade/<toolkit-version>` on every outgoing request.
- Inputs: `query`, `max_results` (default `5`, clamped to `[1, 20]`), and an optional `search_recency_filter` enum (`hour | day | week | month | year`).
- Output: `list[{title, url, snippet}]`.
- No third-party Perplexity SDK / community packages — calls the API directly with `httpx`.

The package layout (Makefile, `.ruff.toml`, `.pre-commit-config.yaml`, `pyproject.toml`, `__main__.py` MCPApp wiring, `tests/`) mirrors the existing `brightdata` toolkit's conventions line-for-line.

## Test plan

- [x] `pytest toolkits/perplexity/tests/` — 5 tests pass (happy path, auth + attribution headers, max_results clamp, recency filter, HTTP error propagation).
- [x] `ruff check toolkits/perplexity/` — clean.
- [x] `ruff format --check toolkits/perplexity/` — clean.