### PR TITLE
fix(arcade-tdk): remove unused type ignore for requests import

### DIFF
--- a/libs/arcade-tdk/arcade_tdk/providers/http/error_adapter.py
+++ b/libs/arcade-tdk/arcade_tdk/providers/http/error_adapter.py
@@ -433,7 +433,7 @@ class _RequestsExceptionHandler:
         """
         # Lazy import requests types locally to avoid import errors for toolkits that don't use requests
         try:
-            from requests.exceptions import (  # type: ignore[import-untyped]
+            from requests.exceptions import (
                 ConnectionError,
                 ContentDecodingError,
                 HTTPError,


### PR DESCRIPTION
## Summary
- The post-merge `Main / quality` workflow on commit 6703ec5b failed with `arcade_tdk/providers/http/error_adapter.py:436: error: Unused "type: ignore" comment [unused-ignore]`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit e8ebb66d0334b70316cde6c50e1eb60cd5458686. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->