### PR TITLE
chore: add graphify config and initial knowledge-graph report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -187,3 +187,10 @@ libs/arcade-mcp-server/site/*
 # Ignore any directory named `monorepo` at any depth
 monorepo/
 **/monorepo/
+
+# Graphify outputs (regeneratable; too large for git)
+graphify-out/cache/
+graphify-out/manifest.json
+graphify-out/.graphify_analysis.json
+graphify-out/graph.json
+graphify-out/cost.json

--- a/.graphifyignore
+++ b/.graphifyignore
@@ -1,0 +1,102 @@
+# Graphify ignore — keep extraction focused on source code and design docs.
+# Same syntax as .gitignore.
+
+# --- VCS / worktree / agent infra ---
+.git/
+.worktrees/
+.claude/
+.cursor/
+.context/
+.beads/
+.runtime/
+.gc/
+.zed/
+
+# --- Agent instruction files (don't extract our own prompts as knowledge) ---
+AGENTS.md
+CLAUDE.md
+CLAUDE.local.md
+**/CLAUDE.local.md
+.cursorrules
+
+# --- Dependencies / lockfiles ---
+node_modules/
+.pnp
+.pnp.js
+bun.lock
+package-lock.json
+pnpm-lock.yaml
+yarn.lock
+uv.lock
+poetry.lock
+Cargo.lock
+mise.lock
+.alchemy
+
+# --- Build outputs ---
+dist/
+build/
+storybook-static/
+*.tsbuildinfo
+.next/
+.turbo/
+.cache/
+
+# --- Python caches / venv ---
+__pycache__/
+*.egg-info/
+.venv/
+.pytest_cache/
+.ruff_cache/
+.mypy_cache/
+
+# --- Test artefacts ---
+coverage/
+.nyc_output/
+.playwright-mcp/
+__screenshots__/
+__snapshots__/
+
+# --- Terraform / OpenTofu state ---
+.terraform/
+*.tfstate
+*.tfstate.*
+
+# --- Logs / scratch / tmp ---
+logs/
+*.log
+scratch/
+tmp/
+temp/
+.DS_Store
+
+# --- Binary / static assets we don't want extracted as concepts ---
+*.svg
+*.png
+*.jpg
+*.jpeg
+*.gif
+*.webp
+*.ico
+*.woff
+*.woff2
+*.ttf
+*.otf
+*.eot
+*.mp4
+*.mov
+*.mkv
+*.webm
+*.mp3
+*.wav
+*.m4a
+*.ogg
+*.pdf
+*.zip
+*.tgz
+
+# --- Translated/duplicated docs ---
+docs/translations/
+
+# --- Graphify's own outputs (don't feed back into itself) ---
+graphify-out/

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,0 +1,2116 @@
+# Graph Report - .  (2026-05-05)
+
+## Corpus Check
+- cluster-only mode — file stats not available
+
+## Summary
+- 8840 nodes · 15627 edges · 989 communities (333 shown, 656 thin omitted)
+- Extraction: 64% EXTRACTED · 36% INFERRED · 0% AMBIGUOUS · INFERRED: 5664 edges (avg confidence: 0.66)
+- Token cost: 0 input · 0 output
+
+## Graph Freshness
+- Built from commit: `7995334e`
+- Run `git rev-parse HEAD` and compare to check if the graph is stale.
+- Run `graphify update .` after code changes (no API cost).
+
+## Community Hubs (Navigation)
+- [[_COMMUNITY_Community 0|Community 0]]
+- [[_COMMUNITY_Community 1|Community 1]]
+- [[_COMMUNITY_Community 2|Community 2]]
+- [[_COMMUNITY_Community 3|Community 3]]
+- [[_COMMUNITY_Community 4|Community 4]]
+- [[_COMMUNITY_Community 5|Community 5]]
+- [[_COMMUNITY_Community 6|Community 6]]
+- [[_COMMUNITY_Community 7|Community 7]]
+- [[_COMMUNITY_Community 8|Community 8]]
+- [[_COMMUNITY_Community 9|Community 9]]
+- [[_COMMUNITY_Community 10|Community 10]]
+- [[_COMMUNITY_Community 11|Community 11]]
+- [[_COMMUNITY_Community 12|Community 12]]
+- [[_COMMUNITY_Community 13|Community 13]]
+- [[_COMMUNITY_Community 14|Community 14]]
+- [[_COMMUNITY_Community 15|Community 15]]
+- [[_COMMUNITY_Community 16|Community 16]]
+- [[_COMMUNITY_Community 17|Community 17]]
+- [[_COMMUNITY_Community 18|Community 18]]
+- [[_COMMUNITY_Community 19|Community 19]]
+- [[_COMMUNITY_Community 20|Community 20]]
+- [[_COMMUNITY_Community 21|Community 21]]
+- [[_COMMUNITY_Community 22|Community 22]]
+- [[_COMMUNITY_Community 23|Community 23]]
+- [[_COMMUNITY_Community 24|Community 24]]
+- [[_COMMUNITY_Community 25|Community 25]]
+- [[_COMMUNITY_Community 26|Community 26]]
+- [[_COMMUNITY_Community 27|Community 27]]
+- [[_COMMUNITY_Community 28|Community 28]]
+- [[_COMMUNITY_Community 29|Community 29]]
+- [[_COMMUNITY_Community 30|Community 30]]
+- [[_COMMUNITY_Community 31|Community 31]]
+- [[_COMMUNITY_Community 32|Community 32]]
+- [[_COMMUNITY_Community 33|Community 33]]
+- [[_COMMUNITY_Community 34|Community 34]]
+- [[_COMMUNITY_Community 35|Community 35]]
+- [[_COMMUNITY_Community 36|Community 36]]
+- [[_COMMUNITY_Community 37|Community 37]]
+- [[_COMMUNITY_Community 38|Community 38]]
+- [[_COMMUNITY_Community 39|Community 39]]
+- [[_COMMUNITY_Community 40|Community 40]]
+- [[_COMMUNITY_Community 41|Community 41]]
+- [[_COMMUNITY_Community 43|Community 43]]
+- [[_COMMUNITY_Community 44|Community 44]]
+- [[_COMMUNITY_Community 45|Community 45]]
+- [[_COMMUNITY_Community 46|Community 46]]
+- [[_COMMUNITY_Community 47|Community 47]]
+- [[_COMMUNITY_Community 48|Community 48]]
+- [[_COMMUNITY_Community 49|Community 49]]
+- [[_COMMUNITY_Community 50|Community 50]]
+- [[_COMMUNITY_Community 51|Community 51]]
+- [[_COMMUNITY_Community 52|Community 52]]
+- [[_COMMUNITY_Community 53|Community 53]]
+- [[_COMMUNITY_Community 54|Community 54]]
+- [[_COMMUNITY_Community 55|Community 55]]
+- [[_COMMUNITY_Community 56|Community 56]]
+- [[_COMMUNITY_Community 57|Community 57]]
+- [[_COMMUNITY_Community 58|Community 58]]
+- [[_COMMUNITY_Community 59|Community 59]]
+- [[_COMMUNITY_Community 60|Community 60]]
+- [[_COMMUNITY_Community 61|Community 61]]
+- [[_COMMUNITY_Community 62|Community 62]]
+- [[_COMMUNITY_Community 63|Community 63]]
+- [[_COMMUNITY_Community 64|Community 64]]
+- [[_COMMUNITY_Community 65|Community 65]]
+- [[_COMMUNITY_Community 66|Community 66]]
+- [[_COMMUNITY_Community 67|Community 67]]
+- [[_COMMUNITY_Community 68|Community 68]]
+- [[_COMMUNITY_Community 69|Community 69]]
+- [[_COMMUNITY_Community 70|Community 70]]
+- [[_COMMUNITY_Community 71|Community 71]]
+- [[_COMMUNITY_Community 72|Community 72]]
+- [[_COMMUNITY_Community 73|Community 73]]
+- [[_COMMUNITY_Community 74|Community 74]]
+- [[_COMMUNITY_Community 75|Community 75]]
+- [[_COMMUNITY_Community 76|Community 76]]
+- [[_COMMUNITY_Community 77|Community 77]]
+- [[_COMMUNITY_Community 78|Community 78]]
+- [[_COMMUNITY_Community 79|Community 79]]
+- [[_COMMUNITY_Community 80|Community 80]]
+- [[_COMMUNITY_Community 81|Community 81]]
+- [[_COMMUNITY_Community 82|Community 82]]
+- [[_COMMUNITY_Community 83|Community 83]]
+- [[_COMMUNITY_Community 84|Community 84]]
+- [[_COMMUNITY_Community 85|Community 85]]
+- [[_COMMUNITY_Community 86|Community 86]]
+- [[_COMMUNITY_Community 87|Community 87]]
+- [[_COMMUNITY_Community 88|Community 88]]
+- [[_COMMUNITY_Community 89|Community 89]]
+- [[_COMMUNITY_Community 90|Community 90]]
+- [[_COMMUNITY_Community 91|Community 91]]
+- [[_COMMUNITY_Community 92|Community 92]]
+- [[_COMMUNITY_Community 93|Community 93]]
+- [[_COMMUNITY_Community 94|Community 94]]
+- [[_COMMUNITY_Community 95|Community 95]]
+- [[_COMMUNITY_Community 96|Community 96]]
+- [[_COMMUNITY_Community 97|Community 97]]
+- [[_COMMUNITY_Community 98|Community 98]]
+- [[_COMMUNITY_Community 99|Community 99]]
+- [[_COMMUNITY_Community 100|Community 100]]
+- [[_COMMUNITY_Community 101|Community 101]]
+- [[_COMMUNITY_Community 102|Community 102]]
+- [[_COMMUNITY_Community 103|Community 103]]
+- [[_COMMUNITY_Community 104|Community 104]]
+- [[_COMMUNITY_Community 105|Community 105]]
+- [[_COMMUNITY_Community 106|Community 106]]
+- [[_COMMUNITY_Community 107|Community 107]]
+- [[_COMMUNITY_Community 108|Community 108]]
+- [[_COMMUNITY_Community 109|Community 109]]
+- [[_COMMUNITY_Community 110|Community 110]]
+- [[_COMMUNITY_Community 111|Community 111]]
+- [[_COMMUNITY_Community 112|Community 112]]
+- [[_COMMUNITY_Community 113|Community 113]]
+- [[_COMMUNITY_Community 114|Community 114]]
+- [[_COMMUNITY_Community 115|Community 115]]
+- [[_COMMUNITY_Community 116|Community 116]]
+- [[_COMMUNITY_Community 117|Community 117]]
+- [[_COMMUNITY_Community 118|Community 118]]
+- [[_COMMUNITY_Community 119|Community 119]]
+- [[_COMMUNITY_Community 120|Community 120]]
+- [[_COMMUNITY_Community 121|Community 121]]
+- [[_COMMUNITY_Community 122|Community 122]]
+- [[_COMMUNITY_Community 123|Community 123]]
+- [[_COMMUNITY_Community 124|Community 124]]
+- [[_COMMUNITY_Community 125|Community 125]]
+- [[_COMMUNITY_Community 126|Community 126]]
+- [[_COMMUNITY_Community 127|Community 127]]
+- [[_COMMUNITY_Community 128|Community 128]]
+- [[_COMMUNITY_Community 129|Community 129]]
+- [[_COMMUNITY_Community 130|Community 130]]
+- [[_COMMUNITY_Community 131|Community 131]]
+- [[_COMMUNITY_Community 132|Community 132]]
+- [[_COMMUNITY_Community 133|Community 133]]
+- [[_COMMUNITY_Community 134|Community 134]]
+- [[_COMMUNITY_Community 135|Community 135]]
+- [[_COMMUNITY_Community 136|Community 136]]
+- [[_COMMUNITY_Community 137|Community 137]]
+- [[_COMMUNITY_Community 138|Community 138]]
+- [[_COMMUNITY_Community 139|Community 139]]
+- [[_COMMUNITY_Community 140|Community 140]]
+- [[_COMMUNITY_Community 141|Community 141]]
+- [[_COMMUNITY_Community 142|Community 142]]
+- [[_COMMUNITY_Community 143|Community 143]]
+- [[_COMMUNITY_Community 144|Community 144]]
+- [[_COMMUNITY_Community 145|Community 145]]
+- [[_COMMUNITY_Community 146|Community 146]]
+- [[_COMMUNITY_Community 147|Community 147]]
+- [[_COMMUNITY_Community 148|Community 148]]
+- [[_COMMUNITY_Community 149|Community 149]]
+- [[_COMMUNITY_Community 150|Community 150]]
+- [[_COMMUNITY_Community 152|Community 152]]
+- [[_COMMUNITY_Community 153|Community 153]]
+- [[_COMMUNITY_Community 154|Community 154]]
+- [[_COMMUNITY_Community 155|Community 155]]
+- [[_COMMUNITY_Community 156|Community 156]]
+- [[_COMMUNITY_Community 157|Community 157]]
+- [[_COMMUNITY_Community 158|Community 158]]
+- [[_COMMUNITY_Community 159|Community 159]]
+- [[_COMMUNITY_Community 160|Community 160]]
+- [[_COMMUNITY_Community 161|Community 161]]
+- [[_COMMUNITY_Community 162|Community 162]]
+- [[_COMMUNITY_Community 163|Community 163]]
+- [[_COMMUNITY_Community 164|Community 164]]
+- [[_COMMUNITY_Community 165|Community 165]]
+- [[_COMMUNITY_Community 166|Community 166]]
+- [[_COMMUNITY_Community 167|Community 167]]
+- [[_COMMUNITY_Community 168|Community 168]]
+- [[_COMMUNITY_Community 169|Community 169]]
+- [[_COMMUNITY_Community 170|Community 170]]
+- [[_COMMUNITY_Community 171|Community 171]]
+- [[_COMMUNITY_Community 172|Community 172]]
+- [[_COMMUNITY_Community 173|Community 173]]
+- [[_COMMUNITY_Community 174|Community 174]]
+- [[_COMMUNITY_Community 175|Community 175]]
+- [[_COMMUNITY_Community 176|Community 176]]
+- [[_COMMUNITY_Community 177|Community 177]]
+- [[_COMMUNITY_Community 178|Community 178]]
+- [[_COMMUNITY_Community 179|Community 179]]
+- [[_COMMUNITY_Community 180|Community 180]]
+- [[_COMMUNITY_Community 181|Community 181]]
+- [[_COMMUNITY_Community 182|Community 182]]
+- [[_COMMUNITY_Community 183|Community 183]]
+- [[_COMMUNITY_Community 184|Community 184]]
+- [[_COMMUNITY_Community 185|Community 185]]
+- [[_COMMUNITY_Community 186|Community 186]]
+- [[_COMMUNITY_Community 187|Community 187]]
+- [[_COMMUNITY_Community 188|Community 188]]
+- [[_COMMUNITY_Community 189|Community 189]]
+- [[_COMMUNITY_Community 190|Community 190]]
+- [[_COMMUNITY_Community 191|Community 191]]
+- [[_COMMUNITY_Community 192|Community 192]]
+- [[_COMMUNITY_Community 193|Community 193]]
+- [[_COMMUNITY_Community 194|Community 194]]
+- [[_COMMUNITY_Community 195|Community 195]]
+- [[_COMMUNITY_Community 196|Community 196]]
+- [[_COMMUNITY_Community 197|Community 197]]
+- [[_COMMUNITY_Community 198|Community 198]]
+- [[_COMMUNITY_Community 199|Community 199]]
+- [[_COMMUNITY_Community 200|Community 200]]
+- [[_COMMUNITY_Community 201|Community 201]]
+- [[_COMMUNITY_Community 202|Community 202]]
+- [[_COMMUNITY_Community 203|Community 203]]
+- [[_COMMUNITY_Community 204|Community 204]]
+- [[_COMMUNITY_Community 205|Community 205]]
+- [[_COMMUNITY_Community 206|Community 206]]
+- [[_COMMUNITY_Community 207|Community 207]]
+- [[_COMMUNITY_Community 208|Community 208]]
+- [[_COMMUNITY_Community 209|Community 209]]
+- [[_COMMUNITY_Community 210|Community 210]]
+- [[_COMMUNITY_Community 211|Community 211]]
+- [[_COMMUNITY_Community 212|Community 212]]
+- [[_COMMUNITY_Community 213|Community 213]]
+- [[_COMMUNITY_Community 214|Community 214]]
+- [[_COMMUNITY_Community 215|Community 215]]
+- [[_COMMUNITY_Community 216|Community 216]]
+- [[_COMMUNITY_Community 217|Community 217]]
+- [[_COMMUNITY_Community 218|Community 218]]
+- [[_COMMUNITY_Community 219|Community 219]]
+- [[_COMMUNITY_Community 220|Community 220]]
+- [[_COMMUNITY_Community 221|Community 221]]
+- [[_COMMUNITY_Community 222|Community 222]]
+- [[_COMMUNITY_Community 223|Community 223]]
+- [[_COMMUNITY_Community 224|Community 224]]
+- [[_COMMUNITY_Community 225|Community 225]]
+- [[_COMMUNITY_Community 226|Community 226]]
+- [[_COMMUNITY_Community 227|Community 227]]
+- [[_COMMUNITY_Community 228|Community 228]]
+- [[_COMMUNITY_Community 230|Community 230]]
+- [[_COMMUNITY_Community 231|Community 231]]
+- [[_COMMUNITY_Community 232|Community 232]]
+- [[_COMMUNITY_Community 233|Community 233]]
+- [[_COMMUNITY_Community 234|Community 234]]
+- [[_COMMUNITY_Community 235|Community 235]]
+- [[_COMMUNITY_Community 236|Community 236]]
+- [[_COMMUNITY_Community 237|Community 237]]
+- [[_COMMUNITY_Community 238|Community 238]]
+- [[_COMMUNITY_Community 239|Community 239]]
+- [[_COMMUNITY_Community 240|Community 240]]
+- [[_COMMUNITY_Community 241|Community 241]]
+- [[_COMMUNITY_Community 242|Community 242]]
+- [[_COMMUNITY_Community 243|Community 243]]
+- [[_COMMUNITY_Community 244|Community 244]]
+- [[_COMMUNITY_Community 245|Community 245]]
+- [[_COMMUNITY_Community 246|Community 246]]
+- [[_COMMUNITY_Community 247|Community 247]]
+- [[_COMMUNITY_Community 248|Community 248]]
+- [[_COMMUNITY_Community 249|Community 249]]
+- [[_COMMUNITY_Community 250|Community 250]]
+- [[_COMMUNITY_Community 251|Community 251]]
+- [[_COMMUNITY_Community 252|Community 252]]
+- [[_COMMUNITY_Community 253|Community 253]]
+- [[_COMMUNITY_Community 254|Community 254]]
+- [[_COMMUNITY_Community 255|Community 255]]
+- [[_COMMUNITY_Community 256|Community 256]]
+- [[_COMMUNITY_Community 257|Community 257]]
+- [[_COMMUNITY_Community 258|Community 258]]
+- [[_COMMUNITY_Community 259|Community 259]]
+- [[_COMMUNITY_Community 260|Community 260]]
+- [[_COMMUNITY_Community 261|Community 261]]
+- [[_COMMUNITY_Community 262|Community 262]]
+- [[_COMMUNITY_Community 263|Community 263]]
+- [[_COMMUNITY_Community 264|Community 264]]
+- [[_COMMUNITY_Community 265|Community 265]]
+- [[_COMMUNITY_Community 266|Community 266]]
+- [[_COMMUNITY_Community 267|Community 267]]
+- [[_COMMUNITY_Community 268|Community 268]]
+- [[_COMMUNITY_Community 269|Community 269]]
+- [[_COMMUNITY_Community 270|Community 270]]
+- [[_COMMUNITY_Community 271|Community 271]]
+- [[_COMMUNITY_Community 272|Community 272]]
+- [[_COMMUNITY_Community 273|Community 273]]
+- [[_COMMUNITY_Community 274|Community 274]]
+- [[_COMMUNITY_Community 275|Community 275]]
+- [[_COMMUNITY_Community 276|Community 276]]
+- [[_COMMUNITY_Community 277|Community 277]]
+- [[_COMMUNITY_Community 278|Community 278]]
+- [[_COMMUNITY_Community 279|Community 279]]
+- [[_COMMUNITY_Community 280|Community 280]]
+- [[_COMMUNITY_Community 281|Community 281]]
+- [[_COMMUNITY_Community 282|Community 282]]
+- [[_COMMUNITY_Community 283|Community 283]]
+- [[_COMMUNITY_Community 284|Community 284]]
+- [[_COMMUNITY_Community 285|Community 285]]
+- [[_COMMUNITY_Community 286|Community 286]]
+- [[_COMMUNITY_Community 287|Community 287]]
+- [[_COMMUNITY_Community 288|Community 288]]
+- [[_COMMUNITY_Community 289|Community 289]]
+- [[_COMMUNITY_Community 290|Community 290]]
+- [[_COMMUNITY_Community 291|Community 291]]
+- [[_COMMUNITY_Community 292|Community 292]]
+- [[_COMMUNITY_Community 293|Community 293]]
+- [[_COMMUNITY_Community 294|Community 294]]
+- [[_COMMUNITY_Community 295|Community 295]]
+- [[_COMMUNITY_Community 296|Community 296]]
+- [[_COMMUNITY_Community 297|Community 297]]
+- [[_COMMUNITY_Community 298|Community 298]]
+- [[_COMMUNITY_Community 299|Community 299]]
+- [[_COMMUNITY_Community 300|Community 300]]
+- [[_COMMUNITY_Community 301|Community 301]]
+- [[_COMMUNITY_Community 302|Community 302]]
+- [[_COMMUNITY_Community 303|Community 303]]
+- [[_COMMUNITY_Community 304|Community 304]]
+- [[_COMMUNITY_Community 305|Community 305]]
+- [[_COMMUNITY_Community 306|Community 306]]
+- [[_COMMUNITY_Community 307|Community 307]]
+- [[_COMMUNITY_Community 308|Community 308]]
+- [[_COMMUNITY_Community 309|Community 309]]
+- [[_COMMUNITY_Community 310|Community 310]]
+- [[_COMMUNITY_Community 311|Community 311]]
+- [[_COMMUNITY_Community 312|Community 312]]
+- [[_COMMUNITY_Community 313|Community 313]]
+- [[_COMMUNITY_Community 314|Community 314]]
+- [[_COMMUNITY_Community 315|Community 315]]
+- [[_COMMUNITY_Community 316|Community 316]]
+- [[_COMMUNITY_Community 317|Community 317]]
+- [[_COMMUNITY_Community 318|Community 318]]
+- [[_COMMUNITY_Community 319|Community 319]]
+- [[_COMMUNITY_Community 320|Community 320]]
+- [[_COMMUNITY_Community 321|Community 321]]
+- [[_COMMUNITY_Community 322|Community 322]]
+- [[_COMMUNITY_Community 323|Community 323]]
+- [[_COMMUNITY_Community 324|Community 324]]
+- [[_COMMUNITY_Community 325|Community 325]]
+- [[_COMMUNITY_Community 326|Community 326]]
+- [[_COMMUNITY_Community 327|Community 327]]
+- [[_COMMUNITY_Community 328|Community 328]]
+- [[_COMMUNITY_Community 329|Community 329]]
+- [[_COMMUNITY_Community 330|Community 330]]
+- [[_COMMUNITY_Community 331|Community 331]]
+- [[_COMMUNITY_Community 332|Community 332]]
+- [[_COMMUNITY_Community 334|Community 334]]
+- [[_COMMUNITY_Community 335|Community 335]]
+- [[_COMMUNITY_Community 336|Community 336]]
+- [[_COMMUNITY_Community 337|Community 337]]
+- [[_COMMUNITY_Community 338|Community 338]]
+- [[_COMMUNITY_Community 339|Community 339]]
+- [[_COMMUNITY_Community 340|Community 340]]
+- [[_COMMUNITY_Community 341|Community 341]]
+- [[_COMMUNITY_Community 342|Community 342]]
+- [[_COMMUNITY_Community 343|Community 343]]
+- [[_COMMUNITY_Community 344|Community 344]]
+- [[_COMMUNITY_Community 345|Community 345]]
+- [[_COMMUNITY_Community 346|Community 346]]
+- [[_COMMUNITY_Community 347|Community 347]]
+- [[_COMMUNITY_Community 348|Community 348]]
+- [[_COMMUNITY_Community 349|Community 349]]
+- [[_COMMUNITY_Community 350|Community 350]]
+- [[_COMMUNITY_Community 351|Community 351]]
+- [[_COMMUNITY_Community 352|Community 352]]
+- [[_COMMUNITY_Community 353|Community 353]]
+- [[_COMMUNITY_Community 354|Community 354]]
+- [[_COMMUNITY_Community 355|Community 355]]
+- [[_COMMUNITY_Community 356|Community 356]]
+- [[_COMMUNITY_Community 357|Community 357]]
+- [[_COMMUNITY_Community 358|Community 358]]
+- [[_COMMUNITY_Community 359|Community 359]]
+- [[_COMMUNITY_Community 360|Community 360]]
+- [[_COMMUNITY_Community 361|Community 361]]
+- [[_COMMUNITY_Community 362|Community 362]]
+- [[_COMMUNITY_Community 363|Community 363]]
+- [[_COMMUNITY_Community 364|Community 364]]
+- [[_COMMUNITY_Community 365|Community 365]]
+- [[_COMMUNITY_Community 366|Community 366]]
+- [[_COMMUNITY_Community 367|Community 367]]
+- [[_COMMUNITY_Community 368|Community 368]]
+- [[_COMMUNITY_Community 369|Community 369]]
+- [[_COMMUNITY_Community 370|Community 370]]
+- [[_COMMUNITY_Community 371|Community 371]]
+- [[_COMMUNITY_Community 372|Community 372]]
+- [[_COMMUNITY_Community 373|Community 373]]
+- [[_COMMUNITY_Community 374|Community 374]]
+- [[_COMMUNITY_Community 375|Community 375]]
+- [[_COMMUNITY_Community 376|Community 376]]
+- [[_COMMUNITY_Community 377|Community 377]]
+- [[_COMMUNITY_Community 378|Community 378]]
+- [[_COMMUNITY_Community 379|Community 379]]
+- [[_COMMUNITY_Community 380|Community 380]]
+- [[_COMMUNITY_Community 381|Community 381]]
+- [[_COMMUNITY_Community 382|Community 382]]
+- [[_COMMUNITY_Community 383|Community 383]]
+- [[_COMMUNITY_Community 384|Community 384]]
+- [[_COMMUNITY_Community 385|Community 385]]
+- [[_COMMUNITY_Community 386|Community 386]]
+- [[_COMMUNITY_Community 387|Community 387]]
+- [[_COMMUNITY_Community 388|Community 388]]
+- [[_COMMUNITY_Community 389|Community 389]]
+- [[_COMMUNITY_Community 390|Community 390]]
+- [[_COMMUNITY_Community 391|Community 391]]
+- [[_COMMUNITY_Community 392|Community 392]]
+- [[_COMMUNITY_Community 393|Community 393]]
+- [[_COMMUNITY_Community 394|Community 394]]
+- [[_COMMUNITY_Community 395|Community 395]]
+- [[_COMMUNITY_Community 396|Community 396]]
+- [[_COMMUNITY_Community 397|Community 397]]
+- [[_COMMUNITY_Community 398|Community 398]]
+- [[_COMMUNITY_Community 399|Community 399]]
+- [[_COMMUNITY_Community 400|Community 400]]
+- [[_COMMUNITY_Community 401|Community 401]]
+- [[_COMMUNITY_Community 402|Community 402]]
+- [[_COMMUNITY_Community 403|Community 403]]
+- [[_COMMUNITY_Community 404|Community 404]]
+- [[_COMMUNITY_Community 405|Community 405]]
+- [[_COMMUNITY_Community 406|Community 406]]
+- [[_COMMUNITY_Community 407|Community 407]]
+- [[_COMMUNITY_Community 408|Community 408]]
+- [[_COMMUNITY_Community 409|Community 409]]
+- [[_COMMUNITY_Community 410|Community 410]]
+- [[_COMMUNITY_Community 411|Community 411]]
+- [[_COMMUNITY_Community 412|Community 412]]
+- [[_COMMUNITY_Community 413|Community 413]]
+- [[_COMMUNITY_Community 414|Community 414]]
+- [[_COMMUNITY_Community 415|Community 415]]
+- [[_COMMUNITY_Community 416|Community 416]]
+- [[_COMMUNITY_Community 417|Community 417]]
+- [[_COMMUNITY_Community 418|Community 418]]
+- [[_COMMUNITY_Community 419|Community 419]]
+- [[_COMMUNITY_Community 420|Community 420]]
+- [[_COMMUNITY_Community 421|Community 421]]
+- [[_COMMUNITY_Community 422|Community 422]]
+- [[_COMMUNITY_Community 423|Community 423]]
+- [[_COMMUNITY_Community 424|Community 424]]
+- [[_COMMUNITY_Community 425|Community 425]]
+- [[_COMMUNITY_Community 426|Community 426]]
+- [[_COMMUNITY_Community 427|Community 427]]
+- [[_COMMUNITY_Community 428|Community 428]]
+- [[_COMMUNITY_Community 429|Community 429]]
+- [[_COMMUNITY_Community 430|Community 430]]
+- [[_COMMUNITY_Community 431|Community 431]]
+- [[_COMMUNITY_Community 432|Community 432]]
+- [[_COMMUNITY_Community 433|Community 433]]
+- [[_COMMUNITY_Community 434|Community 434]]
+- [[_COMMUNITY_Community 435|Community 435]]
+- [[_COMMUNITY_Community 436|Community 436]]
+- [[_COMMUNITY_Community 439|Community 439]]
+- [[_COMMUNITY_Community 440|Community 440]]
+- [[_COMMUNITY_Community 441|Community 441]]
+- [[_COMMUNITY_Community 442|Community 442]]
+- [[_COMMUNITY_Community 443|Community 443]]
+- [[_COMMUNITY_Community 444|Community 444]]
+- [[_COMMUNITY_Community 446|Community 446]]
+- [[_COMMUNITY_Community 447|Community 447]]
+- [[_COMMUNITY_Community 448|Community 448]]
+- [[_COMMUNITY_Community 449|Community 449]]
+- [[_COMMUNITY_Community 450|Community 450]]
+- [[_COMMUNITY_Community 451|Community 451]]
+- [[_COMMUNITY_Community 452|Community 452]]
+- [[_COMMUNITY_Community 453|Community 453]]
+- [[_COMMUNITY_Community 454|Community 454]]
+- [[_COMMUNITY_Community 455|Community 455]]
+- [[_COMMUNITY_Community 456|Community 456]]
+- [[_COMMUNITY_Community 457|Community 457]]
+- [[_COMMUNITY_Community 458|Community 458]]
+- [[_COMMUNITY_Community 459|Community 459]]
+- [[_COMMUNITY_Community 460|Community 460]]
+- [[_COMMUNITY_Community 461|Community 461]]
+- [[_COMMUNITY_Community 462|Community 462]]
+- [[_COMMUNITY_Community 463|Community 463]]
+- [[_COMMUNITY_Community 464|Community 464]]
+- [[_COMMUNITY_Community 465|Community 465]]
+- [[_COMMUNITY_Community 466|Community 466]]
+- [[_COMMUNITY_Community 467|Community 467]]
+- [[_COMMUNITY_Community 468|Community 468]]
+- [[_COMMUNITY_Community 470|Community 470]]
+- [[_COMMUNITY_Community 471|Community 471]]
+- [[_COMMUNITY_Community 472|Community 472]]
+- [[_COMMUNITY_Community 473|Community 473]]
+- [[_COMMUNITY_Community 474|Community 474]]
+- [[_COMMUNITY_Community 475|Community 475]]
+- [[_COMMUNITY_Community 478|Community 478]]
+- [[_COMMUNITY_Community 479|Community 479]]
+- [[_COMMUNITY_Community 480|Community 480]]
+- [[_COMMUNITY_Community 482|Community 482]]
+- [[_COMMUNITY_Community 483|Community 483]]
+- [[_COMMUNITY_Community 484|Community 484]]
+- [[_COMMUNITY_Community 485|Community 485]]
+- [[_COMMUNITY_Community 486|Community 486]]
+- [[_COMMUNITY_Community 487|Community 487]]
+- [[_COMMUNITY_Community 494|Community 494]]
+- [[_COMMUNITY_Community 498|Community 498]]
+- [[_COMMUNITY_Community 499|Community 499]]
+- [[_COMMUNITY_Community 500|Community 500]]
+- [[_COMMUNITY_Community 501|Community 501]]
+- [[_COMMUNITY_Community 502|Community 502]]
+- [[_COMMUNITY_Community 503|Community 503]]
+- [[_COMMUNITY_Community 504|Community 504]]
+- [[_COMMUNITY_Community 505|Community 505]]
+- [[_COMMUNITY_Community 506|Community 506]]
+- [[_COMMUNITY_Community 507|Community 507]]
+- [[_COMMUNITY_Community 508|Community 508]]
+- [[_COMMUNITY_Community 509|Community 509]]
+- [[_COMMUNITY_Community 510|Community 510]]
+- [[_COMMUNITY_Community 511|Community 511]]
+- [[_COMMUNITY_Community 512|Community 512]]
+- [[_COMMUNITY_Community 513|Community 513]]
+- [[_COMMUNITY_Community 514|Community 514]]
+- [[_COMMUNITY_Community 515|Community 515]]
+- [[_COMMUNITY_Community 516|Community 516]]
+- [[_COMMUNITY_Community 517|Community 517]]
+- [[_COMMUNITY_Community 518|Community 518]]
+- [[_COMMUNITY_Community 519|Community 519]]
+- [[_COMMUNITY_Community 521|Community 521]]
+- [[_COMMUNITY_Community 522|Community 522]]
+- [[_COMMUNITY_Community 523|Community 523]]
+- [[_COMMUNITY_Community 524|Community 524]]
+- [[_COMMUNITY_Community 525|Community 525]]
+- [[_COMMUNITY_Community 526|Community 526]]
+- [[_COMMUNITY_Community 527|Community 527]]
+- [[_COMMUNITY_Community 528|Community 528]]
+- [[_COMMUNITY_Community 529|Community 529]]
+- [[_COMMUNITY_Community 530|Community 530]]
+- [[_COMMUNITY_Community 531|Community 531]]
+- [[_COMMUNITY_Community 532|Community 532]]
+- [[_COMMUNITY_Community 533|Community 533]]
+- [[_COMMUNITY_Community 534|Community 534]]
+- [[_COMMUNITY_Community 535|Community 535]]
+- [[_COMMUNITY_Community 536|Community 536]]
+- [[_COMMUNITY_Community 537|Community 537]]
+- [[_COMMUNITY_Community 538|Community 538]]
+- [[_COMMUNITY_Community 539|Community 539]]
+- [[_COMMUNITY_Community 540|Community 540]]
+- [[_COMMUNITY_Community 541|Community 541]]
+- [[_COMMUNITY_Community 542|Community 542]]
+- [[_COMMUNITY_Community 543|Community 543]]
+- [[_COMMUNITY_Community 544|Community 544]]
+- [[_COMMUNITY_Community 545|Community 545]]
+- [[_COMMUNITY_Community 546|Community 546]]
+- [[_COMMUNITY_Community 547|Community 547]]
+- [[_COMMUNITY_Community 548|Community 548]]
+- [[_COMMUNITY_Community 549|Community 549]]
+- [[_COMMUNITY_Community 550|Community 550]]
+- [[_COMMUNITY_Community 551|Community 551]]
+- [[_COMMUNITY_Community 552|Community 552]]
+- [[_COMMUNITY_Community 553|Community 553]]
+- [[_COMMUNITY_Community 554|Community 554]]
+- [[_COMMUNITY_Community 555|Community 555]]
+- [[_COMMUNITY_Community 556|Community 556]]
+- [[_COMMUNITY_Community 557|Community 557]]
+- [[_COMMUNITY_Community 558|Community 558]]
+- [[_COMMUNITY_Community 559|Community 559]]
+- [[_COMMUNITY_Community 560|Community 560]]
+- [[_COMMUNITY_Community 561|Community 561]]
+- [[_COMMUNITY_Community 562|Community 562]]
+- [[_COMMUNITY_Community 563|Community 563]]
+- [[_COMMUNITY_Community 564|Community 564]]
+- [[_COMMUNITY_Community 565|Community 565]]
+- [[_COMMUNITY_Community 566|Community 566]]
+- [[_COMMUNITY_Community 567|Community 567]]
+- [[_COMMUNITY_Community 568|Community 568]]
+- [[_COMMUNITY_Community 569|Community 569]]
+- [[_COMMUNITY_Community 570|Community 570]]
+- [[_COMMUNITY_Community 571|Community 571]]
+- [[_COMMUNITY_Community 572|Community 572]]
+- [[_COMMUNITY_Community 573|Community 573]]
+- [[_COMMUNITY_Community 574|Community 574]]
+- [[_COMMUNITY_Community 575|Community 575]]
+- [[_COMMUNITY_Community 576|Community 576]]
+- [[_COMMUNITY_Community 577|Community 577]]
+- [[_COMMUNITY_Community 578|Community 578]]
+- [[_COMMUNITY_Community 579|Community 579]]
+- [[_COMMUNITY_Community 580|Community 580]]
+- [[_COMMUNITY_Community 581|Community 581]]
+- [[_COMMUNITY_Community 582|Community 582]]
+- [[_COMMUNITY_Community 583|Community 583]]
+- [[_COMMUNITY_Community 584|Community 584]]
+- [[_COMMUNITY_Community 585|Community 585]]
+- [[_COMMUNITY_Community 586|Community 586]]
+- [[_COMMUNITY_Community 587|Community 587]]
+- [[_COMMUNITY_Community 588|Community 588]]
+- [[_COMMUNITY_Community 589|Community 589]]
+- [[_COMMUNITY_Community 590|Community 590]]
+- [[_COMMUNITY_Community 591|Community 591]]
+- [[_COMMUNITY_Community 592|Community 592]]
+- [[_COMMUNITY_Community 593|Community 593]]
+- [[_COMMUNITY_Community 594|Community 594]]
+- [[_COMMUNITY_Community 595|Community 595]]
+- [[_COMMUNITY_Community 596|Community 596]]
+- [[_COMMUNITY_Community 597|Community 597]]
+- [[_COMMUNITY_Community 598|Community 598]]
+- [[_COMMUNITY_Community 599|Community 599]]
+- [[_COMMUNITY_Community 600|Community 600]]
+- [[_COMMUNITY_Community 601|Community 601]]
+- [[_COMMUNITY_Community 602|Community 602]]
+- [[_COMMUNITY_Community 603|Community 603]]
+- [[_COMMUNITY_Community 604|Community 604]]
+- [[_COMMUNITY_Community 605|Community 605]]
+- [[_COMMUNITY_Community 606|Community 606]]
+- [[_COMMUNITY_Community 607|Community 607]]
+- [[_COMMUNITY_Community 608|Community 608]]
+- [[_COMMUNITY_Community 609|Community 609]]
+- [[_COMMUNITY_Community 610|Community 610]]
+- [[_COMMUNITY_Community 611|Community 611]]
+- [[_COMMUNITY_Community 612|Community 612]]
+- [[_COMMUNITY_Community 613|Community 613]]
+- [[_COMMUNITY_Community 614|Community 614]]
+- [[_COMMUNITY_Community 615|Community 615]]
+- [[_COMMUNITY_Community 616|Community 616]]
+- [[_COMMUNITY_Community 617|Community 617]]
+- [[_COMMUNITY_Community 618|Community 618]]
+- [[_COMMUNITY_Community 619|Community 619]]
+- [[_COMMUNITY_Community 620|Community 620]]
+- [[_COMMUNITY_Community 621|Community 621]]
+- [[_COMMUNITY_Community 622|Community 622]]
+- [[_COMMUNITY_Community 623|Community 623]]
+- [[_COMMUNITY_Community 624|Community 624]]
+- [[_COMMUNITY_Community 625|Community 625]]
+- [[_COMMUNITY_Community 626|Community 626]]
+- [[_COMMUNITY_Community 627|Community 627]]
+- [[_COMMUNITY_Community 628|Community 628]]
+- [[_COMMUNITY_Community 629|Community 629]]
+- [[_COMMUNITY_Community 630|Community 630]]
+- [[_COMMUNITY_Community 631|Community 631]]
+- [[_COMMUNITY_Community 632|Community 632]]
+- [[_COMMUNITY_Community 633|Community 633]]
+- [[_COMMUNITY_Community 634|Community 634]]
+- [[_COMMUNITY_Community 635|Community 635]]
+- [[_COMMUNITY_Community 636|Community 636]]
+- [[_COMMUNITY_Community 637|Community 637]]
+- [[_COMMUNITY_Community 638|Community 638]]
+- [[_COMMUNITY_Community 639|Community 639]]
+- [[_COMMUNITY_Community 640|Community 640]]
+- [[_COMMUNITY_Community 641|Community 641]]
+- [[_COMMUNITY_Community 642|Community 642]]
+- [[_COMMUNITY_Community 643|Community 643]]
+- [[_COMMUNITY_Community 644|Community 644]]
+- [[_COMMUNITY_Community 645|Community 645]]
+- [[_COMMUNITY_Community 646|Community 646]]
+- [[_COMMUNITY_Community 647|Community 647]]
+- [[_COMMUNITY_Community 648|Community 648]]
+- [[_COMMUNITY_Community 649|Community 649]]
+- [[_COMMUNITY_Community 650|Community 650]]
+- [[_COMMUNITY_Community 651|Community 651]]
+- [[_COMMUNITY_Community 652|Community 652]]
+- [[_COMMUNITY_Community 653|Community 653]]
+- [[_COMMUNITY_Community 654|Community 654]]
+- [[_COMMUNITY_Community 655|Community 655]]
+- [[_COMMUNITY_Community 656|Community 656]]
+- [[_COMMUNITY_Community 657|Community 657]]
+- [[_COMMUNITY_Community 658|Community 658]]
+- [[_COMMUNITY_Community 659|Community 659]]
+- [[_COMMUNITY_Community 660|Community 660]]
+- [[_COMMUNITY_Community 661|Community 661]]
+- [[_COMMUNITY_Community 662|Community 662]]
+- [[_COMMUNITY_Community 663|Community 663]]
+- [[_COMMUNITY_Community 664|Community 664]]
+- [[_COMMUNITY_Community 665|Community 665]]
+- [[_COMMUNITY_Community 666|Community 666]]
+- [[_COMMUNITY_Community 667|Community 667]]
+- [[_COMMUNITY_Community 668|Community 668]]
+- [[_COMMUNITY_Community 669|Community 669]]
+- [[_COMMUNITY_Community 670|Community 670]]
+- [[_COMMUNITY_Community 671|Community 671]]
+- [[_COMMUNITY_Community 672|Community 672]]
+- [[_COMMUNITY_Community 673|Community 673]]
+- [[_COMMUNITY_Community 674|Community 674]]
+- [[_COMMUNITY_Community 675|Community 675]]
+- [[_COMMUNITY_Community 676|Community 676]]
+- [[_COMMUNITY_Community 677|Community 677]]
+- [[_COMMUNITY_Community 678|Community 678]]
+- [[_COMMUNITY_Community 679|Community 679]]
+- [[_COMMUNITY_Community 680|Community 680]]
+- [[_COMMUNITY_Community 681|Community 681]]
+- [[_COMMUNITY_Community 682|Community 682]]
+- [[_COMMUNITY_Community 683|Community 683]]
+- [[_COMMUNITY_Community 684|Community 684]]
+- [[_COMMUNITY_Community 685|Community 685]]
+- [[_COMMUNITY_Community 686|Community 686]]
+- [[_COMMUNITY_Community 687|Community 687]]
+- [[_COMMUNITY_Community 688|Community 688]]
+- [[_COMMUNITY_Community 689|Community 689]]
+- [[_COMMUNITY_Community 690|Community 690]]
+- [[_COMMUNITY_Community 691|Community 691]]
+- [[_COMMUNITY_Community 692|Community 692]]
+- [[_COMMUNITY_Community 693|Community 693]]
+- [[_COMMUNITY_Community 694|Community 694]]
+- [[_COMMUNITY_Community 695|Community 695]]
+- [[_COMMUNITY_Community 696|Community 696]]
+- [[_COMMUNITY_Community 697|Community 697]]
+- [[_COMMUNITY_Community 698|Community 698]]
+- [[_COMMUNITY_Community 699|Community 699]]
+- [[_COMMUNITY_Community 700|Community 700]]
+- [[_COMMUNITY_Community 701|Community 701]]
+- [[_COMMUNITY_Community 702|Community 702]]
+- [[_COMMUNITY_Community 703|Community 703]]
+- [[_COMMUNITY_Community 704|Community 704]]
+- [[_COMMUNITY_Community 705|Community 705]]
+- [[_COMMUNITY_Community 706|Community 706]]
+- [[_COMMUNITY_Community 707|Community 707]]
+- [[_COMMUNITY_Community 708|Community 708]]
+- [[_COMMUNITY_Community 709|Community 709]]
+- [[_COMMUNITY_Community 710|Community 710]]
+- [[_COMMUNITY_Community 711|Community 711]]
+- [[_COMMUNITY_Community 712|Community 712]]
+- [[_COMMUNITY_Community 713|Community 713]]
+- [[_COMMUNITY_Community 714|Community 714]]
+- [[_COMMUNITY_Community 715|Community 715]]
+- [[_COMMUNITY_Community 716|Community 716]]
+- [[_COMMUNITY_Community 717|Community 717]]
+- [[_COMMUNITY_Community 718|Community 718]]
+- [[_COMMUNITY_Community 719|Community 719]]
+- [[_COMMUNITY_Community 720|Community 720]]
+- [[_COMMUNITY_Community 721|Community 721]]
+- [[_COMMUNITY_Community 722|Community 722]]
+- [[_COMMUNITY_Community 723|Community 723]]
+- [[_COMMUNITY_Community 724|Community 724]]
+- [[_COMMUNITY_Community 725|Community 725]]
+- [[_COMMUNITY_Community 726|Community 726]]
+- [[_COMMUNITY_Community 727|Community 727]]
+- [[_COMMUNITY_Community 728|Community 728]]
+- [[_COMMUNITY_Community 729|Community 729]]
+- [[_COMMUNITY_Community 730|Community 730]]
+- [[_COMMUNITY_Community 731|Community 731]]
+- [[_COMMUNITY_Community 732|Community 732]]
+- [[_COMMUNITY_Community 733|Community 733]]
+- [[_COMMUNITY_Community 734|Community 734]]
+- [[_COMMUNITY_Community 735|Community 735]]
+- [[_COMMUNITY_Community 736|Community 736]]
+- [[_COMMUNITY_Community 737|Community 737]]
+- [[_COMMUNITY_Community 738|Community 738]]
+- [[_COMMUNITY_Community 739|Community 739]]
+- [[_COMMUNITY_Community 740|Community 740]]
+- [[_COMMUNITY_Community 741|Community 741]]
+- [[_COMMUNITY_Community 742|Community 742]]
+- [[_COMMUNITY_Community 743|Community 743]]
+- [[_COMMUNITY_Community 744|Community 744]]
+- [[_COMMUNITY_Community 745|Community 745]]
+- [[_COMMUNITY_Community 746|Community 746]]
+- [[_COMMUNITY_Community 747|Community 747]]
+- [[_COMMUNITY_Community 748|Community 748]]
+- [[_COMMUNITY_Community 749|Community 749]]
+- [[_COMMUNITY_Community 750|Community 750]]
+- [[_COMMUNITY_Community 751|Community 751]]
+- [[_COMMUNITY_Community 752|Community 752]]
+- [[_COMMUNITY_Community 753|Community 753]]
+- [[_COMMUNITY_Community 754|Community 754]]
+- [[_COMMUNITY_Community 755|Community 755]]
+- [[_COMMUNITY_Community 756|Community 756]]
+- [[_COMMUNITY_Community 757|Community 757]]
+- [[_COMMUNITY_Community 758|Community 758]]
+- [[_COMMUNITY_Community 759|Community 759]]
+- [[_COMMUNITY_Community 760|Community 760]]
+- [[_COMMUNITY_Community 761|Community 761]]
+- [[_COMMUNITY_Community 762|Community 762]]
+- [[_COMMUNITY_Community 763|Community 763]]
+- [[_COMMUNITY_Community 764|Community 764]]
+- [[_COMMUNITY_Community 765|Community 765]]
+- [[_COMMUNITY_Community 766|Community 766]]
+- [[_COMMUNITY_Community 767|Community 767]]
+- [[_COMMUNITY_Community 768|Community 768]]
+- [[_COMMUNITY_Community 769|Community 769]]
+- [[_COMMUNITY_Community 770|Community 770]]
+- [[_COMMUNITY_Community 771|Community 771]]
+- [[_COMMUNITY_Community 772|Community 772]]
+- [[_COMMUNITY_Community 773|Community 773]]
+- [[_COMMUNITY_Community 774|Community 774]]
+- [[_COMMUNITY_Community 775|Community 775]]
+- [[_COMMUNITY_Community 776|Community 776]]
+- [[_COMMUNITY_Community 777|Community 777]]
+- [[_COMMUNITY_Community 778|Community 778]]
+- [[_COMMUNITY_Community 779|Community 779]]
+- [[_COMMUNITY_Community 780|Community 780]]
+- [[_COMMUNITY_Community 781|Community 781]]
+- [[_COMMUNITY_Community 782|Community 782]]
+- [[_COMMUNITY_Community 783|Community 783]]
+- [[_COMMUNITY_Community 784|Community 784]]
+- [[_COMMUNITY_Community 785|Community 785]]
+- [[_COMMUNITY_Community 786|Community 786]]
+- [[_COMMUNITY_Community 787|Community 787]]
+- [[_COMMUNITY_Community 788|Community 788]]
+- [[_COMMUNITY_Community 789|Community 789]]
+- [[_COMMUNITY_Community 790|Community 790]]
+- [[_COMMUNITY_Community 791|Community 791]]
+- [[_COMMUNITY_Community 792|Community 792]]
+- [[_COMMUNITY_Community 793|Community 793]]
+- [[_COMMUNITY_Community 794|Community 794]]
+- [[_COMMUNITY_Community 795|Community 795]]
+- [[_COMMUNITY_Community 796|Community 796]]
+- [[_COMMUNITY_Community 797|Community 797]]
+- [[_COMMUNITY_Community 798|Community 798]]
+- [[_COMMUNITY_Community 799|Community 799]]
+- [[_COMMUNITY_Community 800|Community 800]]
+- [[_COMMUNITY_Community 801|Community 801]]
+- [[_COMMUNITY_Community 802|Community 802]]
+- [[_COMMUNITY_Community 803|Community 803]]
+- [[_COMMUNITY_Community 804|Community 804]]
+- [[_COMMUNITY_Community 805|Community 805]]
+- [[_COMMUNITY_Community 806|Community 806]]
+- [[_COMMUNITY_Community 807|Community 807]]
+- [[_COMMUNITY_Community 808|Community 808]]
+- [[_COMMUNITY_Community 809|Community 809]]
+- [[_COMMUNITY_Community 810|Community 810]]
+- [[_COMMUNITY_Community 811|Community 811]]
+- [[_COMMUNITY_Community 812|Community 812]]
+- [[_COMMUNITY_Community 813|Community 813]]
+- [[_COMMUNITY_Community 814|Community 814]]
+- [[_COMMUNITY_Community 815|Community 815]]
+- [[_COMMUNITY_Community 816|Community 816]]
+- [[_COMMUNITY_Community 817|Community 817]]
+- [[_COMMUNITY_Community 818|Community 818]]
+- [[_COMMUNITY_Community 819|Community 819]]
+- [[_COMMUNITY_Community 820|Community 820]]
+- [[_COMMUNITY_Community 821|Community 821]]
+- [[_COMMUNITY_Community 822|Community 822]]
+- [[_COMMUNITY_Community 823|Community 823]]
+- [[_COMMUNITY_Community 824|Community 824]]
+- [[_COMMUNITY_Community 825|Community 825]]
+- [[_COMMUNITY_Community 826|Community 826]]
+- [[_COMMUNITY_Community 827|Community 827]]
+- [[_COMMUNITY_Community 828|Community 828]]
+- [[_COMMUNITY_Community 829|Community 829]]
+- [[_COMMUNITY_Community 830|Community 830]]
+- [[_COMMUNITY_Community 831|Community 831]]
+- [[_COMMUNITY_Community 832|Community 832]]
+- [[_COMMUNITY_Community 833|Community 833]]
+- [[_COMMUNITY_Community 834|Community 834]]
+- [[_COMMUNITY_Community 835|Community 835]]
+- [[_COMMUNITY_Community 836|Community 836]]
+- [[_COMMUNITY_Community 837|Community 837]]
+- [[_COMMUNITY_Community 838|Community 838]]
+- [[_COMMUNITY_Community 839|Community 839]]
+- [[_COMMUNITY_Community 840|Community 840]]
+- [[_COMMUNITY_Community 841|Community 841]]
+- [[_COMMUNITY_Community 842|Community 842]]
+- [[_COMMUNITY_Community 843|Community 843]]
+- [[_COMMUNITY_Community 844|Community 844]]
+- [[_COMMUNITY_Community 845|Community 845]]
+- [[_COMMUNITY_Community 846|Community 846]]
+- [[_COMMUNITY_Community 847|Community 847]]
+- [[_COMMUNITY_Community 848|Community 848]]
+- [[_COMMUNITY_Community 849|Community 849]]
+- [[_COMMUNITY_Community 850|Community 850]]
+- [[_COMMUNITY_Community 851|Community 851]]
+- [[_COMMUNITY_Community 852|Community 852]]
+- [[_COMMUNITY_Community 853|Community 853]]
+- [[_COMMUNITY_Community 854|Community 854]]
+- [[_COMMUNITY_Community 855|Community 855]]
+- [[_COMMUNITY_Community 856|Community 856]]
+- [[_COMMUNITY_Community 857|Community 857]]
+- [[_COMMUNITY_Community 858|Community 858]]
+- [[_COMMUNITY_Community 859|Community 859]]
+- [[_COMMUNITY_Community 860|Community 860]]
+- [[_COMMUNITY_Community 861|Community 861]]
+- [[_COMMUNITY_Community 862|Community 862]]
+- [[_COMMUNITY_Community 865|Community 865]]
+- [[_COMMUNITY_Community 866|Community 866]]
+- [[_COMMUNITY_Community 867|Community 867]]
+- [[_COMMUNITY_Community 868|Community 868]]
+- [[_COMMUNITY_Community 869|Community 869]]
+- [[_COMMUNITY_Community 870|Community 870]]
+- [[_COMMUNITY_Community 871|Community 871]]
+- [[_COMMUNITY_Community 872|Community 872]]
+- [[_COMMUNITY_Community 873|Community 873]]
+- [[_COMMUNITY_Community 874|Community 874]]
+- [[_COMMUNITY_Community 875|Community 875]]
+- [[_COMMUNITY_Community 876|Community 876]]
+- [[_COMMUNITY_Community 877|Community 877]]
+- [[_COMMUNITY_Community 878|Community 878]]
+- [[_COMMUNITY_Community 879|Community 879]]
+- [[_COMMUNITY_Community 880|Community 880]]
+- [[_COMMUNITY_Community 881|Community 881]]
+- [[_COMMUNITY_Community 882|Community 882]]
+- [[_COMMUNITY_Community 883|Community 883]]
+- [[_COMMUNITY_Community 884|Community 884]]
+- [[_COMMUNITY_Community 885|Community 885]]
+- [[_COMMUNITY_Community 886|Community 886]]
+- [[_COMMUNITY_Community 887|Community 887]]
+- [[_COMMUNITY_Community 888|Community 888]]
+- [[_COMMUNITY_Community 889|Community 889]]
+- [[_COMMUNITY_Community 890|Community 890]]
+- [[_COMMUNITY_Community 891|Community 891]]
+- [[_COMMUNITY_Community 892|Community 892]]
+- [[_COMMUNITY_Community 894|Community 894]]
+- [[_COMMUNITY_Community 895|Community 895]]
+- [[_COMMUNITY_Community 896|Community 896]]
+- [[_COMMUNITY_Community 897|Community 897]]
+- [[_COMMUNITY_Community 898|Community 898]]
+- [[_COMMUNITY_Community 899|Community 899]]
+- [[_COMMUNITY_Community 900|Community 900]]
+- [[_COMMUNITY_Community 901|Community 901]]
+- [[_COMMUNITY_Community 902|Community 902]]
+- [[_COMMUNITY_Community 903|Community 903]]
+- [[_COMMUNITY_Community 904|Community 904]]
+- [[_COMMUNITY_Community 905|Community 905]]
+- [[_COMMUNITY_Community 907|Community 907]]
+- [[_COMMUNITY_Community 908|Community 908]]
+- [[_COMMUNITY_Community 909|Community 909]]
+- [[_COMMUNITY_Community 910|Community 910]]
+- [[_COMMUNITY_Community 911|Community 911]]
+- [[_COMMUNITY_Community 912|Community 912]]
+- [[_COMMUNITY_Community 913|Community 913]]
+- [[_COMMUNITY_Community 914|Community 914]]
+- [[_COMMUNITY_Community 915|Community 915]]
+- [[_COMMUNITY_Community 916|Community 916]]
+- [[_COMMUNITY_Community 917|Community 917]]
+- [[_COMMUNITY_Community 918|Community 918]]
+- [[_COMMUNITY_Community 919|Community 919]]
+- [[_COMMUNITY_Community 920|Community 920]]
+- [[_COMMUNITY_Community 921|Community 921]]
+- [[_COMMUNITY_Community 922|Community 922]]
+- [[_COMMUNITY_Community 923|Community 923]]
+- [[_COMMUNITY_Community 924|Community 924]]
+- [[_COMMUNITY_Community 925|Community 925]]
+- [[_COMMUNITY_Community 926|Community 926]]
+- [[_COMMUNITY_Community 927|Community 927]]
+- [[_COMMUNITY_Community 928|Community 928]]
+- [[_COMMUNITY_Community 929|Community 929]]
+- [[_COMMUNITY_Community 930|Community 930]]
+- [[_COMMUNITY_Community 931|Community 931]]
+- [[_COMMUNITY_Community 932|Community 932]]
+- [[_COMMUNITY_Community 933|Community 933]]
+- [[_COMMUNITY_Community 937|Community 937]]
+- [[_COMMUNITY_Community 939|Community 939]]
+- [[_COMMUNITY_Community 941|Community 941]]
+- [[_COMMUNITY_Community 942|Community 942]]
+- [[_COMMUNITY_Community 943|Community 943]]
+- [[_COMMUNITY_Community 944|Community 944]]
+- [[_COMMUNITY_Community 945|Community 945]]
+- [[_COMMUNITY_Community 946|Community 946]]
+- [[_COMMUNITY_Community 948|Community 948]]
+- [[_COMMUNITY_Community 949|Community 949]]
+- [[_COMMUNITY_Community 950|Community 950]]
+- [[_COMMUNITY_Community 951|Community 951]]
+- [[_COMMUNITY_Community 952|Community 952]]
+- [[_COMMUNITY_Community 954|Community 954]]
+- [[_COMMUNITY_Community 955|Community 955]]
+- [[_COMMUNITY_Community 956|Community 956]]
+- [[_COMMUNITY_Community 957|Community 957]]
+- [[_COMMUNITY_Community 963|Community 963]]
+- [[_COMMUNITY_Community 964|Community 964]]
+- [[_COMMUNITY_Community 965|Community 965]]
+- [[_COMMUNITY_Community 966|Community 966]]
+- [[_COMMUNITY_Community 967|Community 967]]
+- [[_COMMUNITY_Community 968|Community 968]]
+- [[_COMMUNITY_Community 986|Community 986]]
+- [[_COMMUNITY_Community 987|Community 987]]
+- [[_COMMUNITY_Community 988|Community 988]]
+
+## God Nodes (most connected - your core abstractions)
+1. `EvalSuite` - 161 edges
+2. `ToolCatalog` - 132 edges
+3. `MCPServer` - 125 edges
+4. `ResourceOwner` - 117 edges
+5. `MaterializedTool` - 107 edges
+6. `ValueSchema` - 98 edges
+7. `ToolMeta` - 89 edges
+8. `InputParameter` - 86 edges
+9. `ToolInput` - 81 edges
+10. `ToolOutput` - 81 edges
+
+## Surprising Connections (you probably didn't know these)
+- `EvalSuite` --semantically_similar_to--> `EvalSuite (lib)`  [INFERRED] [semantically similar]
+  examples/evals/README.md → libs/arcade-evals/README.md
+- `main()` --calls--> `path()`  [INFERRED]
+  tests/install/test_install.py → libs/arcade-core/arcade_core/toolkit.py
+- `_run_configure_smoke()` --calls--> `path()`  [INFERRED]
+  tests/integration/no_auth_cli_smoke.py → libs/arcade-core/arcade_core/toolkit.py
+- `_run_scaffold_and_protocol_smoke()` --calls--> `path()`  [INFERRED]
+  tests/integration/no_auth_cli_smoke.py → libs/arcade-core/arcade_core/toolkit.py
+- `ArcadeResourceServerAuth` --uses--> `TelemetryPassbackMiddleware`  [INFERRED]
+  examples/mcp_servers/telemetry_passback/src/telemetry_passback/server.py → libs/arcade-mcp-server/arcade_mcp_server/middleware/telemetry.py
+
+## Communities (989 total, 656 thin omitted)
+
+### Community 0 - "Community 0"
+Cohesion: 0.02
+Nodes (145): Provider, Supported model providers for evaluations., EvalSuite, A suite for evaluating AI model performance on specific tasks or scenarios., Initialize internal registry and auto-convert catalog if provided., Convert and register tools from a ToolCatalog to the internal registry., Tests for capture mode execution., Tests for EvalSuite.capture() method. (+137 more)
+
+### Community 1 - "Community 1"
+Cohesion: 0.04
+Nodes (127): create_func_models(), MaterializedTool, Analyze a function to create corresponding Pydantic models for its input and out, Metadata for a tool once it's been materialized., Data structure that holds tool information while stored in the Catalog, ToolMeta, InputParameter, Value schema for input parameters and outputs. (+119 more)
+
+### Community 2 - "Community 2"
+Cohesion: 0.03
+Nodes (114): Inferrable, An annotation indicating that a parameter can be inferred by a model (default: T, OAuth2, Marks a tool as requiring authorization., Marks a tool as requiring OAuth 2.0 authorization., ToolAuthorization, extract_pydantic_param_info(), extract_python_param_info() (+106 more)
+
+### Community 3 - "Community 3"
+Cohesion: 0.02
+Nodes (79): CaptureFormatter, _create_mock_capture_no_runs(), _create_mock_capture_result(), _create_mock_capture_with_runs(), Tests for capture mode formatters., Create a mock CaptureResult with multiple runs per case., Create a mock CaptureResult with a case that has no tool calls and no runs., Tests for multi-run capture in the text formatter. (+71 more)
+
+### Community 4 - "Community 4"
+Cohesion: 0.02
+Nodes (61): mcp_server(), Create and start an MCP server., Set the current model context and return a token to reset it., set_current_model_context(), MCPServer, MCP Server Implementation  Provides request handling, middleware orchestration,, Emit a structured WARNING log for a failed tool call., Attach tool error details to the active telemetry span when present. (+53 more)
+
+### Community 5 - "Community 5"
+Cohesion: 0.03
+Nodes (88): Singleton class that holds all tools for a given worker, Load disabled tools from the environment variable.          The ARCADE_DISABLED_, Load disabled toolkits from the environment variable.          The ARCADE_DISABL, Add a function to the catalog as a tool.          Args:             tool_func: T, Add all the tools in a module to the catalog.          Args:             module:, Add the tools from a loaded toolkit to the catalog.          Args:             t, Find a tool by its function., Get a tool from the catalog by name.          Args:             name: The name o (+80 more)
+
+### Community 6 - "Community 6"
+Cohesion: 0.04
+Nodes (71): Create a server session., server_session(), Error in session management, SessionError, InitializationState, NotificationManager, MCP Server Session  Manages per-session state and provides session-level operati, Handle a response message from the client.          Args:             message: R (+63 more)
+
+### Community 7 - "Community 7"
+Cohesion: 0.04
+Nodes (65): Raised when there is an error in the definition/signature of a tool., ToolDefinitionError, Behavior, Classification, _find_json_violations(), Operation, Tool Metadata  Defines the metadata model for Arcade tools. This module provides, Classifies the tool's effect on resources in the target system.      The concret (+57 more)
+
+### Community 8 - "Community 8"
+Cohesion: 0.06
+Nodes (71): ModelContext, Context, _ContextComponent, Logs, _NotificationsPrompts, _NotificationsResources, _NotificationsTools, Set the session for this context. (+63 more)
+
+### Community 9 - "Community 9"
+Cohesion: 0.03
+Nodes (57): _make_multi_model_multi_run_results(), _make_multi_run_case(), _make_multi_run_case_failed(), _make_multi_run_results(), _make_multi_run_results_failed(), Tests for evaluation result formatters., Tests for FORMATTERS registry., Registry should contain txt and md formats. (+49 more)
+
+### Community 10 - "Community 10"
+Cohesion: 0.03
+Nodes (57): Tests for Middleware base classes., Test base middleware functionality., Test MiddlewareContext creation., Test that Middleware follows the protocol., Test metadata management in context., test_basic_middleware(), test_middleware_chain(), test_middleware_error_propagation() (+49 more)
+
+### Community 11 - "Community 11"
+Cohesion: 0.04
+Nodes (48): Tests for CaptureTextFormatter methods that lacked coverage., _format_value should truncate values longer than 60 chars., _format_value should NOT truncate values of exactly 60 chars., CaptureTextFormatter._format_conversation_text should format messages., Should gracefully handle non-JSON tool content., Should gracefully handle non-JSON tool call arguments., Should add separator between messages (not before first)., Multi-model capture with tracks should render correctly with context. (+40 more)
+
+### Community 12 - "Community 12"
+Cohesion: 0.04
+Nodes (45): Tests for MarkdownFormatter., File extension should be 'md'., Should produce valid markdown structure., Should include summary table with stats., Should include results table per model., Should use warning emoji for warned cases., Should use collapsible details section., Should include per-run detail tables when available. (+37 more)
+
+### Community 13 - "Community 13"
+Cohesion: 0.04
+Nodes (45): Tests for CaptureHtmlFormatter., Test file extension is html., Test that output is valid HTML structure., Test that CSS styles are included., Test that suite info is in output., Test that tool calls are in output., Test that HTML special characters are escaped., TestCaptureHtmlFormatter (+37 more)
+
+### Community 14 - "Community 14"
+Cohesion: 0.03
+Nodes (49): make_mock_results(), MockEvaluation, Tests for TextFormatter., File extension should be 'txt'., Should format basic results correctly., Should show warnings correctly., Should include detailed output when show_details=True., Tests for JsonFormatter. (+41 more)
+
+### Community 15 - "Community 15"
+Cohesion: 0.04
+Nodes (51): Critic, Base class for all critics.      Attributes:         critic_field: The field nam, Tests for ComparativeCaseBuilder fluent API., Test builder creates a comparative case., Test builder for_track method., Test for_track raises for nonexistent track., Test builder supports method chaining., Tests for TrackConfig dataclass. (+43 more)
+
+### Community 16 - "Community 16"
+Cohesion: 0.03
+Nodes (41): Test that the adapter has the correct slug., Test URI sanitization removes query parameters., Test URI sanitization removes fragments., Test URI sanitization handles trailing slashes., Test parsing retry-after header with seconds value., Test parsing retry-after header with lowercase key., Create a mock errors module with all necessary error classes., Test parsing retry-after header with absolute date format. (+33 more)
+
+### Community 17 - "Community 17"
+Cohesion: 0.04
+Nodes (53): EvalCase, Represents a single evaluation case within an EvalSuite.      Attributes:, Check if tool call quantity failure should occur.          Args:             act, Factory method to create EvalCase instances.          Used by the comparative mi, NamedExpectedToolCall, Represents a tool call with its name and arguments.      Attributes:         nam, Test EvalCase's evaluate method to ensure it calculates the overall score     co, Test EvalCase's evaluate method when the actual tool calls do not match     the (+45 more)
+
+### Community 18 - "Community 18"
+Cohesion: 0.05
+Nodes (41): EvaluationResult, Add a critic result to the list of critic results.          Args:             fi, Score and record tool selection in results.          Args:             expected:, Compute the final score by normalizing the total score with the total weight., Evaluate the actual tool calls against the expected tool calls and critics., Represents the result of an evaluation case.      Attributes:         score: The, _resolve_pass_rule(), Tests for EvalRubric dataclass. (+33 more)
+
+### Community 19 - "Community 19"
+Cohesion: 0.04
+Nodes (38): MCPApp, Add a tool for build-time materialization (pre-server)., Add all the tools in a module to the catalog., Decorator for adding tools with optional parameters., A FastAPI-like interface for building MCP servers.      The app collects tools a, mcp_app(), Tests for MCPApp initialization and basic functionality., Test versions like 1.10.0 are accepted. (+30 more)
+
+### Community 20 - "Community 20"
+Cohesion: 0.09
+Nodes (61): ContextRequiredToolError, ErrorKind, FatalToolError, NetworkTransportError, Any failure starting from when the tool call begins until the tool call returns., DEPRECATED: Use stacktrace() instead.          This method is deprecated and wil, Raised when an error occurs during the execution of a tool's body.      This is, Raised when a tool execution error is retryable. (+53 more)
+
+### Community 21 - "Community 21"
+Cohesion: 0.05
+Nodes (32): _make_span(), Test ContextVarSpanCollector class., Test start_collecting / stop_collecting., Build a lightweight mock ReadableSpan., TestAttrsToKv, TestCollectingLifecycle, TestContextVarSpanCollector, TestFilterTopLevelSpans (+24 more)
+
+### Community 22 - "Community 22"
+Cohesion: 0.04
+Nodes (42): BinaryCritic, Evaluates whether the expected and actual values are exactly equal after casting, A critic for performing exact equality comparisons between expected and actual v, Casts the actual value to the type of the expected value.          Args:, Tests for critic weight validation and FuzzyWeight support., Test that negative weights raise WeightError., Test that FuzzyWeight skips validation (normalized later)., Test that zero weight is allowed. (+34 more)
+
+### Community 23 - "Community 23"
+Cohesion: 0.04
+Nodes (66): create_package_archive(), get_required_secrets(), get_server_info(), MCPClientInfo, MCPInitializeParams, MCPInitializeRequest, Create a tar.gz archive of the package directory.      Args:         package_dir, Choose stdout/stderr targets for the temporary validation server process.      ` (+58 more)
+
+### Community 24 - "Community 24"
+Cohesion: 0.05
+Nodes (44): Tests for Resource Manager implementation., Register a wildcard and a specific template that overlap., resource_manager(), sample_template(), test_add_file_resource(), test_add_file_resource_binary(), test_add_file_resource_not_found(), test_add_text_resource() (+36 more)
+
+### Community 25 - "Community 25"
+Cohesion: 0.05
+Nodes (53): A requirement for authorization to use a tool., ToolAuthRequirement, _make_tool_with_typeddict_return(), Tests verifying that error responses do NOT emit structuredContent.  When a tool, The ErrorHandlingMiddleware returns structuredContent=None on errors., Even with int fields in the schema, error structuredContent is None (no type mis, Even a TypedDict with some optional fields gets structuredContent=None on error., Test that server-level error paths set structuredContent=None. (+45 more)
+
+### Community 26 - "Community 26"
+Cohesion: 0.04
+Nodes (44): ABC, Tests for multi-model helper functions in base.py., Test detection of multiple models in captures., Test single model detection., Test grouping captures by case for comparison., TestMultiModelHelpers, make_mcp_server_comparative_results(), Create comparative results simulating 3 different MCP servers for Linear.      T (+36 more)
+
+### Community 27 - "Community 27"
+Cohesion: 0.05
+Nodes (38): NoneCritic, NumericCritic, A critic for evaluating numeric values within a specified range.      This criti, A critic that has no effect on the evaluation results and does not actually eval, Raised when the critic weights do not abide by evaluation weight constraints., WeightError, Tests for critic evaluation logic., Test that close values get high scores. (+30 more)
+
+### Community 28 - "Community 28"
+Cohesion: 0.05
+Nodes (53): create_auth_requirement(), create_input_definition(), create_metadata_requirement(), create_model_from_typeddict(), create_output_definition(), create_secrets_requirement(), create_tool_definition(), determine_output_model() (+45 more)
+
+### Community 29 - "Community 29"
+Cohesion: 0.04
+Nodes (39): Tests for shared types in _types.py module., Test that ExpectedToolCall is valid for AnyExpectedToolCall., Test that ExpectedMCPToolCall is valid for AnyExpectedToolCall., Tests for ExpectedToolCall dataclass., Test creating ExpectedToolCall with function and args., Test creating ExpectedToolCall with default empty args., Test creating ExpectedToolCall with positional args., Tests for ExpectedMCPToolCall dataclass. (+31 more)
+
+### Community 30 - "Community 30"
+Cohesion: 0.05
+Nodes (33): A critic for evaluating the similarity between two strings.      This critic use, SimilarityCritic, Tests for SimilarityCritic text similarity comparisons., Test that exact string match returns full weight as score., Test that very similar strings get high scores., Test that different strings get low scores., Test that similarity_threshold correctly determines match status., Test that partial weight is respected. (+25 more)
+
+### Community 31 - "Community 31"
+Cohesion: 0.06
+Nodes (35): Process request in stateful mode - maintain session state., connect(), HTTPStreamableTransport, HTTP Streamable Transport for MCP servers.  This module implements HTTP transpor, HTTP transport with SSE streaming support for MCP.      Responsibilities     - P, Initialize HTTP streamable transport.          Args:             mcp_session_id:, Parse incoming data into a typed MCPMessage.          Accepts a raw JSON string,, Create an error response. (+27 more)
+
+### Community 32 - "Community 32"
+Cohesion: 0.06
+Nodes (38): Raised while importing / loading a toolkit package     (e.g. missing dependency,, ToolkitLoadError, Toolkit, Validate, test_add_tool_with_disabled_toolkit(), test_add_toolkit_import_module_error(), test_add_toolkit_type_error(), test_get_tool() (+30 more)
+
+### Community 33 - "Community 33"
+Cohesion: 0.05
+Nodes (34): compare_tool_name(), get_formatted_tools(), get_tool_args(), normalize_name(), Run evaluation using OpenAI client.          Args:             client: The OpenA, Get the formatted tools from the catalog.      Args:         catalog: The catalo, Returns the tool arguments from the chat completion object.      Args:         c, Compare the tool names by replacing all separators with the TOOL_NAME_SEPARATOR (+26 more)
+
+### Community 34 - "Community 34"
+Cohesion: 0.05
+Nodes (20): Tests for tool metadata serialization to MCP format., tool_manager(), Tests for Tool Manager implementation., Test ToolManager class., Test tool manager initialization., TestToolManager, tool_manager(), AsyncRegistry (+12 more)
+
+### Community 35 - "Community 35"
+Cohesion: 0.06
+Nodes (49): _get_deployment_status(), Get the status of a deployment.      Args:         engine_url: The base URL of t, Stream deployment logs into a deque with retry logic., Check if a server already exists in the Arcade Engine., Upsert secrets to the Arcade Engine.      Args:         engine_url: The base URL, server_already_exists(), _stream_deployment_logs_to_deque(), upsert_secrets_to_engine() (+41 more)
+
+### Community 36 - "Community 36"
+Cohesion: 0.05
+Nodes (54): Authorization MCP Server docker-compose.yml, Authorization MCP Server Docker README, Arcade CLI README, Model Context Protocol (MCP), OAuth 2.1, OpenTelemetry, SEP-2448 serverExecutionTelemetry, Arcade Core README (+46 more)
+
+### Community 37 - "Community 37"
+Cohesion: 0.06
+Nodes (51): filter_failed_evaluations(), Filter evaluation results to show only failed cases and calculate original count, create_mock_evaluation_result(), Test filtering with multiple eval suites., Test filtering with multiple models in same suite., Test filtering when one model has no failed cases., Create a mock EvaluationResult with the specified properties., Test that --capture flag is documented in help. (+43 more)
+
+### Community 38 - "Community 38"
+Cohesion: 0.06
+Nodes (27): Run evaluation using Anthropic client.          Args:             client: The An, convert_messages_to_anthropic(), Convert OpenAI-format messages to Anthropic format.      Anthropic only supports, Tests for the convert_messages_to_anthropic helper function., Test conversion of empty messages list., Test that user messages pass through unchanged., Test that regular assistant messages pass through unchanged., Test that system messages are skipped. (+19 more)
+
+### Community 39 - "Community 39"
+Cohesion: 0.04
+Nodes (47): A tool with unsupported parameter type., A tool with untyped parameter., A tool with invalid parameter name., A tool with an input parameter that has too many annotations., A tool with an input parameter that is a non-optional union type., A tool with an input parameter that has a non-callable default factory., A tool with multiple input parameters that are ToolContext., A tool without return type hint. (+39 more)
+
+### Community 40 - "Community 40"
+Cohesion: 0.05
+Nodes (29): CapturedCase, Result of running a single case in capture mode.      Attributes:         case_n, _create_mock_capture_with_tracks(), Text formatter should show track information., HTML formatter should show track information., Markdown formatter should show track information., Tests for the CAPTURE_FORMATTERS registry., Test that all expected formats are registered. (+21 more)
+
+### Community 41 - "Community 41"
+Cohesion: 0.09
+Nodes (44): CaptureTaskResult, EvalTaskResult, from_error(), from_success(), Evaluation and capture mode execution logic for the CLI.  This module contains t, Result of running a single capture task., Run a single evaluation task with error handling.      Returns EvalTaskResult wi, Run a single capture task with error handling.      Returns CaptureTaskResult wi (+36 more)
+
+### Community 43 - "Community 43"
+Cohesion: 0.07
+Nodes (42): configure_claude_local(), configure_cursor_arcade(), configure_cursor_local(), configure_vscode_local(), _dedupe_paths(), find_python_interpreter(), get_claude_config_path(), get_cursor_config_path() (+34 more)
+
+### Community 44 - "Community 44"
+Cohesion: 0.06
+Nodes (28): make_comparative_results(), Tests for comparative markdown formatting., Should have comparative header., Should show suite-specific tracks., Should show case comparison table with all tracks., Should show which fields differ between tracks., Should include collapsible details per track., Tests for comparative text formatting. (+20 more)
+
+### Community 45 - "Community 45"
+Cohesion: 0.07
+Nodes (37): build_jsonrpc_request(), _cleanup_process(), _find_open_tcp_port(), get_entrypoint_path(), mock_elicitation_response(), mock_sampling_response(), parse_jsonrpc_message(), End-to-end integration tests for arcade_mcp_server.  Tests the full MCP protocol (+29 more)
+
+### Community 46 - "Community 46"
+Cohesion: 0.06
+Nodes (27): denormalize_tool_name(), normalize_tool_name(), Shared utilities for tool name conversion across providers.  This module contain, Reverse the normalization of a tool name.      This converts provider-format nam, Normalize a tool name for LLM provider compatibility.      Both OpenAI and Anthr, Tests for arcade_core.converters.utils module., Test converting simple dot notation to underscores., Test converting multiple dots. (+19 more)
+
+### Community 47 - "Community 47"
+Cohesion: 0.07
+Nodes (40): clean_auth_env(), ed25519_jwks_data(), expired_ed25519_token(), Generate valid JWT token for testing., Generate Ed25519 JWKS data for testing., Generate expired Ed25519 JWT token for testing., Clean server auth environment variables before each test., Generate RSA key pair for testing. (+32 more)
+
+### Community 48 - "Community 48"
+Cohesion: 0.07
+Nodes (26): Tests for multi-model JSON formatting., Should produce structured multi-model JSON., Should include best model per case., Should use regular format for single model., Tests for JSON formatter include_context functionality., JSON output should include context fields when include_context=True., JSON output should NOT include context fields when include_context=False., JSON comparative output should include context when requested. (+18 more)
+
+### Community 49 - "Community 49"
+Cohesion: 0.07
+Nodes (20): test_prompts_api(), prompt_manager(), Tests for Prompt Manager implementation., Test PromptManager class., Test prompt manager initialization., sample_prompt(), test_concurrent_prompt_operations(), test_prompt_error_handling() (+12 more)
+
+### Community 50 - "Community 50"
+Cohesion: 0.08
+Nodes (26): The response to a tool invocation., ToolCallResponse, The raw data for a request to a worker.     This is not intended to represent ev, A router is responsible for adding routes to the underlying framework hosting th, A Worker represents a collection of tools that is hosted inside a web framework, RequestData, Router, Worker (+18 more)
+
+### Community 51 - "Community 51"
+Cohesion: 0.05
+Nodes (29): make_multi_model_results(), Create mock multi-model evaluation results., Tests for multi-model eval helper functions., Should detect multiple models., Should detect single model., Should group results by suite, case, and model., Should find model with highest score., Should return 'Tie' when multiple models have same score. (+21 more)
+
+### Community 52 - "Community 52"
+Cohesion: 0.06
+Nodes (22): Tests for track management in comparative evaluations., Test that each track has its own isolated registry., Tests for TrackManager class., Test creating a new track., Test that creating a duplicate track raises ValueError., Test getting a registry by track name., Test getting a nonexistent registry returns None., Test getting all track names. (+14 more)
+
+### Community 53 - "Community 53"
+Cohesion: 0.06
+Nodes (24): convert_content_to_structured_content(), create_mcp_tool(), Convert a Python value to MCP-compatible structured content (JSON object)., Create an MCP-compatible tool definition from a MaterializedTool.      Computes, Tests for MCP content conversion utilities., Test creating basic MCP tool., Test tool input schema generation., Test that output schema is included when definition has one. (+16 more)
+
+### Community 54 - "Community 54"
+Cohesion: 0.06
+Nodes (23): from_toolkit(), FullyQualifiedName, log(), _NoOpLogs, _NoOpProgress, progress(), Arcade Core Schema  Defines transport-agnostic tool schemas and runtime context, The fully-qualified name of a tool. (+15 more)
+
+### Community 55 - "Community 55"
+Cohesion: 0.07
+Nodes (36): build_coordinator_url(), check_existing_login(), create_oauth_client(), _credentials_file_contains_legacy(), exchange_code_for_tokens(), fetch_whoami(), generate_authorization_url(), get_active_context() (+28 more)
+
+### Community 56 - "Community 56"
+Cohesion: 0.06
+Nodes (40): analyze_text(), calculate_statistics(), CalendarDate, CalendarInfo, get_calendar_info(), get_team_info(), get_user_profile(), lookup_record() (+32 more)
+
+### Community 57 - "Community 57"
+Cohesion: 0.05
+Nodes (25): Tests for EvalSuite convenience methods (TICKET-003)., Tests for MCPToolDefinition TypedDict., MCPToolDefinition should be importable from arcade_evals., MCPToolDefinition should have name, description, and inputSchema keys., Tool definition with only 'name' should work (other fields default)., Tool definition with all fields should work., A list[MCPToolDefinition] should work with add_tool_definitions., Registering a tool with a duplicate name should raise ValueError. (+17 more)
+
+### Community 58 - "Community 58"
+Cohesion: 0.07
+Nodes (12): get_current_model_context(), notifications(), progress(), prompts(), MCP Context System  Provides the primary Context class for MCP tool development., Initialize context with server reference., Validate that the schema conforms to MCP elicitation restrictions., Get the current model context if available. (+4 more)
+
+### Community 59 - "Community 59"
+Cohesion: 0.09
+Nodes (38): display_eval_results(), Display evaluation results in a format inspired by pytest's output.      Args:, create_mock_evaluation_result(), Test display with both output file and failed_only flag., Test that output file creates parent directories if they don't exist., Create a mock EvaluationResult with the specified properties., Test display with cases that have warnings., Test display with empty results. (+30 more)
+
+### Community 60 - "Community 60"
+Cohesion: 0.06
+Nodes (35): Test the MCPApp tool decorator., bad_output_error_tool(), check_output(), check_output_error(), context_required_error_tool(), dict_output_tool(), list_typeddict_output_tool(), multi_field_tool() (+27 more)
+
+### Community 61 - "Community 61"
+Cohesion: 0.08
+Nodes (29): context(), error_middleware(), error_middleware_masked(), Tests for Error Handling Middleware., test_async_error_handling(), test_authorization_error(), test_chained_error_handling(), test_error_context_preservation() (+21 more)
+
+### Community 62 - "Community 62"
+Cohesion: 0.08
+Nodes (22): Test that integer enums have their type changed to string.          OpenAI stric, Test that optional integer enums get type ["string", "null"].          When an i, Test that string enums keep their type as string., Test that boolean enums have their type changed to string., Tests for OpenAI strict mode schema conversion., Test that enums with list type but no null are converted to single string type., Test basic schema conversion to OpenAI strict mode., Test that enum type conversion works in nested objects. (+14 more)
+
+### Community 63 - "Community 63"
+Cohesion: 0.08
+Nodes (18): Tests for tool name resolution (handling Anthropic normalized names)., Test that original names resolve correctly., Test that normalized names (underscores) resolve to original., Test that unknown names return None., Test has_tool works with normalized names., Test get_tool_schema works with normalized names., Test normalize_args works when called with normalized name., Test normalize_args replaces null (None) values with defaults.          OpenAI s (+10 more)
+
+### Community 64 - "Community 64"
+Cohesion: 0.07
+Nodes (32): HTTPServer, build_mcp_tools(), _count_spans(), _extract_auth_url(), _extract_trace_id(), FileTokenStorage, _find_instrumentor_span(), _galileo_config() (+24 more)
+
+### Community 65 - "Community 65"
+Cohesion: 0.07
+Nodes (20): Register a resource at build time (before server start).          If the URI con, Decorator for registering a resource with a handler at build time., Register a static text resource at build time., Register a file-backed resource at build time., Test URI template matching for resources/read., TestResourceTemplateMatching, _is_template_uri(), make_file_handler() (+12 more)
+
+### Community 66 - "Community 66"
+Cohesion: 0.09
+Nodes (29): CommandTracker, Tracks CLI command execution for usage analytics., mock_dependencies(), Tests for user_id property., Test that user_id delegates to identity.get_distinct_id()., Tests for _handle_successful_logout() method., Test that logout resets to anonymous when user was authenticated., Test that logout does not reset anon_id when user was not authenticated. (+21 more)
+
+### Community 67 - "Community 67"
+Cohesion: 0.07
+Nodes (32): get_eval_files(), Get a list of evaluation files starting with 'eval_' and ending with '.py' in th, path(), test_get_eval_files_with_spaces(), cleanup_test_files(), test_validate_file(), test_validate_tools_non_python_file(), test_validate_tools_syntax_error() (+24 more)
+
+### Community 68 - "Community 68"
+Cohesion: 0.09
+Nodes (26): context(), debug_logging_middleware(), logging_middleware(), Tests for Logging Middleware., Test LoggingMiddleware class., Test log level configuration., test_debug_level_logging(), test_error_response_logging() (+18 more)
+
+### Community 69 - "Community 69"
+Cohesion: 0.06
+Nodes (33): Tests for MCP feature graceful degradation in ToolContext.  This module tests th, Test that accessing context.prompts raises RuntimeError., Test that accessing context.sampling raises RuntimeError., Test that accessing context.ui raises RuntimeError., Test that accessing context.notifications raises RuntimeError., Test that accessing context.request_id raises RuntimeError., Test that accessing context.session_id raises RuntimeError., Test that context.log.debug() executes without error. (+25 more)
+
+### Community 70 - "Community 70"
+Cohesion: 0.08
+Nodes (22): get_default_model(), ProviderConfig, Configuration for a single provider from CLI input.      Parsed from --use-provi, Get models, using default if none specified., Get the default model for a provider.      Args:         provider: The provider, Tests for multi-provider utils functions., Test display_name property., Tests for expand_provider_configs function. (+14 more)
+
+### Community 71 - "Community 71"
+Cohesion: 0.07
+Nodes (26): configure_client_gateway(), Configure an MCP client to connect to an Arcade Cloud gateway.      If *auth_tok, _assert_only_added(), Assert that ``updated`` equals ``original`` except for a single new or     repla, Write a realistic existing config that contains:       - top-level keys unrelate, Verify every JSON-based client preserves unrelated data and produces     a corre, Without an auth token the config must not contain a headers field         (so MC, Output must be decodable as UTF-8 JSON with no BOM, and the         token must n (+18 more)
+
+### Community 72 - "Community 72"
+Cohesion: 0.1
+Nodes (18): BaseHTTPErrorMapper, _extract_request_info(), HTTPErrorAdapter, _HTTPXExceptionHandler, Strip query params and fragments from URI for privacy., Build extra metadata for error reporting., Map HTTP status code to appropriate Arcade error., Build a NetworkTransportError for no-response HTTP failures.          Used for t (+10 more)
+
+### Community 73 - "Community 73"
+Cohesion: 0.09
+Nodes (31): new(), Creates a new MCP server with the given name, create_ignore_pattern(), create_new_toolkit(), create_new_toolkit_minimal(), create_package(), Create a new toolkit from a template with user input., Create a new toolkit from a template with user input. (+23 more)
+
+### Community 74 - "Community 74"
+Cohesion: 0.06
+Nodes (17): Test MCPApp initialization creates proper settings., Test MCPApp initialization with default values., Test MCPApp initialization with partial values., Test adding a tool to the MCP app., Test configuration overrides from environment variables., Test _create_and_run_server method with mocked dependencies., Test _run_with_reload spawns child process with correct environment., Test _run_with_reload restarts server when file changes detected. (+9 more)
+
+### Community 75 - "Community 75"
+Cohesion: 0.09
+Nodes (20): The name and version of a tool., The request to call (invoke) a tool., ToolCallRequest, ToolReference, error_tool(), Success and error log lines must use identical tool identifier strings     so lo, The primary failure warning's f-string must use the same resolved     ``tool_fqn, Under the strict data-leak policy, the @tool fallback puts the verbose     ``str (+12 more)
+
+### Community 76 - "Community 76"
+Cohesion: 0.08
+Nodes (26): oauth_callback_server(), OAuthCallbackServer, Local HTTP server for OAuth callback., Shut down the callback server., Wait for the server to start listening., Wait for the OAuth callback to complete., Get the redirect URI for this server., Context manager for the OAuth callback server.      Ensures the server is proper (+18 more)
+
+### Community 77 - "Community 77"
+Cohesion: 0.06
+Nodes (31): ArticleDetail, Author, TypedDict definitions for structured tool outputs., Full article detail with nested author information., A single search hit with relevance context., Search results with metadata, The team or person who authored an article., SearchMatch (+23 more)
+
+### Community 78 - "Community 78"
+Cohesion: 0.11
+Nodes (28): build_tool_error_log_extra(), build_tool_error_span_attributes(), Shared helper for tool-call-error structured-log extras.  Field names (``error_*, Build the structured ``extra`` dict for a failed-tool-call WARNING log.      Arg, Build stable span attributes for failed tool-call diagnostics., Call (invoke) a tool using the ToolExecutor., Handle the request to call (invoke) a tool., _err() (+20 more)
+
+### Community 79 - "Community 79"
+Cohesion: 0.1
+Nodes (16): Error in server operations., ServerError, _get_configuration_overrides(), prompts(), _PromptsAPI, MCPApp - A FastAPI-like interface for MCP servers.  Provides a clean, minimal AP, Unified tools API for MCPApp (build-time and runtime)., Add or update a tool at runtime if server is bound; otherwise queue via app.add_ (+8 more)
+
+### Community 80 - "Community 80"
+Cohesion: 0.07
+Nodes (29): DatetimeCritic, A critic that evaluates the closeness of datetime values within a specified tole, Evaluates the closeness of datetime values within a specified tolerance., Create an evaluation suite for datetime tools using DatetimeCritic.      Datetim, server_with_evaluations_datetime_eval_suite(), Test the SimilarityCritic's evaluate method to ensure it computes     the simila, Test that SimilarityCritic handles non-string inputs (lists, dicts)     by conve, Test that initializing a critic with a negative weight raises a WeightError. (+21 more)
+
+### Community 81 - "Community 81"
+Cohesion: 0.09
+Nodes (18): make_empty_results(), MockEvaluation, Additional edge case tests for formatters to ensure robustness., Mock EvaluationResult for testing., HTML formatter must escape all special characters to prevent XSS., JSON formatter must always produce valid JSON., Formatters should handle None suite_name gracefully., Test pass rate calculation in various edge cases. (+10 more)
+
+### Community 82 - "Community 82"
+Cohesion: 0.09
+Nodes (17): _patch_loader(), Non-gql exceptions should return None., Should extract messages and map error codes to status., Should handle empty/missing errors gracefully., Duplicate error codes should be deduplicated., Should detect rate limits from status + headers., Should default to 500 when no status code., Should extract URL from __cause__ (aiohttp pattern). (+9 more)
+
+### Community 83 - "Community 83"
+Cohesion: 0.1
+Nodes (30): create_cli_catalog_local(), _discover_installed_toolkits(), Load a local toolkit from the current working directory if a pyproject.toml is p, add_discovered_tools(), analyze_files_for_tools(), build_catalog_from_toolkits(), build_minimal_toolkit(), collect_tools_from_modules() (+22 more)
+
+### Community 84 - "Community 84"
+Cohesion: 0.07
+Nodes (19): EvalError, Base class for all evaluation errors., Tests for arcade_evals.errors module., Test that EvalError is an Exception subclass., Test that EvalError can be raised and caught., Test that EvalError can be raised without a message., Tests for WeightError class., Test that WeightError is a subclass of EvalError. (+11 more)
+
+### Community 85 - "Community 85"
+Cohesion: 0.17
+Nodes (28): NotFoundError, Error in resource management., Requested entity not found., ResourceError, Test that handlers returning raw bytes are auto-encoded to BlobResourceContents., Test ResourceManager class., Test convenience methods for static resources., Test duplicate resource handling policies. (+20 more)
+
+### Community 86 - "Community 86"
+Cohesion: 0.09
+Nodes (18): parse_provider_spec(), Parse a --use-provider value into a ProviderConfig.      Args:         spec: Pro, Tests for parse_provider_spec function., Integration tests for the multi-provider workflow., Test full workflow from spec parsing to model specs., Test full workflow with multiple providers., Test parsing just provider name., Test that multiple --use-provider flags are parsed correctly (simulating CLI beh (+10 more)
+
+### Community 87 - "Community 87"
+Cohesion: 0.09
+Nodes (19): CaptureResult, Result of running an EvalSuite in capture mode.      Attributes:         suite_n, Convert to JSON string., Write capture results to a JSON file., tool_eval(), Test that decorator adds __tool_eval__ attribute., test_wrapper_accepts_provider_parameter(), Tests for CaptureResult dataclass. (+11 more)
+
+### Community 88 - "Community 88"
+Cohesion: 0.1
+Nodes (18): main(), Check that required tools are available., Build the `uv sync` command for the current runtime context.          When this, Install arcade-mcp from source., Test that the CLI is available and working., Test cross-platform file locking with portalocker., Run all tests and return exit code., Organizes and runs installation tests for arcade-mcp. (+10 more)
+
+### Community 89 - "Community 89"
+Cohesion: 0.07
+Nodes (15): Test mapping 429 status to rate limit error., Test mapping generic HTTP status to upstream error., Test the base HTTP error mapper functionality., Test parsing retry-after header with seconds value., Test parsing x-ratelimit-reset header with seconds value., Test parsing x-ratelimit-reset-ms header with milliseconds value., Test parsing retry header with absolute date format., Test parsing retry when no rate limit headers are present. (+7 more)
+
+### Community 90 - "Community 90"
+Cohesion: 0.08
+Nodes (23): Validate and normalize version to canonical semver., version(), ArcadeSettings, _find_project_root(), MiddlewareSettings, NotificationSettings, MCP Settings Management  Provides Pydantic-based settings with validation and en, Transport-related settings. (+15 more)
+
+### Community 91 - "Community 91"
+Cohesion: 0.13
+Nodes (21): _assert_ok(), _build_request(), _drain_stderr(), _find_free_port(), _find_greet_tool(), _http_post(), _kill_process(), main() (+13 more)
+
+### Community 92 - "Community 92"
+Cohesion: 0.09
+Nodes (16): BaseHTTPErrorMapper, _extract_error_message(), GraphQLErrorAdapter, _load_gql_transport_errors(), Handle TransportQueryError (GraphQL errors in response body)., Handle TransportServerError and other transport errors., Extract headers from an object if available., Extract URL and method from the __cause__ exception. (+8 more)
+
+### Community 93 - "Community 93"
+Cohesion: 0.07
+Nodes (28): CreateDeploymentRequest, deploy_server_logic(), deploy_server_to_engine(), DeploymentToolkits, _monitor_deployment_with_logs(), _poll_deployment_status(), Deployment request payload for /v1/deployments/{deployment_name} endpoint., Poll deployment status until it's running or error. (+20 more)
+
+### Community 94 - "Community 94"
+Cohesion: 0.11
+Nodes (25): augment_error_message_for_debug(), _leak_enabled(), Debug-only escape hatch for MCP tool error responses.  MCP clients typically ren, Append debug internals to ``message`` when the corresponding env flags are set., Tests for the debug-exposure escape hatch in ``arcade_mcp_server/_debug_exposure, Developer flag on but developer_message None → only stacktrace absence is report, Second call with the flag on must NOT emit another activation warning., Regression: once a truthy-but-non-magic value has been rejected for a     flag, (+17 more)
+
+### Community 95 - "Community 95"
+Cohesion: 0.1
+Nodes (25): _call(), erroring_server(), raises_fatal_tool_error(), raises_unhandled_exception(), End-to-end integration tests for the MCP debug-exposure escape hatch.  These com, Default state: the agent sees ONLY the sanitized message., Developer message stays out of MCP content but is attached to telemetry., A no-op/non-recording span should not be mutated. (+17 more)
+
+### Community 96 - "Community 96"
+Cohesion: 0.09
+Nodes (15): _build_adapter_chain(), _raise_as_arcade_error(), Build the adapter chain for error handling.      Args:         adapters: User-pr, Try to translate an exception using the adapter chain, then raise the translated, get_adapter_for_auth_provider(), Get an error adapter from an auth provider., MicrosoftGraphErrorAdapter, Extract error message and developer details from Microsoft Graph APIError. (+7 more)
+
+### Community 97 - "Community 97"
+Cohesion: 0.07
+Nodes (3): Tests for MCP server loaders (official MCP SDK wrappers)., Tests for load_stdio_arcade function., TestLoadStdioArcade
+
+### Community 98 - "Community 98"
+Cohesion: 0.08
+Nodes (19): basic_suite(), Tests for EvalSuite capture mode functionality.  Capture mode allows running eva, Tests for capture mode imports., Test that capture classes are importable from arcade_evals., Tests for EvalSuite.capture() method., Tests for tool_eval decorator with capture mode., Tests for capturing multiple tool calls from a single case., Tests for capture mode with Anthropic provider. (+11 more)
+
+### Community 99 - "Community 99"
+Cohesion: 0.1
+Nodes (15): Any error related to an Arcade tool.      Note: This class is an abstract class, Raised when there is an error serializing/marshalling the tool call arguments or, Raised when there is an error parsing a tool call argument., Raised when there is an error serializing a tool call return value., Base class for all Arcade errors.      Note: This class is an abstract class and, Add context to the error message.          Args:             name: The name of t, ToolError, ToolInputError (+7 more)
+
+### Community 100 - "Community 100"
+Cohesion: 0.11
+Nodes (17): Tests for ResourceServerMiddleware class., Tests for JWKSTokenValidator class., TestJWKSTokenValidator, TestResourceServerMiddleware, AuthenticationError, InvalidTokenError, Base classes for MCP Resource Server authentication., Token is invalid (signature, audience, issuer, etc.). (+9 more)
+
+### Community 101 - "Community 101"
+Cohesion: 0.08
+Nodes (23): AnthropicInputSchemaProperty, AnthropicToolSchema, _convert_input_parameters_to_json_schema(), _convert_value_schema_to_json_schema(), _create_tool_schema(), Converter for converting Arcade ToolDefinition to Anthropic tool schema., Convert Arcade ValueSchema to JSON Schema format for Anthropic., Convert list of InputParameter to JSON schema parameters object.      Unlike Ope (+15 more)
+
+### Community 102 - "Community 102"
+Cohesion: 0.08
+Nodes (25): collect_messages(), event_loop(), initialized_server_session(), mcp_settings(), mock_context(), mock_read_stream(), mock_write_stream(), Shared fixtures and utilities for arcade-mcp-server tests. (+17 more)
+
+### Community 103 - "Community 103"
+Cohesion: 0.1
+Nodes (17): _configure_windows_utf8(), _needs_utf8(), Shared console setup for Arcade CLI output., Ensure Windows console encoding won't raise UnicodeEncodeError., Tests for the console.py encoding safety layer.  These tests verify that _needs_, Streams without a reconfigure method should not crash., If both streams are already utf-8, nothing should be reconfigured., After reconfiguring a cp1252 stream, writing emoji should not crash. (+9 more)
+
+### Community 104 - "Community 104"
+Cohesion: 0.1
+Nodes (18): # IMPORTANT: Convert non-string values to strings before TF-IDF comparison., resolved_weight(), _is_placeholder_critic(), _normalize_fuzzy_critic_weights(), Weight definitions and normalization for arcade-evals.  This module contains: -, Resolve a Weight value to a float.      Used when a single weight needs to be re, Validate and normalize critic weights in-place.      If any critic uses FuzzyWei, Normalize critic weights when FuzzyWeight is used.      Filters out placeholder (+10 more)
+
+### Community 105 - "Community 105"
+Cohesion: 0.12
+Nodes (18): Wait for the transport to shut down., Stdio transport implementation for stdio communication.      This transport uses, Initialize stdio transport., StdioTransport, Test StdioWriteStream functionality., Test StdioTransport functionality., test_connect_session_creates_session(), test_connect_session_single_session_limit() (+10 more)
+
+### Community 106 - "Community 106"
+Cohesion: 0.13
+Nodes (23): discover_toolkits(), Return all Arcade toolkits installed in the active Python environment.      Rais, notifications(), prompts(), request_id(), resources(), sampling(), session_id() (+15 more)
+
+### Community 107 - "Community 107"
+Cohesion: 0.09
+Nodes (22): configure_amazonq_arcade(), configure_vscode_arcade(), _format_path_for_display(), get_amazonq_config_path(), Get the Amazon Q Developer configuration file path., Configure VS Code to connect to an Arcade Cloud MCP gateway., Configure Amazon Q Developer to connect to an Arcade Cloud MCP gateway.      Ama, _warn_overwrite() (+14 more)
+
+### Community 108 - "Community 108"
+Cohesion: 0.09
+Nodes (20): Convert settings to list of AuthorizationServerEntry objects., Tests for front-door auth env var configuration support., Test that missing required fields raise ValueError., Test that ResourceServerAuth validation happens during init., Tests for ResourceServerAuth class., Test that ResourceServerAuth supports OAuth discovery., Test getting OAuth Protected Resource Metadata., test_arcade_as_config() (+12 more)
+
+### Community 109 - "Community 109"
+Cohesion: 0.09
+Nodes (23): fetch_organizations(), fetch_projects(), Fetch organizations the user belongs to.      Args:         coordinator_url: Bas, Fetch projects in an organization.      Args:         coordinator_url: Base URL, dashboard(), Opens the Arcade Dashboard in a web browser.      The Dashboard is a web-based A, main(), org_list() (+15 more)
+
+### Community 110 - "Community 110"
+Cohesion: 0.12
+Nodes (14): parse_output_formats(), Parse output format string into a list of formats.      Supports:     - Single f, Tests for parse_output_formats function., Should return a list with a single format., Should return a list of multiple formats., Should handle spaces around commas., Should return all formats for 'all' keyword., Should be case-insensitive. (+6 more)
+
+### Community 111 - "Community 111"
+Cohesion: 0.11
+Nodes (14): Should return JsonFormatter for 'json' format., Tests for get_formatter function., Should return TextFormatter for 'txt'., Should return MarkdownFormatter for 'md'., get_formatter should return HtmlFormatter for 'html'., Should be case-insensitive., Should raise ValueError for unknown format., Should suggest 'txt' when 'txtt' is provided. (+6 more)
+
+### Community 112 - "Community 112"
+Cohesion: 0.11
+Nodes (15): Tests for Anthropic schema conversion., Test basic MCP to Anthropic tool conversion., Test that the schema is preserved without modifications., Test that dots in tool names are converted to underscores.          Anthropic to, Test that hyphens in tool names are preserved (they're valid)., Test that multiple dots are all converted to underscores., Test that missing description defaults to empty string., Test that missing inputSchema defaults to empty object schema. (+7 more)
+
+### Community 113 - "Community 113"
+Cohesion: 0.11
+Nodes (14): Run with file watching for auto-reload.          This method runs as the parent, find_env_file(), Find a .env file by traversing upward through parent directories.      Starts at, Tests for find_env_file() upward directory traversal., Test the find_env_file() utility function., Should find .env in a subdirectory within the project., Should find .env file in cwd., Should traverse upward to find .env in parent (no pyproject.toml boundary). (+6 more)
+
+### Community 114 - "Community 114"
+Cohesion: 0.12
+Nodes (18): HTTPSessionManager, HTTP Session Manager for MCP servers.  Manages HTTP streaming sessions with opti, Process ASGI request with proper session handling.          Args:             sc, Process request in stateless mode - new transport per request., Manages HTTP streaming sessions with optional resumability.      This class abst, Initialize HTTP session manager.          Args:             server: The MCP serv, run(), Test HTTPSessionManager initialization and lifecycle. (+10 more)
+
+### Community 115 - "Community 115"
+Cohesion: 0.14
+Nodes (7): OTELHandler, ShutdownError, handler_disabled(), test_get_meter(), test_init_with_enable_false(), test_init_with_enable_true(), test_shutdown()
+
+### Community 116 - "Community 116"
+Cohesion: 0.16
+Nodes (11): configure_client_toolkit(), configure_opencode_arcade(), get_opencode_config_path(), Configure an MCP client for Arcade toolkits.      When *transport* is ``"stdio"`, Get the OpenCode configuration file path (user-scope).      Honors ``XDG_CONFIG_, Configure OpenCode to connect to an Arcade Cloud MCP gateway.      Writes to the, _load_json(), _rich_opencode_config() (+3 more)
+
+### Community 117 - "Community 117"
+Cohesion: 0.11
+Nodes (15): The context for a tool invocation that requires authorization., The context for a tool secret., The context for a tool metadata., Add or update a secret to the tool context., ToolAuthorizationContext, ToolMetadataItem, ToolSecretItem, test_get_auth_token_or_empty_with_token() (+7 more)
+
+### Community 118 - "Community 118"
+Cohesion: 0.13
+Nodes (11): anon_id(), Identity management for PostHog analytics tracking.  Handles anonymous/authentic, Get distinct_id based on authentication state.          We use principal_id for, Fetch principal_id (account_id) from Arcade Cloud API.          Prefers any link, Check if PostHog alias is needed.          Alias is needed when the user is auth, Generate new anonymous ID and clear linked principal_id.          Used after log, Update linked_principal_id in usage.json.          Args:             principal_i, Manages user identity for PostHog analytics tracking. (+3 more)
+
+### Community 119 - "Community 119"
+Cohesion: 0.13
+Nodes (19): build_windows_hidden_startupinfo(), get_windows_no_window_creationflags(), graceful_terminate_process(), Shared Windows subprocess helpers used across Arcade libraries., Return Windows creation flags to suppress phantom console windows.      Args:, Create a Windows ``STARTUPINFO`` configured with ``SW_HIDE``.      Returns:, Terminate a process with Windows-friendly graceful fallback behavior.      On Wi, test_calls_terminate_on_linux() (+11 more)
+
+### Community 120 - "Community 120"
+Cohesion: 0.13
+Nodes (13): parse_output_paths(), Parse --output/-o paths into base path and format list.      Supports:     - Sin, Tests for parse_output_paths function., Test parsing single path with extension., Test parsing multiple paths with same base., Test that path without extension returns all formats., Test parsing path with directory., Test parsing path with spaces. (+5 more)
+
+### Community 121 - "Community 121"
+Cohesion: 0.17
+Nodes (20): configure_client(), Configure an MCP client to connect to a server.      Args:         client: The M, _assert_stdio_entry(), Tests for get_tool_secrets() and gateway configuration in arcade configure., Config files must be written with UTF-8 encoding, including non-ASCII paths., Write a config with Unicode, then overwrite and verify it still decodes., Should load secrets from .env file., Should return empty dict when no .env exists. (+12 more)
+
+### Community 122 - "Community 122"
+Cohesion: 0.1
+Nodes (14): make_comparative_results_with_context(), Create mock comparative results with context., Tests that grouping functions preserve context data., group_comparative_by_case should preserve system_message and additional_messages, group_comparative_by_case_first should preserve context., Tests for comparative formatters with context enabled., HTML comparative format should include context., Markdown comparative format should include context. (+6 more)
+
+### Community 123 - "Community 123"
+Cohesion: 0.12
+Nodes (14): Tests for shared utility functions in base.py., Should not truncate values within limit., Should truncate values exceeding limit., Should respect custom max_length., Should handle exactly at boundary., Should group results by model and suite., Should correctly separate multiple models., Should fall back to 'Unnamed Suite' when suite_name is missing. (+6 more)
+
+### Community 124 - "Community 124"
+Cohesion: 0.11
+Nodes (15): make_results_with_context(), Create mock results with system_message and additional_messages., Tests for HTML formatter include_context functionality., HTML output should include context section when include_context=True., HTML output should NOT include context when include_context=False., HTML should pretty-print JSON in tool responses., Tests for Markdown formatter include_context functionality., Markdown output should include context when include_context=True. (+7 more)
+
+### Community 125 - "Community 125"
+Cohesion: 0.12
+Nodes (15): make_multi_model_comparative_results(), Create mock results for multi-model comparative evaluation., Tests for multi-model comparative evaluation with case-first grouping., Should correctly detect multi-model comparative evaluation., Should group results by case first, then model., Markdown formatter should use case-first grouping for multi-model comparative., Text formatter should use case-first grouping for multi-model comparative., HTML formatter should use case-first grouping for multi-model comparative. (+7 more)
+
+### Community 126 - "Community 126"
+Cohesion: 0.12
+Nodes (14): Config, ensure_config_dir_exists(), get_config_dir_path(), get_config_file_path(), load_from_file(), Configuration for Arcade CLI., Check if the user is authenticated (has valid auth config)., Restrict a file so only the current user can read/write it on Windows.      On P (+6 more)
+
+### Community 127 - "Community 127"
+Cohesion: 0.14
+Nodes (21): _acquire_lock_with_timeout(), clear_tools_cache(), _ensure_mcp_path(), _get_cache_lock(), load_from_stdio_async(), load_mcp_remote_async(), load_stdio_arcade_async(), _make_cache_key() (+13 more)
+
+### Community 128 - "Community 128"
+Cohesion: 0.11
+Nodes (12): BaseWorker, FastAPIRouter, FastAPIWorker, Add a route to the FastAPI application., Mount an ASGI application at the specified path.          Args:             path, An Arcade Worker that is hosted inside a FastAPI app., Initialize the FastAPIWorker with a FastAPI app instance.         If no secret i, Register a component with the worker.          Args:             component_cls: (+4 more)
+
+### Community 129 - "Community 129"
+Cohesion: 0.13
+Nodes (20): create_gateway(), list_gateways(), List existing MCP gateways from the user's project.      Returns a list of gatew, Create a new MCP gateway on Arcade Cloud.      Args:         access_token: OAuth, Resolve a gateway name or slug to the actual slug.      The user may pass a name, _resolve_gateway_slug(), Tests for the arcade connect command., test_falls_back_to_input() (+12 more)
+
+### Community 130 - "Community 130"
+Cohesion: 0.12
+Nodes (21): _atomic_write_json(), _atomic_write_text(), _backup_path(), Return the ``.bak`` sibling used to back up ``path``.      We append ``.bak`` to, If ``path`` exists, copy its current contents to ``<path>.bak``.      Returns th, Write ``content`` to ``path`` atomically, preserving a ``.bak`` backup.      A c, Serialize ``data`` as JSON (indent=2) and atomically write to ``path``., _write_backup_if_exists() (+13 more)
+
+### Community 131 - "Community 131"
+Cohesion: 0.11
+Nodes (9): logout(), Logs the user out of Arcade., CLIError, Custom exception for CLI errors that preserves error messages for tracking., Focused cross-platform regression tests with minimal duplication.  This module k, Verify graceful handling for Windows-style file-locking scenarios., Verify UTF-8 behavior across file I/O paths that have regressed before., TestFileLockingErrorHandling (+1 more)
+
+### Community 132 - "Community 132"
+Cohesion: 0.1
+Nodes (11): OrderCommands, Return list of commands in the order appear., TyperGroup, Custom TyperGroup that creates tracked commands., Override command decorator to use TrackedTyperCommand., Return list of commands in the order appear., Custom Typer that creates tracked commands., Override command decorator to use TrackedTyperCommand. (+3 more)
+
+### Community 133 - "Community 133"
+Cohesion: 0.1
+Nodes (6): error_throwing_tool(), A sample tool for FastAPI tests., Test that ClientDisconnect during body read returns HTTP 499., This tool throws a ValueError., sample_tool_fastapi(), test_client_disconnect_returns_499()
+
+### Community 134 - "Community 134"
+Cohesion: 0.15
+Nodes (14): _configure_gateway(), fetch_available_toolkits(), _get_context_key(), Connect command — one-command toolkit + gateway setup for Arcade MCP., Fetch tools from the Arcade Engine and group them by toolkit name.      Results, Return a string identifying the active org+project (for cache scoping)., Return cached toolkit map if the cache file exists, is fresh, and matches the ac, Persist the toolkit map to disk, scoped to the active org/project. (+6 more)
+
+### Community 135 - "Community 135"
+Cohesion: 0.14
+Nodes (12): CapturedRun, CapturedToolCall, A captured tool call from the model during capture mode.      Attributes:, Convert to dictionary for JSON serialization., A single capture run for a case, containing tool calls.      Attributes:, When runs=[], to_dict should NOT include a 'runs' key., When runs has items, to_dict should include 'runs' key., to_dict with include_context=True should include system_message. (+4 more)
+
+### Community 136 - "Community 136"
+Cohesion: 0.14
+Nodes (10): Map Slack SlackApiError to appropriate ToolRuntimeError., Build developer message with additional details from Slack API error., Error adapter for Slack SDK (slack-sdk)., Safely extract a field from Slack API response., Handle SlackApiError and its subclasses., Handle non-API Slack SDK errors., Translate a Slack SDK exception into a ToolRuntimeError., Strip query params and fragments from URI for privacy. (+2 more)
+
+### Community 137 - "Community 137"
+Cohesion: 0.11
+Nodes (11): func_returns_pydantic_model(), func_takes_pydantic_field_default_factory(), ProductOutput, ProductOutputModel, Accepts a product name with a default value provided by a factory.      Paramete, # TODO: Function that takes a Pydantic model as an argument: break it down into, # TODO: Should title and default_value be added to JSON schema?, # TODO: Pydantic Field() properties stretch goal: gt, ge, lt, le, multiple_of, r (+3 more)
+
+### Community 138 - "Community 138"
+Cohesion: 0.16
+Nodes (19): _LoopbackHTTPServer, OAuthLoginError, OAuthLoginResult, OrgInfo, ProjectInfo, Organization info from Coordinator., Project info from Coordinator., Response from Coordinator /whoami endpoint. (+11 more)
+
+### Community 139 - "Community 139"
+Cohesion: 0.12
+Nodes (11): _EvalSuiteConvenienceMixin, EvalSuite convenience methods (internal-only).  This module contains only the fu, Add tools from an MCP HTTP server.          Args:             url: The MCP serve, Add tools from an MCP stdio server.          Args:             command: Command, Add tools from a ToolCatalog to the internal registry.          Args:, Get the number of registered tools.          Args:             track: Optional t, List all registered tool names.          Args:             track: Optional track, Mixin providing convenience tool registration methods. (+3 more)
+
+### Community 140 - "Community 140"
+Cohesion: 0.12
+Nodes (11): output_factory(), Test that dict and list types are properly handled by ToolOutputFactory., Test that BaseModel instances are converted to dict via model_dump()., Test that raw dict values (not wrapped in model) are handled correctly., Test that raw list values (not wrapped in model) are handled correctly., SampleOutputModel, test_success(), test_success_complex_types() (+3 more)
+
+### Community 141 - "Community 141"
+Cohesion: 0.15
+Nodes (16): _patch_win32_subprocess_flags(), Tests for Windows-specific subprocess flags and signal handling.  Verifies that:, Verify MCPApp._run_with_reload subprocess behavior at runtime., On Windows, _run_with_reload sends CTRL_BREAK_EVENT for graceful child shutdown., On Windows, shutdown falls back to terminate() if send_signal raises OSError., Verify stdio transport registers a stdlib signal.signal fallback on Windows., Verify start_server_process sets CREATE_NO_WINDOW | CREATE_NEW_PROCESS_GROUP on, _running_process() (+8 more)
+
+### Community 142 - "Community 142"
+Cohesion: 0.12
+Nodes (14): CustomUvicornServer, Uvicorn server with force quit support on double SIGINT/SIGTERM., Handle termination signals with force quit on second signal.          First sign, create_mcp_router(), get_openapi_routes(), MCPError, MCPRequest, MCPResponse (+6 more)
+
+### Community 143 - "Community 143"
+Cohesion: 0.14
+Nodes (15): Create and run the server directly without reload.          This is used when re, create_arcade_mcp(), create_arcade_mcp_factory(), create_lifespan(), Arcade MCP Server (Integrated Worker + MCP HTTP)  Creates a FastAPI application, Create a FastAPI app exposing MCP HTTP endpoints     and Arcade Worker endpoints, App factory for uvicorn reload support.      This function is called by uvicorn, Serve the FastAPI app with force quit capability. (+7 more)
+
+### Community 144 - "Community 144"
+Cohesion: 0.15
+Nodes (11): parse_api_key_spec(), Parse --api-key value into (provider, key).      Args:         spec: API key spe, Tests for parse_api_key_spec function., Test parsing OpenAI API key., Test parsing Anthropic API key., Test that whitespace is stripped., Test that provider name is case-insensitive., Test that missing colon raises ValueError. (+3 more)
+
+### Community 145 - "Community 145"
+Cohesion: 0.1
+Nodes (11): Test that display_name shows provider/model format., Test EvalTaskResult dataclass., Test creating a successful result., Test creating a failed result from an exception., Test that error_type captures the correct exception class name., Test that display_name shows provider/model format., Test CaptureTaskResult dataclass., Test creating a successful capture result. (+3 more)
+
+### Community 146 - "Community 146"
+Cohesion: 0.18
+Nodes (11): _background_check(), Entry point for the detached background process. Fetches PyPI, writes cache., Read the update cache from disk. Returns None if missing or corrupt., Write the update cache to disk., read_update_cache(), write_update_cache(), When fetch returns None, the cache timestamp is still updated to throttle retrie, When fetch fails but a previous version is cached, preserve it. (+3 more)
+
+### Community 147 - "Community 147"
+Cohesion: 0.14
+Nodes (12): configure_codex_arcade(), get_codex_config_path(), Get the Codex CLI (OpenAI) configuration file path., Configure Codex CLI to connect to an Arcade Cloud MCP gateway.      Writes a ``[, A realistic Codex config.toml with comments, top-level keys, other     server se, Every line from the original TOML (comments, other tables, other         mcp_ser, Replacing ``[mcp_servers.keep-me]`` must not disturb         ``[mcp_servers.also, Codex uses TOML; verify the same guarantees: preserves all unrelated     content (+4 more)
+
+### Community 148 - "Community 148"
+Cohesion: 0.15
+Nodes (11): Tests for get_capture_formatter function., Test getting JSON formatter., Test getting text formatter., Test getting markdown formatter., Test getting HTML formatter., Test that format names are case insensitive., Test that unsupported formats raise ValueError., Test that close matches are suggested. (+3 more)
+
+### Community 149 - "Community 149"
+Cohesion: 0.11
+Nodes (9): Test fallback handling for unhandled Microsoft Graph errors., Test that the adapter has the correct slug., Test handling non-Microsoft Graph errors returns None., Test URI sanitization removes query parameters., Test handling error without __module__ attribute., Test full integration with rate limit error., Test URI sanitization removes fragments., Test the Microsoft Graph error adapter functionality. (+1 more)
+
+### Community 150 - "Community 150"
+Cohesion: 0.11
+Nodes (12): Tests for MCP tool schema converters (OpenAI and Anthropic formats)., Tests for EvalSuiteToolRegistry OpenAI format output., Test listing tools in OpenAI format., Test OpenAI format without strict mode., Tests comparing OpenAI and Anthropic format outputs., Test that the same tool produces correct different formats., Test that invalid format raises ValueError., Tests for registry with multiple tools. (+4 more)
+
+### Community 152 - "Community 152"
+Cohesion: 0.14
+Nodes (11): AsyncOrgScopedTransport, build_org_scoped_async_http_client(), build_org_scoped_http_client(), OrgScopedTransport, Shared HTTP transport helpers for org-scoped Arcade API access., Return a request with its path rewritten to include org/project scope., Sync transport that rewrites requests to include org/project scope., Async transport that rewrites requests to include org/project scope. (+3 more)
+
+### Community 153 - "Community 153"
+Cohesion: 0.12
+Nodes (9): BaseWorker, Provide a health check that serves as a heartbeat of worker health., Register the necessary routes to the application., A base worker class that provides a default implementation for registering tools, Initialize the BaseWorker with an empty ToolCatalog.         If no secret is pro, Get the catalog as a list of ToolDefinitions., Register a tool to the catalog., Register a toolkit to the catalog. (+1 more)
+
+### Community 154 - "Community 154"
+Cohesion: 0.2
+Nodes (8): Run the quickstart flow: login → determine mode → configure client.      Everyth, run_connect(), _mock_list_gw(), --server github --tool Slack.SendMessage merges both., TestRunConnectAdvanced, TestRunConnectInteractive, TestRunConnectToolkit, TestRunConnectToolOnly
+
+### Community 155 - "Community 155"
+Cohesion: 0.12
+Nodes (7): identity(), Setup temporary config directory for testing., Create a UsageIdentity instance with temp config path., # NOTE: Although temp_config_path is directly used, it's required to ensure that, Tests for should_alias() method., temp_config_path(), TestShouldAlias
+
+### Community 156 - "Community 156"
+Cohesion: 0.15
+Nodes (10): test_www_authenticate_header_format(), ASGI middleware for MCP Resource Server authentication., Build the OAuth Protected Resource Metadata URL per RFC 9728.          For examp, Create a CORS preflight response for OPTIONS requests.          Returns:, Create RFC 6750 + RFC 9728 compliant 401 response.          The WWW-Authenticate, ASGI middleware that validates Bearer tokens on every HTTP request.      Validat, Initialize the Resource Server middleware.          Args:             app: ASGI, Process ASGI request with authentication.          For HTTP requests:         1. (+2 more)
+
+### Community 157 - "Community 157"
+Cohesion: 0.13
+Nodes (10): ResourceServerValidator, ResourceServerAuth implementation with OAuth discovery metadata support.  This m, Build RFC 9728 Protected Resource Metadata          Returns:             Diction, Create a mapping of authorization server URLs to their JWKSTokenValidator instan, Validate the given token against each configured authorization server., This Resource Server supports OAuth discovery., Return RFC 9728 Protected Resource Metadata.          This metadata tells MCP cl, OAuth 2.1 Resource Server with discovery metadata support.      This class imple (+2 more)
+
+### Community 158 - "Community 158"
+Cohesion: 0.18
+Nodes (11): _DummyStartupInfo, test_capture_non_windows_uses_start_new_session(), test_capture_noop_when_tracking_disabled(), test_capture_windows_falls_back_to_python_when_pythonw_missing(), test_capture_windows_prefers_pythonw_and_hides_window(), test_capture_windows_uses_base_prefix_pythonw_when_venv_pythonw_missing(), test_capture_windows_uses_pythonw_from_path_when_available(), Resolve the best interpreter for detached usage tracking. (+3 more)
+
+### Community 159 - "Community 159"
+Cohesion: 0.15
+Nodes (10): MockCommand, MockContext, Tests for get_full_command_path() method., Test get_full_command_path with a single command., Test get_full_command_path with nested commands., Test get_full_command_path with deeply nested commands., Test get_full_command_path with root command (no parent)., Mock Typer context for testing. (+2 more)
+
+### Community 160 - "Community 160"
+Cohesion: 0.17
+Nodes (10): Resolve API keys for all providers from flags and environment.      Priority: --, resolve_provider_api_keys(), Tests for resolve_provider_api_keys function., Test that --api-key takes precedence over environment variables., Test that environment variables are used when no explicit key., Test that None is returned when key not found anywhere., Test parsing multiple --api-key specs., Test that --api-key specs override environment variables. (+2 more)
+
+### Community 161 - "Community 161"
+Cohesion: 0.12
+Nodes (8): Test extracting error details from standard Microsoft Graph error structure., Test extracting error details with complete inner error structure., Create a mock APIError following Microsoft Graph error structure:         {, Test extracting error details when innerError field is missing., Test mapping 503 error with TooManyRequests code., Test mapping API error without url and error code attributes., Test parsing retry-after header with lowercase key., Test parsing retry-after header with absolute date format.
+
+### Community 162 - "Community 162"
+Cohesion: 0.12
+Nodes (8): Test mapping basic HTTP error., Test mapping HTTP error with structured error details., Test mapping HTTP error without uri and method attributes., Test URI sanitization removes fragments., Test URI sanitization handles trailing slashes., Test parsing retry-after header with seconds value., Test the Google error adapter functionality., TestGoogleErrorAdapter
+
+### Community 163 - "Community 163"
+Cohesion: 0.14
+Nodes (13): load_dotenv(), _parse_line(), Return (key, value) if the line looks like KEY=VALUE, else None.     Handles quo, Load variables from *path* into os.environ.      Args:         path: .env file p, main(), Arcade MCP Server Runner  Provides a unified interface for running MCP servers w, Main entry point for arcade_mcp_server module., from_env() (+5 more)
+
+### Community 164 - "Community 164"
+Cohesion: 0.14
+Nodes (8): Convert an ExpectedToolCall, ExpectedMCPToolCall, or tuple to a NamedExpectedToo, Convert an MCP tool reference to a NamedExpectedToolCall (NEW in this PR)., Add a new evaluation case to the suite.          Args:             name: The nam, Add NoneCritics for any fields in the expected tool calls that are not already i, Validate the critics.          Args:             critics: The list of critics., Fill in default arguments for a tool function.          Args:             func:, Extend the last added case with new information.          Args:             name, Process tool calls by resolving names and applying defaults.          Args:
+
+### Community 165 - "Community 165"
+Cohesion: 0.13
+Nodes (9): TyperCommand, Handle a successful login event.          Upon a successful login, we retrieve a, Handle a successful logout event.          Upon a successful logout, we rotate t, Track command execution event.          Args:             command_name: The name, Custom TyperCommand that tracks individual command execution., Override invoke to track command execution., Get the full command path by traversing the context hierarchy., Get org_id and project_id from config if available. (+1 more)
+
+### Community 166 - "Community 166"
+Cohesion: 0.13
+Nodes (14): empty_exception_tool(), fallback_with_secret_in_exception_tool(), keyerror_tool(), ``developer_message`` (server-side log only) is where verbose exception     cont, Empty exceptions (``raise Exception()``) get a ``(no exception message)``     ma, Tool that raises a bare KeyError, Tool that raises an exception with no message, Tool that raises an exception whose ``str()`` contains a fake secret.      Used (+6 more)
+
+### Community 167 - "Community 167"
+Cohesion: 0.18
+Nodes (9): detect_install_method(), Auto-detect how the user originally installed the CLI.      Detection order:, If `uv tool list` output contains the package name, method is UV_TOOL., If uv tool doesn't have it but pipx does, method is PIPX., If uv is available but package not in uv tool or pipx, use UV_PIP., If uv is on PATH but package is not in the current env, fall back to PIP., arcade-mcp-server should NOT be detected as arcade-mcp in uv tool list., If neither uv nor pipx is available, fall back to PIP. (+1 more)
+
+### Community 168 - "Community 168"
+Cohesion: 0.14
+Nodes (11): _capture_with_anthropic(), _capture_with_openai(), _normalize_messages(), Capture mode for EvalSuite.  Capture mode runs evaluation cases and records tool, Convert to dictionary for JSON serialization., Convert to dictionary for JSON serialization., Run capture mode with OpenAI client., Run capture mode with Anthropic client. (+3 more)
+
+### Community 169 - "Community 169"
+Cohesion: 0.13
+Nodes (14): Tests for arcade_core.errors.  Covers the empty-message guard in ``ToolkitError., ToolCallError (Pydantic wire-format model) classification helpers must     be co, NetworkTransportError and UpstreamError serve different semantic roles.      The, The class invariant — kind must be in the NETWORK_TRANSPORT_ namespace —     pro, test_network_transport_error_defaults(), test_network_transport_error_is_sibling_to_upstream_error(), test_network_transport_error_rejects_non_network_kind(), test_network_transport_error_to_payload_omits_status_code() (+6 more)
+
+### Community 171 - "Community 171"
+Cohesion: 0.14
+Nodes (14): configure(), connect(), deploy(), mcp(), Check for updates to the Arcade CLI and install if available., Alias for `arcade update`., Display the current logged-in user and active organization/project., Run Arcade MCP Server (passthrough to arcade_mcp_server).      This command prov (+6 more)
+
+### Community 172 - "Community 172"
+Cohesion: 0.17
+Nodes (12): _add_nested_properties(), _display_results_to_console(), display_tool_details(), display_tools_table(), _format_evaluation(), _format_type_string(), Display a table of tools with their name, description, package, and version., Recursively add nested properties to the output table.      Args:         table: (+4 more)
+
+### Community 173 - "Community 173"
+Cohesion: 0.13
+Nodes (14): create_note(), delete_note(), get_notes_stats(), Update an existing note's content., Permanently delete a note. This action cannot be undone., Get statistics about stored notes. Demonstrates the 'extras' field., Create or update a note. If the note exists, it will be updated., Reverse the characters in a string. A pure computation with no side effects. (+6 more)
+
+### Community 174 - "Community 174"
+Cohesion: 0.14
+Nodes (13): loguru_sink(), Integration tests for ``LoguruInterceptHandler``.  Exercises the full stdlib-log, ``record.getMessage()`` (which performs ``%`` interpolation of args)     must re, ``exc_info`` from ``logger.exception(...)`` must propagate so loguru     can ren, A custom numeric level not registered with loguru must still be     accepted (ha, Capture every loguru record into a list and tear down at end., The whole point of the handler: extras must survive the bridge., ``record.__dict__`` carries dozens of stdlib-internal attributes     (``levelnam (+5 more)
+
+### Community 175 - "Community 175"
+Cohesion: 0.18
+Nodes (8): LifespanManager, Run the lifespan context manager., Async context manager entry., Async context manager exit., Manages server lifecycle with proper resource management.      This class wraps, Initialize lifespan manager.          Args:             server: The server insta, Run startup phase of lifespan., Run shutdown phase of lifespan.
+
+### Community 177 - "Community 177"
+Cohesion: 0.14
+Nodes (7): Test the main HTTP error adapter., Test handling when httpx is not installed., Test handling requests HTTPError when request is not available but response.url, URLRequired (no URL provided) → FatalToolError., Unhandled requests base exceptions → NetworkTransportError (UNMAPPED)., LocalProtocolError = our HTTP framing was invalid (construction bug)., TestHTTPErrorAdapter
+
+### Community 178 - "Community 178"
+Cohesion: 0.14
+Nodes (8): Tests for track_command_execution() method., Test that track_command_execution does nothing when tracking is disabled., Test that login command triggers _handle_successful_login., Test that logout command triggers _handle_successful_logout., Test that non-login commands trigger lazy alias check., Test that duration is rounded to 2 decimal places., Test that duration is not included in properties when not provided., TestTrackCommandExecution
+
+### Community 179 - "Community 179"
+Cohesion: 0.15
+Nodes (6): # TODO: Use background thread instead of subprocess to capture server start even, Track MCP tool call event.          Args:             success: Whether the tool, Tracks MCP server events for usage analytics.      To opt out, set the ARCADE_US, Get the class name of the resource server validator.          Args:, Track MCP server start event.          Args:             transport: The transpor, ServerTracker
+
+### Community 180 - "Community 180"
+Cohesion: 0.19
+Nodes (9): configure_claude_code_arcade(), get_claude_code_config_path(), Get the Claude Code configuration file path.      Claude Code (the CLI / IDE ext, Configure Claude Code to connect to an Arcade Cloud MCP gateway.      Writes to, Config that mimics the real ~/.claude.json: many top-level keys,     projects ma, Running connect twice with different names keeps both entries., _rich_claude_config(), TestClaudeCodePreservesEverything (+1 more)
+
+### Community 181 - "Community 181"
+Cohesion: 0.14
+Nodes (8): Tests for load_or_create() method., Test that load_or_create creates a new usage.json file when it doesn't exist., Test that load_or_create loads existing usage.json file., Test that load_or_create caches data after first load., Test that load_or_create creates new data if JSON is corrupted., Test that load_or_create creates new data if anon_id is missing., Test that load_or_create creates new data if JSON is not a dict., TestLoadOrCreate
+
+### Community 182 - "Community 182"
+Cohesion: 0.14
+Nodes (7): Create a mock errors module with all necessary error classes., Test handling InvalidJsonError., Test handling UnknownApiNameOrVersion., Test handling UnacceptableMimeTypeError., Test handling InvalidChunkSizeError., Test full from_exception flow with HTTP error., Test full from_exception flow with other error types.
+
+### Community 183 - "Community 183"
+Cohesion: 0.14
+Nodes (8): Tests for _ensure_mcp_path utility function., Should append /mcp to URL without path., Should append /mcp to URL with existing path., Should not duplicate /mcp if already present., Should not add /mcp if 'mcp' is anywhere in path segments., Should preserve query string in URL., Should preserve fragment in URL., TestEnsureMcpPath
+
+### Community 184 - "Community 184"
+Cohesion: 0.14
+Nodes (8): Tests for tools caching functionality., Clear cache before each test., Clear cache after each test., Should clear the tools cache and locks., Should create different keys for different URLs., Should create different keys for different headers., Should create same key for same inputs., TestToolsCache
+
+### Community 185 - "Community 185"
+Cohesion: 0.19
+Nodes (9): _open_browser(), Open a URL in the default browser without flashing a CMD window on Windows., Tests for the _open_browser helper that suppresses CMD flash on Windows.      On, On non-Windows, _open_browser should use webbrowser.open., On Windows, _open_browser should try ctypes ShellExecuteW first., If ctypes fails, try rundll32 url.dll., If ctypes and rundll32 both fail, use webbrowser.open (step 3)., If all methods fail, _open_browser should return False. (+1 more)
+
+### Community 186 - "Community 186"
+Cohesion: 0.25
+Nodes (11): find_all_arcade_toolkits(), find_arcade_toolkits_from_entrypoints(), find_arcade_toolkits_from_prefix(), from_directory(), from_entrypoint(), from_module(), from_package(), get_package_directory() (+3 more)
+
+### Community 187 - "Community 187"
+Cohesion: 0.21
+Nodes (12): _apply_nullable(), _build_arcade_meta(), build_input_schema_from_definition(), _build_value_schema_json(), _map_type_to_json_schema_type(), Build the _meta.arcade structure from a tool definition.      The structure of _, Map Arcade value types to JSON schema types.      Args:         val_type: The Ar, Build a JSON schema object for tool inputs from a ToolDefinition.      Returns a (+4 more)
+
+### Community 188 - "Community 188"
+Cohesion: 0.22
+Nodes (7): fetch_latest_pypi_version(), Query PyPI for the latest stable version of the package.      Returns None only, When info.version is stable but yanked, fall back to scanning releases., When info.version is a pre-release, return the highest stable from releases., When all releases are pre-releases, return None., Yanked releases should not be returned even if they are the highest stable., TestFetchLatestPypiVersion
+
+### Community 189 - "Community 189"
+Cohesion: 0.19
+Nodes (8): fork_background_check(), Spawn a detached process that checks PyPI and writes the cache., The hardcoded import string in fork_background_check must resolve to the real fu, On Unix, spawns a detached subprocess with start_new_session=True., On Windows, spawns a subprocess with creationflags instead of start_new_session., When cache is fresh, no subprocess is spawned., Popen raising an exception should not crash., TestForkBackgroundCheck
+
+### Community 190 - "Community 190"
+Cohesion: 0.15
+Nodes (8): Resolve the API key for a given provider for evals.      Args:         provider:, resolve_provider_api_key(), test_compute_base_url(), test_resolve_provider_api_key(), Test that explicit key is returned regardless of env., Test OpenAI API key from environment., Test Anthropic API key from environment., Test that missing key returns None.
+
+### Community 191 - "Community 191"
+Cohesion: 0.18
+Nodes (11): ChatCommand, load_eval_suites(), parse_user_command(), Load evaluation suites from the given eval_files by importing the modules     an, Parse the user command and return the corresponding ChatCommand enum.     Return, AuthProviderType, SigningAlgorithm, TokenValidationResult (+3 more)
+
+### Community 192 - "Community 192"
+Cohesion: 0.17
+Nodes (7): BaseHTTPMiddleware, AddTrailingSlashToPathMiddleware, Middleware that adds trailing slashes to specific paths.      Example:     - /mc, Middleware that tracks active HTTP request tasks for force quit functionality., Track the current task while handling the request., Cancel all tracked (active) HTTP request tasks.          This method must be cal, TaskTrackerMiddleware
+
+### Community 193 - "Community 193"
+Cohesion: 0.18
+Nodes (8): convert_to_mcp_content(), Convert a Python value to MCP-compatible content., Test converting custom objects., Test handling circular references in objects., test_convert_json_roundtrip(), test_convert_primitives_and_bytes(), test_convert_to_mcp_content_complex(), test_convert_to_mcp_content_primitives()
+
+### Community 194 - "Community 194"
+Cohesion: 0.17
+Nodes (7): NotificationsContext, NotificationsPromptsContext, NotificationsResourcesContext, NotificationsToolsContext, ProgressContext, SamplingContext, Protocol
+
+### Community 195 - "Community 195"
+Cohesion: 0.2
+Nodes (9): Test is_tracking_enabled() with various environment variable values., Test is_tracking_enabled() returns True when environment variable is not set., Test is_tracking_enabled() returns True when environment variable is empty strin, test_is_tracking_enabled_default_when_empty_string(), test_is_tracking_enabled_default_when_not_set(), test_is_tracking_enabled_with_env_var(), Perform PostHog alias synchronously (blocking).          Must be called BEFORE t, is_tracking_enabled() (+1 more)
+
+### Community 196 - "Community 196"
+Cohesion: 0.17
+Nodes (8): Read stream implementation for stdio., Stop the read stream., StdioReadStream, Test StdioReadStream functionality., test_read_stream_iteration(), test_read_stream_none_stops_iteration(), test_read_stream_stop(), TestStdioReadStream
+
+### Community 197 - "Community 197"
+Cohesion: 0.18
+Nodes (6): connect_session(), Stdio Transport  Provides stdio (stdin/stdout) transport for MCP communication., Write stream implementation for stdio., StdioWriteStream, test_send_adds_newline(), test_send_preserves_existing_newline()
+
+### Community 198 - "Community 198"
+Cohesion: 0.21
+Nodes (7): configure_gemini_arcade(), get_gemini_config_path(), Get the Gemini CLI (Google) configuration file path (user-scope)., Configure Gemini CLI to connect to an Arcade Cloud MCP gateway.      Writes to `, _rich_gemini_config(), TestConfigureGeminiArcade, TestGeminiPreservesEverything
+
+### Community 199 - "Community 199"
+Cohesion: 0.23
+Nodes (6): _aggregate_critic_stats(), Fields with zero weight should still aggregate correctly., Fields missing from some runs should get 0.0 for those runs., Verify mean and std are consistent with run_scores., TestAggregateCriticStats, TestAggregateCriticStatsExtended
+
+### Community 200 - "Community 200"
+Cohesion: 0.17
+Nodes (9): Unit tests for MCP tool loaders (no network / no external processes)., Importing the module must not require the optional MCP SDK., Calling _require_mcp should raise a helpful ImportError if MCP isn't available., load_stdio_arcade_async should map auth into env vars and call load_from_stdio_a, Verify the default Arcade API base URL is set correctly., test_arcade_api_base_url_constant(), test_module_imports_without_mcp_installed(), test_require_mcp_raises_helpful_error_when_missing() (+1 more)
+
+### Community 201 - "Community 201"
+Cohesion: 0.18
+Nodes (7): GoogleErrorAdapter, Handle non-HTTP Google API errors., Error adapter for Google's API Python Client library., Translate a Google API client exception into a ToolRuntimeError., Strip query params and fragments from URI for privacy., Extract retry-after from Google API errors.         Returns milliseconds to wait, # TODO: Log?
+
+### Community 202 - "Community 202"
+Cohesion: 0.17
+Nodes (7): Tests for EvalSuiteToolRegistry error handling., Test that registering the same tool twice raises ValueError., Test that registering a tool without name raises ValueError., Test that empty registry has zero tools., Test that empty registry returns empty list for both formats., Test that invalid tool format raises ValueError., TestToolRegistryErrors
+
+### Community 203 - "Community 203"
+Cohesion: 0.18
+Nodes (10): Show the available tools or detailed information about a specific tool., show(), Wrapper function for the `arcade show` CLI command     Handles the logic for sho, show_logic(), display_chat_help(), handle_user_command(), Display the help message for arcade chat., Handle user commands during `arcade chat` and return True if a command was proce (+2 more)
+
+### Community 204 - "Community 204"
+Cohesion: 0.21
+Nodes (7): OAuthCallbackHandler, HTTP request handler for OAuth callback., Handle GET request (OAuth callback)., Start the callback server.          Binds to 127.0.0.1 (loopback only) rather th, Render a Jinja2 template and return as bytes., _render_template(), BaseHTTPRequestHandler
+
+### Community 205 - "Community 205"
+Cohesion: 0.17
+Nodes (7): Tests for the ExpectedMCPToolCall dataclass (MCP tools)., Test creating with keyword arguments., Test creating with positional arguments., Test that args defaults to empty dict., Test that tool_name is required (no default)., Test creating with just tool_name as positional., TestExpectedMCPToolCall
+
+### Community 206 - "Community 206"
+Cohesion: 0.18
+Nodes (8): isolate_environment(), Isolate environment variables for each test., Reset logging state before and after each test., Tests for logging configuration in create_arcade_mcp_factory.      These tests v, Verify factory filters DEBUG logs when ARCADE_MCP_DEBUG is not set., Verify factory allows DEBUG logs when ARCADE_MCP_DEBUG=true., reset_logging(), TestFactoryLoggingConfiguration
+
+### Community 207 - "Community 207"
+Cohesion: 0.22
+Nodes (9): intercept_standard_logging(), LoguruInterceptHandler, Shared logging utilities for MCP server., Configure logging with Loguru., Intercept standard logging and route to Loguru.      This handler bridges the st, Configure standard logging to route through Loguru.      This should be called a, setup_logging(), A real stdlib logger wired through LoguruInterceptHandler — no mocks. (+1 more)
+
+### Community 208 - "Community 208"
+Cohesion: 0.18
+Nodes (6): Tests for the `arcade update` CLI command., Running a non-update command triggers check_and_notify., Running `arcade update` should NOT trigger check_and_notify., Running `arcade upgrade` should NOT trigger check_and_notify., Running `arcade mcp` should NOT trigger check_and_notify (would corrupt stdio)., TestMainCallbackUpdateNotification
+
+### Community 209 - "Community 209"
+Cohesion: 0.18
+Nodes (3): Non-uv-tool methods should show a warning recommending uv tool install., The `arcade upgrade` alias should behave identically., TestUpdateCommand
+
+### Community 210 - "Community 210"
+Cohesion: 0.18
+Nodes (8): Ensures a function will run when decorated by @tool, Checks the behavior of @tool.deprecated when used before and after the @tool dec, Checks the behavior of @tool.deprecated when used with authentication.     The o, Ensures an async function will run when decorated by @tool, test_async_function(), test_sync_function(), test_tool_deprecated_ordering_no_auth(), test_tool_deprecated_ordering_with_auth()
+
+### Community 212 - "Community 212"
+Cohesion: 0.22
+Nodes (9): ApiConfig, Config, from_dict(), print_config(), Configuration utilities for the Arcade CLI., Arcade CLI configuration., Convert configuration to a dictionary.          Returns:             Configurati, Print the configuration in a formatted table.      Args:         config: Configu (+1 more)
+
+### Community 213 - "Community 213"
+Cohesion: 0.24
+Nodes (9): get_function_name_if_decorated(), get_tools_from_ast(), get_tools_from_file(), load_ast_tree(), Check if a function has a decorator., Retrieve tools from a Python file., Load and parse the Abstract Syntax Tree (AST) from a Python file., Retrieve tools from Python source code. (+1 more)
+
+### Community 214 - "Community 214"
+Cohesion: 0.18
+Nodes (6): Dropbox, Hubspot, Marks a tool as requiring Hubspot authorization., Marks a tool as requiring Zoom authorization., Marks a tool as requiring Dropbox authorization., Zoom
+
+### Community 215 - "Community 215"
+Cohesion: 0.2
+Nodes (6): Tests for _handle_successful_login() method., Test that login aliases anon_id to principal_id when should_alias is True., Test that login does not alias when should_alias is False., Test that login always sets linked_principal_id on success., Test that login does nothing when principal_id is None., TestHandleSuccessfulLogin
+
+### Community 216 - "Community 216"
+Cohesion: 0.2
+Nodes (9): Tests for Windows signal handling in stdio transport.  Verifies that: - The sign, On Windows, signal.signal(SIGINT, ...) should be called as a fallback., Windows SIGINT fallback should schedule stop() on the captured event loop., On Windows, don't log a user-facing signal-support message., On Windows, avoid warning noise when asyncio signal handlers are unavailable., test_signal_handler_no_failed_setup_warning_on_windows(), test_signal_handler_support_message_is_suppressed_on_windows(), test_signal_signal_fallback_registered_on_windows() (+1 more)
+
+### Community 217 - "Community 217"
+Cohesion: 0.2
+Nodes (6): Tests for CapturedToolCall dataclass., Test creating a captured tool call with name and args., Test creating a captured tool call with default empty args., Test to_dict serialization., Test to_dict with empty args., TestCapturedToolCall
+
+### Community 218 - "Community 218"
+Cohesion: 0.22
+Nodes (4): _EvalSuiteCaptureMixin, Capture mode mixin for EvalSuite.  This module provides the capture functionalit, Mixin providing capture mode functionality for EvalSuite., Run the evaluation suite in capture mode - records tool calls without scoring.
+
+### Community 219 - "Community 219"
+Cohesion: 0.33
+Nodes (3): Resolve a seed specification into a (policy, value) pair.      Args:         see, _resolve_seed_spec(), TestResolveSeedSpec
+
+### Community 220 - "Community 220"
+Cohesion: 0.2
+Nodes (6): Test that normalized name lookup works when only dot version exists., Test that Anthropic format output uses normalized names (underscores)., Tests for handling tool name collisions during normalization., Test that tools with different original names but same normalized name are both, Test that when both Google.Search and Google_Search exist,         resolving 'Go, TestToolNameCollisions
+
+### Community 221 - "Community 221"
+Cohesion: 0.2
+Nodes (6): Tests for EvalSuiteToolRegistry Anthropic format output., Test listing tools in Anthropic format., Test that Anthropic format preserves JSON Schema keywords., Test that Anthropic format doesn't add null union types., Test that Anthropic format normalizes tool names (dots to underscores)., TestToolRegistryAnthropicFormat
+
+### Community 222 - "Community 222"
+Cohesion: 0.2
+Nodes (6): Test FuzzyWeight enum values., Test FuzzyWeight enum has correct base values (linear scale 1-7)., Test FuzzyWeight values are properly ordered., Test FuzzyWeight values have uniform increment of 1., Test that FuzzyWeight is a proper enum., TestFuzzyWeightEnum
+
+### Community 223 - "Community 223"
+Cohesion: 0.2
+Nodes (9): _async_request_hook(), _async_response_hook(), list_emails(), Gmail MCP server with SEP-2448 MCP server execution telemetry.  Vendor-side refe, List recent emails from the user's Gmail inbox., Send an email via the user's Gmail account., Capture request method + URL with gen_ai semantic conventions., Capture response status with gen_ai semantic conventions. (+1 more)
+
+### Community 224 - "Community 224"
+Cohesion: 0.31
+Nodes (5): Escape a string for a TOML basic string literal., Insert or replace a ``[mcp_servers.<name>]`` section in Codex's ``config.toml``., _toml_str(), _upsert_codex_mcp_server(), TestUpsertCodexMcpServer
+
+### Community 225 - "Community 225"
+Cohesion: 0.25
+Nodes (7): _configure_mcpservers_arcade(), configure_windsurf_arcade(), get_windsurf_config_path(), Get the Windsurf (Codeium) configuration file path., Shared helper for clients that use the ``mcpServers`` JSON key.      Used by Cla, Configure Windsurf to connect to an Arcade Cloud MCP gateway.      Windsurf's do, TestConfigureWindsurfArcade
+
+### Community 226 - "Community 226"
+Cohesion: 0.25
+Nodes (4): Resolve a tool name to its original registry key.          Handles both original, Apply schema defaults to arguments.          Fills in default values from the to, Public method to resolve a tool name to its original registry key.          This, Resolve tool name and apply schema defaults in one step.          This combines
+
+### Community 227 - "Community 227"
+Cohesion: 0.22
+Nodes (8): Test manager imports., Test basic imports from arcade_mcp_server., Test middleware imports., Test transport imports., test_basic_imports(), test_manager_imports(), test_middleware_imports(), test_transport_imports()
+
+### Community 228 - "Community 228"
+Cohesion: 0.22
+Nodes (6): ClickUp, Microsoft, Marks a tool as requiring Microsoft authorization., Marks a tool as requiring Reddit authorization., Marks a tool as requiring ClickUp authorization., Reddit
+
+### Community 230 - "Community 230"
+Cohesion: 0.25
+Nodes (7): isolate_environment(), pytest_collection_modifyitems(), pytest_configure(), Global test configuration for all tests.  This conftest.py is at the root of the, Register custom markers., Auto-skip evals tests if dependencies not available.      Tests are detected as, Isolate environment variables for each test.      This fixture captures the enti
+
+### Community 231 - "Community 231"
+Cohesion: 0.39
+Nodes (3): find_matching_gateway(), Find an existing gateway whose allow-list is a superset of *tool_allow_list*, TestFindMatchingGateway
+
+### Community 232 - "Community 232"
+Cohesion: 0.39
+Nodes (3): get_toolkit_examples(), Return example prompts for the given toolkit names., TestGetToolkitExamples
+
+### Community 233 - "Community 233"
+Cohesion: 0.43
+Nodes (4): Determine whether a background PyPI check is needed., should_check_for_update(), UpdateCache, TestShouldCheckForUpdate
+
+### Community 234 - "Community 234"
+Cohesion: 0.39
+Nodes (3): check_and_notify(), Read cache, print notification if update available, fork background check., TestCheckAndNotify
+
+### Community 235 - "Community 235"
+Cohesion: 0.25
+Nodes (5): Tests for reset_to_anonymous() method., Test that reset_to_anonymous generates a new anon_id., Test that reset_to_anonymous clears linked_principal_id., Test that reset_to_anonymous persists changes to file., TestResetToAnonymous
+
+### Community 236 - "Community 236"
+Cohesion: 0.25
+Nodes (5): Tests for set_linked_principal_id() method., Test that set_linked_principal_id updates the linked_principal_id., Test that set_linked_principal_id persists changes to file., Test that set_linked_principal_id updates the cached data., TestSetLinkedPrincipalId
+
+### Community 237 - "Community 237"
+Cohesion: 0.25
+Nodes (5): Tests for EvalSuiteToolRegistry.process_tool_call combined method., Test that process_tool_call resolves name and applies defaults., Test that unknown tools keep original name., Test when all args provided., TestProcessToolCall
+
+### Community 238 - "Community 238"
+Cohesion: 0.25
+Nodes (5): Tests for OpenAI format tool name normalization., Test that OpenAI format normalizes tool names (dots to underscores).          Op, Test that multiple dots are all converted to underscores for OpenAI., Test that underscores in tool names are preserved for OpenAI., TestToolRegistryOpenAINameNormalization
+
+### Community 239 - "Community 239"
+Cohesion: 0.25
+Nodes (5): Tests for MCP SDK logging filter., Should suppress 'Session termination failed: 202' messages., Should allow other log messages through., Should allow real error messages through., TestMCPLoggingFilter
+
+### Community 240 - "Community 240"
+Cohesion: 0.25
+Nodes (5): Tests for _build_arcade_mcp_url utility function., Should build correct URL with gateway slug., Should build correct URL without gateway slug., Should strip trailing slash from base URL., TestBuildArcadeMcpUrl
+
+### Community 241 - "Community 241"
+Cohesion: 0.25
+Nodes (7): _build_arcade_mcp_url(), _get_arcade_base_url(), load_arcade_mcp_gateway_async(), Get the Arcade API base URL, checking env var at runtime., Build the Arcade MCP gateway URL., Load tools from an Arcade MCP gateway.      Args:         gateway_slug: Optional, Add tools from an Arcade MCP gateway.          Args:             gateway_slug: T
+
+### Community 242 - "Community 242"
+Cohesion: 0.32
+Nodes (7): get_api_key_as_hash_value(), get_password_as_hash_value(), get_secret_as_hash_value(), hash_text(), Get the hash value of the password, Get the hash value of the API key, Get the hash value of a secret
+
+### Community 244 - "Community 244"
+Cohesion: 0.43
+Nodes (3): prompt_toolkit_selection(), Interactively prompt the user to select toolkits.      Returns a list of selecte, TestPromptToolkitSelection
+
+### Community 245 - "Community 245"
+Cohesion: 0.29
+Nodes (6): Test that the dashboard command constructs the correct URL with various args., Test fallback message when _open_browser fails., Test successful health check., test_dashboard_url_construction(), test_fallback_when_browser_fails(), test_health_check_success()
+
+### Community 246 - "Community 246"
+Cohesion: 0.33
+Nodes (5): _patch_win32_ctrl_break(), Verify graceful_terminate_process uses CTRL_BREAK_EVENT on Windows., On Windows, graceful_terminate_process should send CTRL_BREAK_EVENT., If send_signal fails on Windows, fall back to terminate., TestGracefulTerminate
+
+### Community 247 - "Community 247"
+Cohesion: 0.43
+Nodes (3): get_toolkit_http_config(), Build an HTTP/SSE config entry pointing at a local ``arcade mcp http`` server., TestGetToolkitHttpConfig
+
+### Community 248 - "Community 248"
+Cohesion: 0.29
+Nodes (6): get_posts_in_subreddit(), greet(), Greet a person by name., Reveal the last 4 characters of a secret, Get posts from a specific subreddit, whisper_secret()
+
+### Community 249 - "Community 249"
+Cohesion: 0.29
+Nodes (6): get_posts_in_subreddit(), greet(), Greet a person by name., Reveal the last 4 characters of a secret, Get posts from a specific subreddit, whisper_secret()
+
+### Community 250 - "Community 250"
+Cohesion: 0.29
+Nodes (6): get_posts_in_subreddit(), greet(), Greet a person by name., Reveal the last 4 characters of a secret, Get posts from a specific subreddit, whisper_secret()
+
+### Community 251 - "Community 251"
+Cohesion: 0.33
+Nodes (5): MCPToolDefinition, _MCPToolDefinitionRequired, EvalSuite internal unified tool registry (not part of the public API)., Required fields for MCP-style tool definition., MCP-style tool definition structure.      This is the format expected by `add_to
+
+### Community 252 - "Community 252"
+Cohesion: 0.29
+Nodes (5): Google, Marks a tool as requiring Google authorization., ResourceServerAuth, ArcadeResourceServerAuth, ResourceServerAuth that uses the ``email`` claim as user_id.      Arcade's tool
+
+### Community 253 - "Community 253"
+Cohesion: 0.29
+Nodes (6): get_posts_in_subreddit(), greet(), Greet a person by name., Reveal the last 4 characters of a secret, Get posts from a specific subreddit, whisper_secret()
+
+### Community 254 - "Community 254"
+Cohesion: 0.29
+Nodes (6): get_posts_in_subreddit(), greet(), Greet a person by name., Reveal the last 4 characters of a secret, Get posts from a specific subreddit, whisper_secret()
+
+### Community 255 - "Community 255"
+Cohesion: 0.33
+Nodes (5): compose_lifespans(), default_lifespan(), Lifespan management for MCP server.  Provides a clean interface for managing ser, Compose multiple lifespan functions into one.      Each lifespan's context is me, Default lifespan that does basic startup/shutdown logging.
+
+### Community 257 - "Community 257"
+Cohesion: 0.33
+Nodes (4): Tests for get_principal_id() method., Test that get_principal_id returns None when credentials file doesn't exist., Test that get_principal_id returns None when API key is missing., TestGetPrincipalId
+
+### Community 258 - "Community 258"
+Cohesion: 0.33
+Nodes (4): Tests for anon_id property., Test that anon_id property returns the anon_id., Test that anon_id property returns a valid UUID., TestAnonIdProperty
+
+### Community 259 - "Community 259"
+Cohesion: 0.33
+Nodes (4): Tests for _write_atomic() method., Test that _write_atomic writes data to usage.json., Test that _write_atomic cleans up temp file on failure., TestWriteAtomic
+
+### Community 261 - "Community 261"
+Cohesion: 0.33
+Nodes (4): Tests for _tool_to_dict utility function., Should convert MCP Tool object to dictionary., Should handle None description., TestToolToDict
+
+### Community 262 - "Community 262"
+Cohesion: 0.33
+Nodes (4): Tests for load_from_http function., Clear cache before each test., Clear cache after each test., TestLoadFromHttp
+
+### Community 263 - "Community 263"
+Cohesion: 0.33
+Nodes (4): Tests for load_arcade_mcp_gateway function., Clear cache before each test., Clear cache after each test., TestLoadArcadeMcpGateway
+
+### Community 264 - "Community 264"
+Cohesion: 0.33
+Nodes (4): Tests for load_from_stdio function., Clear cache before each test., Clear cache after each test., TestLoadFromStdio
+
+### Community 265 - "Community 265"
+Cohesion: 0.33
+Nodes (4): Tests for multiple authorization server support., Test parsing JSON array of AS configs from env var., Test that resource metadata returns all AS URLs., TestMultipleAuthorizationServers
+
+### Community 266 - "Community 266"
+Cohesion: 0.33
+Nodes (4): Tests for JWKSTokenValidator with Ed25519 algorithm., Test that Ed25519 is in supported algorithms., Test that EdDSA is in supported algorithms., TestJWKSTokenValidatorEd25519
+
+### Community 267 - "Community 267"
+Cohesion: 0.33
+Nodes (4): Base class for MCP Resource Server token validation.      An MCP server acts as, Whether this validator supports OAuth discovery endpoints.          Returns True, Return OAuth Protected Resource Metadata (RFC 9728) if supported.          Retur, ResourceServerValidator
+
+### Community 268 - "Community 268"
+Cohesion: 0.4
+Nodes (3): Case, generate_tool_function(), test_create_tool_def2()
+
+### Community 270 - "Community 270"
+Cohesion: 0.33
+Nodes (5): main(), Entry point for detached usage tracking subprocess.  This module is invoked as `, Force exit after timeout, Capture a PostHog event from environment variable., _timeout_exit()
+
+### Community 271 - "Community 271"
+Cohesion: 0.33
+Nodes (5): _configure_mcp_logging(), MCPSessionFilter, Filter to suppress/rewrite misleading MCP SDK session termination messages., Return False to suppress log record, True to allow it., Configure MCP SDK logging to suppress misleading messages.
+
+### Community 272 - "Community 272"
+Cohesion: 0.33
+Nodes (4): Tests for default model selection per provider., Test that DEFAULT_MODELS has entries for all providers., Test that all default models are non-empty strings., TestDefaultModels
+
+### Community 274 - "Community 274"
+Cohesion: 0.4
+Nodes (3): ErrorAdapter, Plugin that translates vendor-specific exceptions / responses into     the appro, Translate an exception raised by an SDK, HTTP client, etc.         into a `ToolR
+
+### Community 275 - "Community 275"
+Cohesion: 0.8
+Nodes (4): _get_requirement(), _load_pyproject(), test_root_dependency_includes_workspace_arcade_core_version(), test_root_dependency_includes_workspace_arcade_mcp_server_version()
+
+### Community 277 - "Community 277"
+Cohesion: 0.4
+Nodes (4): InstallMethod, Logic for the `arcade update` / `arcade upgrade` CLI command., Check for updates and install if available., run_update()
+
+### Community 278 - "Community 278"
+Cohesion: 0.4
+Nodes (4): A tool that takes time to execute (async)., A tool that takes time to execute (sync)., slow_async_tool(), slow_sync_tool()
+
+### Community 279 - "Community 279"
+Cohesion: 0.4
+Nodes (4): call_other_tool(), Get the hash value of a secret, A tool that is called by a tool, the_other_tool()
+
+### Community 280 - "Community 280"
+Cohesion: 0.4
+Nodes (4): create_email_subject(), Generate an email subject line based on the email content.      Useful when you, Create a marketing description for a product.      The description should emphas, write_product_description()
+
+### Community 281 - "Community 281"
+Cohesion: 0.4
+Nodes (4): calculate_time_until_event(), get_meeting_reminder(), Calculate the reminder time for a meeting.      Useful when you need to schedule, Calculate the time remaining until an event.      Provides a time difference cal
+
+### Community 282 - "Community 282"
+Cohesion: 0.5
+Nodes (3): disable_usage_tracking(), Test configuration for installation tests.  Mirrors the autouse fixtures in libs, Disable CLI usage tracking for all installation tests.      Prevents test runs f
+
+### Community 283 - "Community 283"
+Cohesion: 0.5
+Nodes (3): Test that MCP routes appear in OpenAPI documentation., Test that MCP routes appear in FastAPI OpenAPI documentation., test_mcp_routes_in_openapi()
+
+### Community 284 - "Community 284"
+Cohesion: 0.5
+Nodes (3): Tests for get_distinct_id() method., Test that get_distinct_id returns persisted linked_principal_id., TestGetDistinctId
+
+### Community 285 - "Community 285"
+Cohesion: 0.5
+Nodes (3): Tests for _capture_with_openai and _capture_with_anthropic helpers., Test that _capture_with_anthropic helper function exists and is callable., TestCaptureHelperFunctions
+
+### Community 286 - "Community 286"
+Cohesion: 0.5
+Nodes (3): Tests for lazy MCP import behavior., Should raise helpful ImportError when MCP SDK is not installed., TestLazyImport
+
+### Community 287 - "Community 287"
+Cohesion: 0.5
+Nodes (3): Tests for Arcade AS configuration., Test OAuth metadata for Arcade AS configuration., TestArcadeASConfiguration
+
+### Community 289 - "Community 289"
+Cohesion: 0.83
+Nodes (3): main(), _repo_root(), _tracked_files()
+
+### Community 290 - "Community 290"
+Cohesion: 0.67
+Nodes (4): Behavior, Classification, Tool Metadata Example README, ServiceDomain
+
+### Community 325 - "Community 325"
+Cohesion: 0.67
+Nodes (3): Resources MCP App HTML, Resources_GetArticle Tool, Resources_SearchArticles Tool
+
+## Knowledge Gaps
+- **3720 isolated node(s):** `Test configuration for installation tests.  Mirrors the autouse fixtures in libs`, `Disable CLI usage tracking for all installation tests.      Prevents test runs f`, `Installation tests for arcade-mcp.`, `Organizes and runs installation tests for arcade-mcp.`, `Initialize test runner with project root.` (+3715 more)
+  These have ≤1 connection - possible missing edges or undocumented components.
+- **656 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
+
+## Suggested Questions
+_Questions this graph is uniquely positioned to answer:_
+
+- **Why does `ToolCatalog` connect `Community 5` to `Community 0`, `Community 1`, `Community 2`, `Community 4`, `Community 7`, `Community 8`, `Community 265`, `Community 266`, `Community 137`, `Community 268`, `Community 142`, `Community 19`, `Community 20`, `Community 153`, `Community 25`, `Community 283`, `Community 28`, `Community 287`, `Community 32`, `Community 34`, `Community 35`, `Community 39`, `Community 47`, `Community 53`, `Community 54`, `Community 57`, `Community 79`, `Community 83`, `Community 100`, `Community 102`, `Community 108`?**
+  _High betweenness centrality (0.114) - this node is a cross-community bridge._
+- **Why does `EvalSuite` connect `Community 0` to `Community 135`, `Community 15`, `Community 272`, `Community 17`, `Community 18`, `Community 27`, `Community 29`, `Community 30`, `Community 33`, `Community 164`, `Community 38`, `Community 168`, `Community 40`, `Community 52`, `Community 57`, `Community 63`, `Community 205`, `Community 80`, `Community 87`, `Community 98`?**
+  _High betweenness centrality (0.105) - this node is a cross-community bridge._
+- **Why does `path()` connect `Community 67` to `Community 130`, `Community 141`, `Community 23`, `Community 158`, `Community 32`, `Community 289`, `Community 163`, `Community 41`, `Community 43`, `Community 45`, `Community 186`, `Community 59`, `Community 65`, `Community 73`, `Community 87`, `Community 88`, `Community 106`, `Community 107`, `Community 116`, `Community 120`, `Community 126`?**
+  _High betweenness centrality (0.080) - this node is a cross-community bridge._
+- **Are the 140 inferred relationships involving `EvalSuite` (e.g. with `.test_add_single_tool()` and `.test_method_chaining()`) actually correct?**
+  _`EvalSuite` has 140 INFERRED edges - model-reasoned connections that need verification._
+- **Are the 113 inferred relationships involving `ToolCatalog` (e.g. with `CustomUvicornServer` and `MCPServer`) actually correct?**
+  _`ToolCatalog` has 113 INFERRED edges - model-reasoned connections that need verification._
+- **Are the 90 inferred relationships involving `MCPServer` (e.g. with `CustomUvicornServer` and `create_lifespan()`) actually correct?**
+  _`MCPServer` has 90 INFERRED edges - model-reasoned connections that need verification._
+- **Are the 115 inferred relationships involving `ResourceOwner` (e.g. with `MCPServer` and `InitializationState`) actually correct?**
+  _`ResourceOwner` has 115 INFERRED edges - model-reasoned connections that need verification._


### PR DESCRIPTION
## What & Why

[Graphify](https://github.com/jsr/graphify) is a tool that builds a navigable knowledge graph of a codebase by combining tree-sitter AST extraction with LLM-driven semantic linking, then clusters the result into communities so we can browse "god nodes" (highly-connected hubs) and surprising cross-module connections. This PR adds a tuned `.graphifyignore`, gitignores the heavy regeneratable artefacts, and commits the first `GRAPH_REPORT.md` so the team can browse the graph in Obsidian (or any markdown wiki-link viewer) without re-running extraction.

## Headline graph stats

- **8,840 nodes**
- **15,627 edges** (64% extracted from AST, 36% LLM-inferred at avg confidence 0.66)
- **989 communities** (333 shown in the report, 656 thin ones omitted)
- Built from commit `7995334e`

## Token spend

Extraction cost (Claude backend): **~$0.21** (22,402 input / 9,475 output tokens).

## HTML viz

The interactive `graph.html` visualisation was **skipped** because the graph has 8,840 nodes, exceeding graphify's default 5,000-node HTML limit. To generate one anyway, raise the limit (`GRAPHIFY_VIZ_NODE_LIMIT=10000`) or pass `--no-viz` is the inverse — to enable, simply rerun cluster-only with the env var set. The full graph is still browsable through `GRAPH_REPORT.md` and the gitignored `graph.json`.

## What's committed vs gitignored

Committed:

- `.graphifyignore` — tuned to keep extraction focused on source + design docs
- `.gitignore` — adds rules for the regeneratable graphify outputs
- `graphify-out/GRAPH_REPORT.md` — human-readable report with community hubs

Gitignored (regeneratable, too large for git):

- `graphify-out/graph.json` (~9 MB)
- `graphify-out/manifest.json`
- `graphify-out/.graphify_analysis.json`
- `graphify-out/cache/`
- `graphify-out/cost.json`

## Regenerate locally

```bash
source ~/.graphify-key.env  # ANTHROPIC_API_KEY
PYTHONUNBUFFERED=1 GRAPHIFY_MAX_TOKENS=16000 \
    graphify extract . --backend claude
graphify cluster-only .
```

After the first extract, incremental updates are free (no API cost):

```bash
graphify update .
```

Made with [Cursor](https://cursor.com)