### PR TITLE
chore(arcade-mcp-server): promote 1.22.0rc1 to 1.22.0

### DIFF
--- a/libs/arcade-mcp-server/pyproject.toml
+++ b/libs/arcade-mcp-server/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "arcade-mcp-server"
-version = "1.22.0rc1"
+version = "1.22.0"
 description = "Model Context Protocol (MCP) server framework for Arcade.dev"
 readme = "README.md"
 authors = [{ name = "Arcade.dev" }]


### PR DESCRIPTION
## Summary

- Removes the `rc1` pre-release suffix from `arcade-mcp-server` version, promoting it to the stable `1.22.0` release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a metadata-only version bump with no runtime or dependency changes.
> 
> **Overview**
> Promotes `arcade-mcp-server` to the stable `1.22.0` release by removing the `rc1` suffix in `libs/arcade-mcp-server/pyproject.toml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa604407efe02a8c029bd388332e54d6c3bd8a56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->