### PR TITLE
feat(arcade-core): lazy materialization + precomputed catalog manifest

### DIFF
--- a/libs/arcade-core/arcade_core/catalog.py
+++ b/libs/arcade-core/arcade_core/catalog.py
@@ -227,7 +227,8 @@ class MaterializedTool:
     def tool(self) -> Callable:
         """Resolve the underlying callable, importing the toolkit if needed."""
         if self._tool is None:
-            assert self._tool_factory is not None
+            if self._tool_factory is None:
+                raise RuntimeError("MaterializedTool has no callable or tool factory.")
             self._tool = self._tool_factory()
             self._tool_factory = None
         return self._tool

--- a/libs/arcade-core/arcade_core/catalog.py
+++ b/libs/arcade-core/arcade_core/catalog.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
 from importlib import import_module
+from pathlib import Path
 from types import ModuleType
 from typing import (
     Annotated,
@@ -91,6 +92,51 @@ def is_typeddict(tp: type) -> bool:
         return False
 
 
+def _validate_tool_eagerly(tool: Callable) -> None:
+    """Run cheap validation that doesn't require signature inspection.
+
+    These checks mirror the ones in ``create_tool_definition`` /
+    ``create_secrets_requirement`` / ``create_metadata_requirement`` but skip
+    parameter inspection. Catching them at registration time preserves the
+    existing developer experience for the most common mistakes without
+    forcing the full lazy definition to be built upfront.
+    """
+    raw_tool_name = getattr(tool, "__tool_name__", tool.__name__)
+
+    tool_description = getattr(tool, "__tool_description__", None)
+    if not tool_description:
+        raise ToolDefinitionError(
+            f"Tool '{raw_tool_name}' is missing a description. Tool descriptions are specified as docstrings for the tool function."
+        )
+
+    if does_function_return_value(tool) and tool.__annotations__.get("return") is None:
+        raise ToolOutputSchemaError(f"Tool '{raw_tool_name}' must have a return type")
+
+    # Eagerly construct (and discard) the cheap requirement objects so that
+    # malformed secrets/metadata declarations are detected at registration.
+    auth_requirement = create_auth_requirement(tool)
+    create_secrets_requirement(tool)
+    create_metadata_requirement(tool, auth_requirement)
+
+
+def compute_fully_qualified_name(
+    tool: Callable, toolkit_name: str, toolkit_version: str | None = None
+) -> FullyQualifiedName:
+    """Compute a tool's FullyQualifiedName without building its full definition.
+
+    Mirrors the FQN derivation inside ``ToolCatalog.create_tool_definition`` but
+    avoids signature inspection, wire-type traversal, and Pydantic model
+    construction.
+    """
+    raw_tool_name = getattr(tool, "__tool_name__", tool.__name__)
+    tool_name = snake_to_pascal_case(raw_tool_name)
+    toolkit_definition = ToolkitDefinition(
+        name=snake_to_pascal_case(space_to_snake_case(toolkit_name)),
+        version=toolkit_version,
+    )
+    return FullyQualifiedName.from_toolkit(tool_name, toolkit_definition)
+
+
 @dataclass
 class WireTypeInfo:
     """
@@ -121,18 +167,110 @@ class ToolMeta(BaseModel):
     date_updated: datetime = Field(default_factory=datetime.now)
 
 
-class MaterializedTool(BaseModel):
-    """
-    Data structure that holds tool information while stored in the Catalog
+class MaterializedTool:
+    """Tool information stored in the Catalog.
+
+    Supports two layers of lazy work:
+
+    1. ``definition`` / ``input_model`` / ``output_model`` are materialized
+       lazily from a ``factory`` callable on first access, deferring the
+       expensive Pydantic-model + ``ToolDefinition`` construction.
+    2. ``tool`` (the callable itself) can also be lazy: when a manifest is
+       loaded from disk, the toolkit's Python module hasn't been imported
+       yet. Pass ``tool_factory`` instead of ``tool`` and the import is
+       deferred until execution time (or until ``input_model`` /
+       ``output_model`` is needed, which requires the signature).
     """
 
-    tool: Callable
-    definition: ToolDefinition
-    meta: ToolMeta
+    __slots__ = (
+        "_definition",
+        "_factory",
+        "_input_model",
+        "_output_model",
+        "_tool",
+        "_tool_factory",
+        "meta",
+    )
 
-    # Thought (Sam): Should generate create these from ToolDefinition?
-    input_model: type[BaseModel]
-    output_model: type[BaseModel]
+    def __init__(
+        self,
+        *,
+        meta: ToolMeta,
+        tool: Callable | None = None,
+        tool_factory: Callable[[], Callable] | None = None,
+        definition: ToolDefinition | None = None,
+        input_model: type[BaseModel] | None = None,
+        output_model: type[BaseModel] | None = None,
+        factory: Callable[
+            [Callable], tuple[ToolDefinition, type[BaseModel], type[BaseModel]]
+        ]
+        | None = None,
+    ) -> None:
+        if tool is None and tool_factory is None:
+            raise ValueError("MaterializedTool requires either tool or tool_factory.")
+        self._tool = tool
+        self._tool_factory = tool_factory
+        self.meta = meta
+        self._definition = definition
+        self._input_model = input_model
+        self._output_model = output_model
+        self._factory = factory
+        if (
+            definition is None or input_model is None or output_model is None
+        ) and factory is None:
+            raise ValueError(
+                "MaterializedTool requires either eager (definition, input_model, "
+                "output_model) or a lazy factory."
+            )
+
+    @property
+    def tool(self) -> Callable:
+        """Resolve the underlying callable, importing the toolkit if needed."""
+        if self._tool is None:
+            assert self._tool_factory is not None
+            self._tool = self._tool_factory()
+            self._tool_factory = None
+        return self._tool
+
+    @property
+    def is_tool_resolved(self) -> bool:
+        """True when the callable is in memory (no import required)."""
+        return self._tool is not None
+
+    def _materialize(self) -> None:
+        if self._factory is None:
+            return
+        defn, in_m, out_m = self._factory(self.tool)
+        # Don't clobber a pre-built definition (manifest case): the factory
+        # may have rebuilt it from the just-imported function, but the
+        # manifest copy is the source of truth at runtime.
+        if self._definition is None:
+            self._definition = defn
+        self._input_model = in_m
+        self._output_model = out_m
+        self._factory = None  # release closure once materialized
+
+    @property
+    def definition(self) -> ToolDefinition:
+        if self._definition is None:
+            self._materialize()
+        return cast(ToolDefinition, self._definition)
+
+    @property
+    def input_model(self) -> type[BaseModel]:
+        if self._input_model is None:
+            self._materialize()
+        return cast("type[BaseModel]", self._input_model)
+
+    @property
+    def output_model(self) -> type[BaseModel]:
+        if self._output_model is None:
+            self._materialize()
+        return cast("type[BaseModel]", self._output_model)
+
+    @property
+    def is_materialized(self) -> bool:
+        return self._factory is None
 
     @property
     def name(self) -> str:
@@ -149,6 +287,36 @@ class MaterializedTool(BaseModel):
     @property
     def requires_auth(self) -> bool:
         return self.definition.requirements.authorization is not None
+
+    def requires_secrets_keys(self) -> list[str]:
+        """Return declared secret keys without forcing tool import or definition materialization.
+
+        Prefers a pre-built ``_definition`` (manifest-loaded tools) since that
+        avoids importing the toolkit just to read decorator attributes. Falls
+        back to ``__tool_requires_secrets__`` set by the ``@tool`` decorator
+        when the function is already in memory.
+        """
+        # Manifest-loaded tools have the definition pre-built; reading from
+        # it avoids forcing a toolkit import for the startup secrets check.
+        if self._definition is not None:
+            secrets = self._definition.requirements.secrets or []
+            from_def = [s.key for s in secrets if s.key]
+            if from_def:
+                return from_def
+
+        # Tool already in memory (discovery path) — read decorator attrs.
+        if self._tool is None:
+            return []
+
+        raw = getattr(self._tool, "__tool_requires_secrets__", None) or []
+        seen: dict[str, str] = {}
+        for k in raw:
+            if not isinstance(k, str):
+                continue
+            lowered = k.lower()
+            if lowered not in seen:
+                seen[lowered] = k
+        return list(seen.values())
 
 
 class ToolCatalog(BaseModel):
@@ -214,6 +382,11 @@ class ToolCatalog(BaseModel):
         """
         Add a function to the catalog as a tool.
 
+        The expensive Pydantic model and ``ToolDefinition`` construction is
+        deferred to the first attribute access on the resulting
+        ``MaterializedTool``. Only the fully-qualified name is computed
+        eagerly, so catalog lookup and iteration remain cheap.
+
         Args:
             tool_func: The function to add to the catalog.
             toolkit_or_name: The toolkit or name of the toolkit.
@@ -221,9 +394,6 @@ class ToolCatalog(BaseModel):
             toolkit_version: The version of the toolkit. Overrides the version of the toolkit if provided.
             toolkit_description: The description of the toolkit. Overrides the description of the toolkit if provided.
         """
-
-        input_model, output_model = create_func_models(tool_func)
-
         if isinstance(toolkit_or_name, Toolkit):
             toolkit = toolkit_or_name
             toolkit_name = toolkit.name
@@ -236,18 +406,18 @@ class ToolCatalog(BaseModel):
         if not toolkit_name:
             raise ValueError("A server name or server must be provided.")
 
-        definition = ToolCatalog.create_tool_definition(
-            tool_func,
-            toolkit_name,
-            toolkit_version,
-            toolkit_description,
-        )
+        # Cheap eager validation — catch easy-to-detect mistakes at registration
+        # time so toolkit authors get fast feedback. The expensive signature
+        # inspection happens lazily on first ``definition`` access.
+        _validate_tool_eagerly(tool_func)
 
-        fully_qualified_name = definition.get_fully_qualified_name()
+        fully_qualified_name = compute_fully_qualified_name(
+            tool_func, toolkit_name, toolkit_version
+        )
 
         if fully_qualified_name in self._tools:
             raise ToolkitLoadError(
-                f"Tool '{definition.name}' in server '{toolkit_name}' already exists in the catalog."
+                f"Tool '{fully_qualified_name.name}' in server '{toolkit_name}' already exists in the catalog."
             )
 
         if str(fully_qualified_name).lower() in self._disabled_tools:
@@ -258,8 +428,25 @@ class ToolCatalog(BaseModel):
             logger.info(f"Server '{toolkit_name!s}' is disabled and will not be cataloged.")
             return
 
+        # Capture by value, not reference, so closures stay correct across loops.
+        _tk_name = toolkit_name
+        _tk_version = toolkit_version
+        _tk_description = toolkit_description
+
+        def _factory(
+            func: Callable,
+        ) -> tuple[ToolDefinition, type[BaseModel], type[BaseModel]]:
+            # Match the original eager order: build Pydantic models first so
+            # unsupported output types raise ToolOutputSchemaError (as opposed
+            # to the ToolDefinitionError that ``create_tool_definition`` would
+            # surface from the wire-type path).
+            input_model, output_model = create_func_models(func)
+            definition = ToolCatalog.create_tool_definition(
+                func, _tk_name, _tk_version, _tk_description
+            )
+            return definition, input_model, output_model
+
         self._tools[fully_qualified_name] = MaterializedTool(
-            definition=definition,
             tool=tool_func,
             meta=ToolMeta(
                 module=module.__name__ if module else tool_func.__module__,
@@ -267,8 +454,7 @@ class ToolCatalog(BaseModel):
                 package=toolkit.package_name if toolkit else None,
                 path=module.__file__ if module else None,
             ),
-            input_model=input_model,
-            output_model=output_model,
+            factory=_factory,
         )
 
     def add_module(
@@ -341,6 +527,94 @@ class ToolCatalog(BaseModel):
                         f"Error encountered while adding tool {tool_name} from {module_name}. Reason: {e}"
                     ).with_context(tool_name)
 
+    @classmethod
+    def from_manifest(cls, path: str | Path) -> "ToolCatalog":
+        """Build a catalog from a precomputed manifest, deferring toolkit imports.
+
+        Each entry's ``ToolDefinition`` is loaded eagerly (so ``/worker/tools``
+        and ``tools/list`` are O(JSON parse)), but the underlying Python
+        function and its Pydantic input/output models stay un-resolved until
+        the first ``tools/call`` for that tool. ``ARCADE_DISABLED_TOOLS`` and
+        ``ARCADE_DISABLED_TOOLKITS`` are honored at load time so deployments
+        can override the manifest without rebuilding.
+        """
+        # Local imports to break the catalog→manifest import cycle.
+        from arcade_core.manifest import (
+            check_manifest_staleness,
+            load_manifest,
+            make_tool_factory,
+        )
+
+        manifest = load_manifest(path)
+        warnings_ = check_manifest_staleness(manifest)
+        for warn in warnings_:
+            logger.warning(f"Catalog manifest staleness: {warn}")
+
+        catalog = cls()
+
+        for entry in manifest.entries:
+            fqn = FullyQualifiedName.from_toolkit(
+                entry.definition.name,
+                entry.definition.toolkit,
+            )
+            if str(fqn).lower() in catalog._disabled_tools:
+                logger.info(f"Tool '{fqn!s}' is disabled and will not be loaded from manifest.")
+                continue
+            if entry.toolkit_name.lower() in catalog._disabled_toolkits:
+                logger.info(
+                    f"Server '{entry.toolkit_name}' is disabled and will not be loaded from manifest."
+                )
+                continue
+            if fqn in catalog._tools:
+                raise ToolkitLoadError(
+                    f"Tool '{fqn.name}' in server '{entry.toolkit_name}' "
+                    f"appears multiple times in the manifest."
+                )
+
+            tool_factory = make_tool_factory(entry.module_name, entry.function_name)
+
+            # Restore the context-parameter name dropped during serialization
+            # (ToolInput.tool_context_parameter_name is exclude=True). Without
+            # this, ToolExecutor.run silently skips Context injection for every
+            # manifest-loaded tool, see executor.py:55-56.
+            definition = entry.definition
+            if (
+                entry.tool_context_parameter_name is not None
+                and definition.input.tool_context_parameter_name is None
+            ):
+                definition = definition.model_copy(
+                    update={
+                        "input": definition.input.model_copy(
+                            update={
+                                "tool_context_parameter_name": entry.tool_context_parameter_name
+                            }
+                        )
+                    }
+                )
+
+            # ``_factory`` builds input/output Pydantic models on first access.
+            # The definition is already pinned from the manifest, so the
+            # tuple's definition entry is unused (see ``MaterializedTool._materialize``).
+            def _models_factory(
+                func: Callable,
+                _defn: ToolDefinition = definition,
+            ) -> tuple[ToolDefinition, type[BaseModel], type[BaseModel]]:
+                input_model, output_model = create_func_models(func)
+                return _defn, input_model, output_model
+
+            catalog._tools[fqn] = MaterializedTool(
+                meta=ToolMeta(
+                    module=entry.module_name,
+                    toolkit=entry.toolkit_name,
+                    package=entry.package_name,
+                ),
+                tool_factory=tool_factory,
+                definition=definition,
+                factory=_models_factory,
+            )
+
+        return catalog
+
     def __getitem__(self, name: FullyQualifiedName) -> MaterializedTool:
         return self.get_tool(name)
 
@@ -357,7 +631,17 @@ class ToolCatalog(BaseModel):
         return len(self._tools) == 0
 
     def get_tool_names(self) -> list[FullyQualifiedName]:
-        return [tool.definition.get_fully_qualified_name() for tool in self._tools.values()]
+        # Use the dict keys directly — they are already FullyQualifiedName instances
+        # computed at insertion time, so no tool definition needs to be materialized.
+        return list(self._tools.keys())
+
+    def items(self) -> Iterator[tuple[FullyQualifiedName, MaterializedTool]]:
+        """Iterate over (fully_qualified_name, materialized_tool) pairs.
+
+        Yields the FQN dict key first so callers can route tools without
+        triggering lazy materialization of the underlying ``ToolDefinition``.
+        """
+        yield from self._tools.items()
 
     def find_tool_by_func(self, func: Callable) -> ToolDefinition:
         """

--- a/libs/arcade-core/arcade_core/catalog.py
+++ b/libs/arcade-core/arcade_core/catalog.py
@@ -201,9 +201,7 @@ class MaterializedTool:
         definition: ToolDefinition | None = None,
         input_model: type[BaseModel] | None = None,
         output_model: type[BaseModel] | None = None,
-        factory: Callable[
-            [Callable], tuple[ToolDefinition, type[BaseModel], type[BaseModel]]
-        ]
+        factory: Callable[[Callable], tuple[ToolDefinition, type[BaseModel], type[BaseModel]]]
         | None = None,
     ) -> None:
         if tool is None and tool_factory is None:
@@ -215,9 +213,7 @@ class MaterializedTool:
         self._input_model = input_model
         self._output_model = output_model
         self._factory = factory
-        if (
-            definition is None or input_model is None or output_model is None
-        ) and factory is None:
+        if (definition is None or input_model is None or output_model is None) and factory is None:
             raise ValueError(
                 "MaterializedTool requires either eager (definition, input_model, "
                 "output_model) or a lazy factory."

--- a/libs/arcade-core/arcade_core/manifest.py
+++ b/libs/arcade-core/arcade_core/manifest.py
@@ -11,8 +11,10 @@ from __future__ import annotations
 import importlib.metadata
 import json
 import logging
+from collections.abc import Callable
 from importlib import import_module
 from pathlib import Path
+from typing import cast
 
 from pydantic import BaseModel, Field
 
@@ -161,9 +163,7 @@ def check_manifest_staleness(manifest: CatalogManifest) -> list[str]:
             )
             continue
         if current != pkg.version:
-            warnings.append(
-                f"manifest pinned {pkg.name}=={pkg.version} but {current} is installed"
-            )
+            warnings.append(f"manifest pinned {pkg.name}=={pkg.version} but {current} is installed")
     return warnings
 
 
@@ -175,7 +175,7 @@ class ManifestToolResolutionError(RuntimeError):
     """
 
 
-def make_tool_factory(module_name: str, function_name: str):
+def make_tool_factory(module_name: str, function_name: str) -> Callable[[], Callable[..., object]]:
     """Return a zero-arg callable that imports the module and returns the function.
 
     Used by ``ToolCatalog.from_manifest`` to defer toolkit imports until
@@ -185,7 +185,7 @@ def make_tool_factory(module_name: str, function_name: str):
     "manifest stale" from "the tool function itself raised at import".
     """
 
-    def _resolve() -> object:
+    def _resolve() -> Callable[..., object]:
         try:
             module = import_module(module_name)
         except ImportError as exc:
@@ -196,7 +196,7 @@ def make_tool_factory(module_name: str, function_name: str):
                 f"python -m arcade_mcp_server build-manifest."
             ) from exc
         try:
-            return getattr(module, function_name)
+            return cast("Callable[..., object]", getattr(module, function_name))
         except AttributeError as exc:
             raise ManifestToolResolutionError(
                 f"Manifest references function '{function_name}' in module "

--- a/libs/arcade-core/arcade_core/manifest.py
+++ b/libs/arcade-core/arcade_core/manifest.py
@@ -1,0 +1,209 @@
+"""Precomputed catalog manifest.
+
+Allows a built worker image to skip toolkit discovery and tool-schema
+materialization at startup by reading a pre-built JSON file produced
+at image-build time. The runtime catalog still imports toolkit modules
+lazily on first ``tools/call`` for each toolkit.
+"""
+
+from __future__ import annotations
+
+import importlib.metadata
+import json
+import logging
+from importlib import import_module
+from pathlib import Path
+
+from pydantic import BaseModel, Field
+
+from arcade_core.schema import ToolDefinition
+
+logger = logging.getLogger(__name__)
+
+MANIFEST_SCHEMA_VERSION = "1"
+
+
+class PackageVersion(BaseModel):
+    """Package name + version pinned at manifest-build time."""
+
+    name: str
+    version: str
+
+
+class ManifestEntry(BaseModel):
+    """One tool's persisted record.
+
+    The Python function name (``function_name``) is stored separately from
+    ``definition.name``: the former is the raw identifier used to
+    ``getattr(module, function_name)`` at execution time, while the latter
+    is the PascalCase name surfaced to clients.
+
+    ``tool_context_parameter_name`` mirrors
+    ``ToolDefinition.input.tool_context_parameter_name`` because that field
+    is ``exclude=True`` in pydantic and would otherwise be dropped on
+    serialization, leaving ``ToolExecutor`` unable to inject the
+    ``Context`` argument at call time.
+    """
+
+    module_name: str
+    function_name: str
+    toolkit_name: str
+    toolkit_version: str | None = None
+    toolkit_description: str | None = None
+    package_name: str | None = None
+    tool_context_parameter_name: str | None = None
+    definition: ToolDefinition
+
+
+class CatalogManifest(BaseModel):
+    """A precomputed tool catalog, durable across processes."""
+
+    schema_version: str = MANIFEST_SCHEMA_VERSION
+    package_versions: list[PackageVersion] = Field(default_factory=list)
+    entries: list[ManifestEntry] = Field(default_factory=list)
+
+
+def build_manifest(catalog: object) -> CatalogManifest:
+    """Walk a ToolCatalog and produce a serializable manifest.
+
+    Imported lazily to avoid a circular import between ``catalog`` and
+    ``manifest`` at module load time.
+    """
+    from arcade_core.catalog import ToolCatalog  # local to break import cycle
+
+    if not isinstance(catalog, ToolCatalog):
+        raise TypeError(f"Expected ToolCatalog, got {type(catalog).__name__}")
+
+    entries: list[ManifestEntry] = []
+    packages: dict[str, str] = {}
+
+    for materialized_tool in catalog:
+        meta = materialized_tool.meta
+        definition = materialized_tool.definition
+        function_name = getattr(materialized_tool.tool, "__name__", definition.name)
+
+        entries.append(
+            ManifestEntry(
+                module_name=meta.module,
+                function_name=function_name,
+                toolkit_name=definition.toolkit.name,
+                toolkit_version=definition.toolkit.version,
+                toolkit_description=definition.toolkit.description,
+                package_name=meta.package,
+                tool_context_parameter_name=definition.input.tool_context_parameter_name,
+                definition=definition,
+            )
+        )
+
+        if meta.package and meta.package not in packages:
+            try:
+                packages[meta.package] = importlib.metadata.version(meta.package)
+            except importlib.metadata.PackageNotFoundError:
+                continue
+
+    return CatalogManifest(
+        package_versions=[PackageVersion(name=n, version=v) for n, v in sorted(packages.items())],
+        entries=entries,
+    )
+
+
+def write_manifest(catalog: object, path: str | Path) -> Path:
+    """Build a manifest for ``catalog`` and write it to ``path``.
+
+    Returns the resolved output path. The parent directory must exist.
+    """
+    out = Path(path)
+    manifest = build_manifest(catalog)
+    out.write_text(manifest.model_dump_json(indent=2))
+    return out
+
+
+class IncompatibleManifestError(ValueError):
+    """Raised when a manifest's ``schema_version`` does not match this runtime."""
+
+
+def load_manifest(path: str | Path) -> CatalogManifest:
+    """Load a manifest from disk and validate it.
+
+    Raises:
+        IncompatibleManifestError: if the on-disk ``schema_version`` doesn't
+            match :data:`MANIFEST_SCHEMA_VERSION`. Older manifests can lack
+            fields the runtime depends on (e.g. ``tool_context_parameter_name``
+            was added between versions), so silent acceptance would produce
+            tools that pass ``/worker/tools`` but fail on first call.
+    """
+    raw = Path(path).read_text()
+    data = json.loads(raw)
+    on_disk_version = data.get("schema_version")
+    if on_disk_version != MANIFEST_SCHEMA_VERSION:
+        raise IncompatibleManifestError(
+            f"Catalog manifest at {path} has schema_version={on_disk_version!r} "
+            f"but this runtime expects {MANIFEST_SCHEMA_VERSION!r}. "
+            f"Rebuild with: python -m arcade_mcp_server build-manifest --output {path}"
+        )
+    return CatalogManifest.model_validate(data)
+
+
+def check_manifest_staleness(manifest: CatalogManifest) -> list[str]:
+    """Compare the manifest's pinned package versions against the live install.
+
+    Returns a list of human-readable warning strings (one per mismatch).
+    Caller decides whether to log, fail, or ignore. An empty list means
+    every recorded package matches what is currently importable.
+    """
+    warnings: list[str] = []
+    for pkg in manifest.package_versions:
+        try:
+            current = importlib.metadata.version(pkg.name)
+        except importlib.metadata.PackageNotFoundError:
+            warnings.append(
+                f"manifest references {pkg.name}=={pkg.version} but the package is not installed"
+            )
+            continue
+        if current != pkg.version:
+            warnings.append(
+                f"manifest pinned {pkg.name}=={pkg.version} but {current} is installed"
+            )
+    return warnings
+
+
+class ManifestToolResolutionError(RuntimeError):
+    """Raised when a manifest-declared tool cannot be resolved from its module.
+
+    Indicates a stale manifest: the toolkit was uninstalled, renamed, or had
+    the function removed between manifest build and runtime.
+    """
+
+
+def make_tool_factory(module_name: str, function_name: str):
+    """Return a zero-arg callable that imports the module and returns the function.
+
+    Used by ``ToolCatalog.from_manifest`` to defer toolkit imports until
+    the first ``tools/call`` for that toolkit. Captures by value so the
+    closure is safe across loop iterations. Surfaces import/attribute
+    errors as ``ManifestToolResolutionError`` so the caller can distinguish
+    "manifest stale" from "the tool function itself raised at import".
+    """
+
+    def _resolve() -> object:
+        try:
+            module = import_module(module_name)
+        except ImportError as exc:
+            raise ManifestToolResolutionError(
+                f"Manifest references module '{module_name}' (function "
+                f"'{function_name}') but the module cannot be imported. "
+                f"Reason: {exc}. The manifest is likely stale — rebuild with "
+                f"python -m arcade_mcp_server build-manifest."
+            ) from exc
+        try:
+            return getattr(module, function_name)
+        except AttributeError as exc:
+            raise ManifestToolResolutionError(
+                f"Manifest references function '{function_name}' in module "
+                f"'{module_name}' but the attribute does not exist. "
+                f"The manifest is likely stale — rebuild with "
+                f"python -m arcade_mcp_server build-manifest."
+            ) from exc
+
+    _resolve.__qualname__ = f"manifest_resolver[{module_name}.{function_name}]"
+    return _resolve

--- a/libs/arcade-mcp-server/arcade_mcp_server/__main__.py
+++ b/libs/arcade-mcp-server/arcade_mcp_server/__main__.py
@@ -31,9 +31,79 @@ from arcade_mcp_server.logging_utils import setup_logging
 from arcade_mcp_server.stdio_runner import initialize_tool_catalog, run_stdio_server
 
 
+def _build_manifest_command(argv: list[str]) -> int:
+    """Discover installed toolkits and write a precomputed catalog manifest.
+
+    Run at Docker image build time to skip toolkit discovery + Pydantic
+    model construction on every container start.
+    """
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        prog="python -m arcade_mcp_server build-manifest",
+        description="Build a precomputed tool catalog manifest from installed toolkits.",
+    )
+    parser.add_argument(
+        "--output",
+        "-o",
+        required=True,
+        help="Path where the manifest JSON should be written.",
+    )
+    parser.add_argument(
+        "--tool-package",
+        "-p",
+        dest="tool_package",
+        help="Build for a single installed package instead of all of them.",
+    )
+    parser.add_argument(
+        "--discover-installed",
+        "--all",
+        action="store_true",
+        default=True,
+        help="Include every installed arcade-* toolkit (default).",
+    )
+    parser.add_argument(
+        "--show-packages",
+        action="store_true",
+        help="Log loaded packages during discovery.",
+    )
+    args = parser.parse_args(argv)
+
+    # Set up logging before any toolkit imports
+    setup_logging(level="INFO", stdio_mode=False)
+
+    from arcade_core.discovery import discover_tools
+    from arcade_core.manifest import write_manifest
+
+    catalog = discover_tools(
+        tool_package=args.tool_package,
+        show_packages=args.show_packages,
+        discover_installed=args.discover_installed,
+    )
+    if len(catalog) == 0:
+        logger.error("No tools discovered. Manifest would be empty.")
+        return 1
+
+    # Force materialization of every tool definition so the manifest
+    # captures the full ToolDefinition for each one.
+    for tool in catalog:
+        _ = tool.definition
+
+    out = Path(args.output).expanduser().resolve()
+    out.parent.mkdir(parents=True, exist_ok=True)
+    written = write_manifest(catalog, out)
+    logger.info(f"Wrote manifest with {len(catalog)} tools to {written}")
+    return 0
+
+
 def main() -> None:
     """Main entry point for arcade_mcp_server module."""
     import argparse
+
+    # Subcommand dispatch: handle build-manifest before the main parser so it
+    # doesn't collide with the legacy transport positional.
+    if len(sys.argv) >= 2 and sys.argv[1] == "build-manifest":
+        sys.exit(_build_manifest_command(sys.argv[2:]))
 
     parser = argparse.ArgumentParser(
         description="Run Arcade MCP Server",

--- a/libs/arcade-mcp-server/arcade_mcp_server/convert.py
+++ b/libs/arcade-mcp-server/arcade_mcp_server/convert.py
@@ -63,8 +63,15 @@ def create_mcp_tool(materialized_tool: MaterializedTool) -> MCPTool:
             # (it wraps non-object types in a result property internally)
             output_schema = _build_value_schema_json(output_def.value_schema)
 
-    # Build MCP tool annotations from metadata behavior fields
-    title = getattr(materialized_tool.tool, "__tool_name__", definition.name)
+    # Build MCP tool annotations from metadata behavior fields.
+    # Prefer the resolved callable's __tool_name__ only when the toolkit is
+    # already imported — manifest-loaded tools defer the import to the first
+    # invocation, and the definition's PascalCase name is equivalent for all
+    # toolkits that don't override it via @tool(name=...).
+    if materialized_tool.is_tool_resolved:
+        title = getattr(materialized_tool.tool, "__tool_name__", definition.name)
+    else:
+        title = definition.name
     tool_metadata = definition.metadata
     if tool_metadata and tool_metadata.behavior:
         behavior = tool_metadata.behavior

--- a/libs/arcade-mcp-server/arcade_mcp_server/convert.py
+++ b/libs/arcade-mcp-server/arcade_mcp_server/convert.py
@@ -191,7 +191,9 @@ def build_input_schema_from_definition(definition: ToolDefinition) -> dict[str, 
     if getattr(definition, "input", None) and getattr(definition.input, "parameters", None):
         for param in definition.input.parameters:
             val_schema = getattr(param, "value_schema", None)
-            schema = _value_schema_to_json_schema(val_schema) if val_schema else {"type": "string"}
+            schema: dict[str, Any] = (
+                _value_schema_to_json_schema(val_schema) if val_schema else {"type": "string"}
+            )
 
             if getattr(param, "description", None):
                 schema["description"] = param.description

--- a/libs/arcade-mcp-server/arcade_mcp_server/managers/tool.py
+++ b/libs/arcade-mcp-server/arcade_mcp_server/managers/tool.py
@@ -19,7 +19,7 @@ from arcade_mcp_server.types import MCPTool
 logger = logging.getLogger("arcade.mcp.managers.tool")
 
 
-class ManagedTool(TypedDict):
+class ManagedTool(TypedDict, total=False):
     dto: MCPTool
     materialized: MaterializedTool
 
@@ -47,16 +47,26 @@ class ToolManager(ComponentManager[Key, ManagedTool]):
         return create_mcp_tool(materialized_tool)
 
     async def load_from_catalog(self, catalog: ToolCatalog) -> None:
+        # Load only the FQN + materialized handle here. The MCPTool DTO is
+        # built lazily on first access (in ``list_tools`` and ``get_tool``)
+        # to keep server startup cheap when the catalog has many tools.
         pairs: list[tuple[Key, ManagedTool]] = []
-        for t in catalog:
-            fq = t.definition.fully_qualified_name
-            pairs.append((fq, {"dto": self._to_dto(t), "materialized": t}))
+        for fq_name, t in catalog.items():
+            fq = str(fq_name)
+            pairs.append((fq, {"materialized": t}))
             self._sanitized_to_key[self._sanitize_name(fq)] = fq
         await self.registry.bulk_load(pairs)
 
+    def _ensure_dto(self, rec: ManagedTool) -> MCPTool:
+        dto = rec.get("dto")
+        if dto is None:
+            dto = self._to_dto(rec["materialized"])
+            rec["dto"] = dto
+        return dto
+
     async def list_tools(self) -> list[MCPTool]:
         records = await self.registry.list()
-        return [r["dto"] for r in records]
+        return [self._ensure_dto(r) for r in records]
 
     async def get_tool(self, name: str) -> MaterializedTool:
         # Try exact key first (dotted FQN)
@@ -108,7 +118,7 @@ class ToolManager(ComponentManager[Key, ManagedTool]):
             except KeyError:
                 logger.warning(f"Tool meta extension for '{fqn}' skipped: tool not found")
                 continue
-            dto = rec["dto"]
+            dto = self._ensure_dto(rec)
             if dto.meta is None:
                 dto.meta = {}
             dto.meta.update(extra_meta)

--- a/libs/arcade-mcp-server/arcade_mcp_server/server.py
+++ b/libs/arcade-mcp-server/arcade_mcp_server/server.py
@@ -835,22 +835,32 @@ class MCPServer:
         # Get all available secrets from settings and environment
         available_secrets = set(self.settings.tool_secrets().keys()) | set(os.environ.keys())
 
-        # Check each tool for missing secrets
+        # Check each tool for missing secrets. Use the cheap accessor so
+        # lazily-loaded tools don't trigger full definition materialization
+        # during startup. For tools that already have an eagerly-built
+        # definition (e.g. test fixtures), prefer its ``name`` to preserve
+        # the warning format.
         managed_tools = await self._tool_manager.registry.list()
         for managed_tool in managed_tools:
             tool = managed_tool["materialized"]
-            if tool.definition.requirements and tool.definition.requirements.secrets:
-                missing_secrets = []
-                for secret_requirement in tool.definition.requirements.secrets:
-                    if secret_requirement.key not in available_secrets:
-                        missing_secrets.append(secret_requirement.key)
-
-                if missing_secrets:
-                    secret_list = "', '".join(missing_secrets)
+            declared = tool.requires_secrets_keys()
+            if not declared:
+                continue
+            missing_secrets = [key for key in declared if key not in available_secrets]
+            if missing_secrets:
+                secret_list = "', '".join(missing_secrets)
+                # Prefer the pre-built definition name (manifest-loaded tools
+                # and fully materialized tools both have one) so we don't force
+                # a toolkit import just to format a warning string.
+                if tool._definition is not None:
                     tool_name = tool.definition.name
-                    logger.warning(
-                        f"Tool '{tool_name}' declares secret(s) '{secret_list}' which is/are not set. It will return an error if called."
-                    )
+                elif tool.is_tool_resolved:
+                    tool_name = getattr(tool.tool, "__tool_name__", tool.tool.__name__)
+                else:
+                    tool_name = "<unknown>"
+                logger.warning(
+                    f"Tool '{tool_name}' declares secret(s) '{secret_list}' which is/are not set. It will return an error if called."
+                )
 
     async def _handle_call_tool(
         self,

--- a/libs/arcade-mcp-server/arcade_mcp_server/worker.py
+++ b/libs/arcade-mcp-server/arcade_mcp_server/worker.py
@@ -333,18 +333,42 @@ def create_arcade_mcp_factory() -> FastAPI:
     server_title = os.environ.get("ARCADE_MCP_SERVER_TITLE")
     server_instructions = os.environ.get("ARCADE_MCP_SERVER_INSTRUCTIONS")
 
-    # Rediscover tools since there have been changes
-    try:
-        catalog = discover_tools(
-            tool_package=tool_package,
-            show_packages=show_packages,
-            discover_installed=discover_installed,
-            server_name=server_name,
-            server_version=server_version,
-        )
-    except ToolkitLoadError as exc:
-        logger.error(str(exc))
-        raise RuntimeError(f"Failed to discover tools: {exc}") from exc
+    # If a precomputed manifest is available, load from it and skip discovery
+    # entirely. This is the production fast-path: boot and /worker/tools both
+    # become O(JSON parse) regardless of installed toolkit count.
+    manifest_path = os.environ.get("ARCADE_CATALOG_MANIFEST")
+    if manifest_path:
+        from arcade_core.catalog import ToolCatalog
+
+        if tool_package:
+            raise RuntimeError(
+                "ARCADE_CATALOG_MANIFEST and --tool-package are mutually exclusive: "
+                "the manifest pins which tools are served. Rebuild the manifest with the "
+                "intended packages installed, or unset ARCADE_CATALOG_MANIFEST."
+            )
+        if not os.path.isfile(manifest_path):
+            raise RuntimeError(
+                f"ARCADE_CATALOG_MANIFEST={manifest_path} is set but the file does not exist."
+            )
+        try:
+            catalog = ToolCatalog.from_manifest(manifest_path)
+        except Exception as exc:
+            logger.error(f"Failed to load catalog manifest from {manifest_path}: {exc}")
+            raise RuntimeError(f"Failed to load catalog manifest: {exc}") from exc
+        logger.info(f"Catalog loaded from manifest: {manifest_path}")
+    else:
+        # Rediscover tools since there have been changes
+        try:
+            catalog = discover_tools(
+                tool_package=tool_package,
+                show_packages=show_packages,
+                discover_installed=discover_installed,
+                server_name=server_name,
+                server_version=server_version,
+            )
+        except ToolkitLoadError as exc:
+            logger.error(str(exc))
+            raise RuntimeError(f"Failed to discover tools: {exc}") from exc
 
     total_tools = len(catalog)
     if total_tools == 0:

--- a/libs/tests/core/test_catalog.py
+++ b/libs/tests/core/test_catalog.py
@@ -453,7 +453,12 @@ def test_add_tool_with_disabled_toolkit(monkeypatch):
 def test_add_toolkit_with_invalid_tools(
     tool_name: str, expected_error_type: type, expected_error_substring: str
 ):
-    """Test that add_toolkit raises the correct error for various invalid tool definitions."""
+    """Test that invalid tool definitions surface the correct error.
+
+    Cheap errors (missing description, malformed secrets/metadata, missing
+    return type) raise at registration time. Signature-level errors are
+    detected lazily, on first access to the tool's ``definition``.
+    """
     catalog = ToolCatalog()
 
     # Create a toolkit that references our test tool
@@ -470,14 +475,34 @@ def test_add_toolkit_with_invalid_tools(
 
     current_module = sys.modules[__name__]
 
+    # Errors that depend on signature inspection are deferred to first
+    # ``definition`` access; the rest still raise at registration time.
+    LAZY_TOOLS = {
+        "tool_with_unsupported_param_type",
+        "tool_with_missing_input_parameter_annotation",
+        "tool_with_no_type_annotation",
+        "tool_with_invalid_param_name",
+        "tool_with_too_many_annotations",
+        "tool_with_required_union_param",
+        "tool_with_non_callable_default_factory",
+        "tool_with_multiple_tool_contexts",
+        "tool_with_unsupported_output_type",
+    }
+
     with patch("arcade_core.catalog.import_module") as mock_import:
         mock_import.return_value = current_module
 
-        # Add the toolkit and expect the specified error
-        with pytest.raises(expected_error_type) as exc_info:
+        if tool_name in LAZY_TOOLS:
+            # add_toolkit succeeds; the error surfaces when we materialize.
             catalog.add_toolkit(test_toolkit)
+            with pytest.raises(expected_error_type) as exc_info:
+                # Force materialization of every registered tool's definition.
+                for materialized in catalog._tools.values():
+                    _ = materialized.definition
+        else:
+            with pytest.raises(expected_error_type) as exc_info:
+                catalog.add_toolkit(test_toolkit)
 
-        # Check that the error message contains the expected substring
         actual_error_message = str(exc_info.value)
         # Adjust for Python 3.11 and below where Annotated is returned as "typing.Annotated"
         if "typing.Annotated" in actual_error_message:

--- a/libs/tests/core/test_manifest.py
+++ b/libs/tests/core/test_manifest.py
@@ -1,0 +1,184 @@
+"""Tests for the precomputed catalog manifest."""
+
+from typing import Annotated
+
+import pytest
+from arcade_core.catalog import ToolCatalog
+from arcade_core.manifest import (
+    MANIFEST_SCHEMA_VERSION,
+    CatalogManifest,
+    IncompatibleManifestError,
+    build_manifest,
+    load_manifest,
+    write_manifest,
+)
+from arcade_core.schema import ToolContext
+from arcade_core.toolkit import Toolkit
+from arcade_tdk import tool
+
+
+@tool
+def echo(text: Annotated[str, "Text to echo"]) -> str:
+    """Return the input unchanged."""
+    return text
+
+
+@tool
+def add(x: Annotated[int, "First addend"], y: Annotated[int, "Second addend"]) -> int:
+    """Add two integers."""
+    return x + y
+
+
+@tool
+def with_context(context: ToolContext, text: Annotated[str, "Input"]) -> str:
+    """Tool whose first parameter is the tool context."""
+    return f"ctx:{text}"
+
+
+@pytest.fixture
+def populated_catalog() -> ToolCatalog:
+    toolkit = Toolkit(
+        name="manifest_test",
+        package_name="manifest_test_package",
+        version="0.1.0",
+        description="Manifest test toolkit",
+    )
+    catalog = ToolCatalog()
+    catalog.add_tool(echo, toolkit)
+    catalog.add_tool(add, toolkit)
+    return catalog
+
+
+def test_build_manifest_records_each_tool(populated_catalog: ToolCatalog) -> None:
+    manifest = build_manifest(populated_catalog)
+
+    assert manifest.schema_version == MANIFEST_SCHEMA_VERSION
+    assert len(manifest.entries) == 2
+    function_names = {e.function_name for e in manifest.entries}
+    assert function_names == {"echo", "add"}
+
+    for entry in manifest.entries:
+        # toolkit name is normalized to PascalCase in the definition
+        assert entry.toolkit_name == "ManifestTest"
+        assert entry.toolkit_version == "0.1.0"
+        assert entry.module_name == __name__
+        # definition.name is PascalCase; function_name is the raw identifier
+        assert entry.function_name != entry.definition.name
+
+
+def test_write_and_load_manifest_roundtrip(
+    populated_catalog: ToolCatalog, tmp_path
+) -> None:
+    out = tmp_path / "catalog.json"
+    written = write_manifest(populated_catalog, out)
+    assert written == out
+    assert out.exists()
+
+    loaded = load_manifest(out)
+    assert isinstance(loaded, CatalogManifest)
+    assert loaded.schema_version == MANIFEST_SCHEMA_VERSION
+    assert len(loaded.entries) == 2
+
+    # Every definition is byte-equivalent after a round-trip.
+    original = build_manifest(populated_catalog)
+    for orig_entry, loaded_entry in zip(original.entries, loaded.entries, strict=True):
+        assert orig_entry.model_dump(mode="json") == loaded_entry.model_dump(mode="json")
+
+
+def test_build_manifest_rejects_non_catalog() -> None:
+    with pytest.raises(TypeError, match="ToolCatalog"):
+        build_manifest({"not": "a catalog"})
+
+
+def test_from_manifest_preserves_definitions(
+    populated_catalog: ToolCatalog, tmp_path
+) -> None:
+    out = tmp_path / "catalog.json"
+    write_manifest(populated_catalog, out)
+
+    loaded = ToolCatalog.from_manifest(out)
+    assert len(loaded) == len(populated_catalog)
+
+    original_defs = {t.definition.name: t.definition.model_dump(mode="json") for t in populated_catalog}
+    loaded_defs = {t.definition.name: t.definition.model_dump(mode="json") for t in loaded}
+    assert original_defs == loaded_defs
+
+
+def test_from_manifest_defers_tool_resolution(
+    populated_catalog: ToolCatalog, tmp_path
+) -> None:
+    out = tmp_path / "catalog.json"
+    write_manifest(populated_catalog, out)
+
+    loaded = ToolCatalog.from_manifest(out)
+    materialized = next(iter(loaded))
+
+    # Before touching .tool, the callable is unresolved.
+    assert not materialized.is_tool_resolved
+    # Touching .definition (manifest path) does not force a tool import.
+    _ = materialized.definition
+    assert not materialized.is_tool_resolved
+
+    # Touching .tool resolves it (from this test module's namespace).
+    resolved = materialized.tool
+    assert callable(resolved)
+    assert materialized.is_tool_resolved
+
+
+def test_from_manifest_preserves_tool_context_parameter_name(tmp_path) -> None:
+    """Round-trip must restore ToolInput.tool_context_parameter_name.
+
+    The field is ``exclude=True`` on ``ToolInput`` so it's dropped from
+    the on-wire definition. Without explicit handling in the manifest,
+    every manifest-loaded tool with a Context parameter would silently
+    fail to receive its context at execution time
+    (see arcade_core/executor.py:55-56).
+    """
+    toolkit = Toolkit(
+        name="manifest_ctx_test",
+        package_name="manifest_ctx_pkg",
+        version="0.1.0",
+        description="Context test toolkit",
+    )
+    catalog = ToolCatalog()
+    catalog.add_tool(with_context, toolkit)
+
+    pre = next(iter(catalog))
+    assert pre.definition.input.tool_context_parameter_name == "context"
+
+    out = tmp_path / "ctx.json"
+    write_manifest(catalog, out)
+    loaded = ToolCatalog.from_manifest(out)
+    restored = next(iter(loaded))
+    assert restored.definition.input.tool_context_parameter_name == "context"
+
+
+def test_load_manifest_rejects_incompatible_schema_version(
+    populated_catalog: ToolCatalog, tmp_path
+) -> None:
+    out = tmp_path / "stale.json"
+    write_manifest(populated_catalog, out)
+    # Corrupt the version on disk
+    import json as jsonlib
+
+    data = jsonlib.loads(out.read_text())
+    data["schema_version"] = "0-prehistoric"
+    out.write_text(jsonlib.dumps(data))
+
+    with pytest.raises(IncompatibleManifestError, match="schema_version"):
+        load_manifest(out)
+
+
+def test_from_manifest_respects_disabled_tools(
+    populated_catalog: ToolCatalog, tmp_path, monkeypatch
+) -> None:
+    out = tmp_path / "catalog.json"
+    write_manifest(populated_catalog, out)
+
+    # ARCADE_DISABLED_TOOLS is read by ToolCatalog.__init__ via class-var hooks.
+    monkeypatch.setenv("ARCADE_DISABLED_TOOLS", "ManifestTest.Add")
+
+    loaded = ToolCatalog.from_manifest(out)
+    names = {t.definition.name for t in loaded}
+    assert "Add" not in names
+    assert "Echo" in names


### PR DESCRIPTION
Defer Pydantic schema construction (input/output models, ToolDefinition) to first .definition/.input_model/.output_model access via a lazy _factory on MaterializedTool. Toolkit module imports also defer when the catalog is loaded from a precomputed manifest — tool() resolves the callable on first .tool access.

New module arcade_core.manifest exposes CatalogManifest/ManifestEntry types, build_manifest/write_manifest/load_manifest, and the ToolCatalog.from_manifest() classmethod that loads tool definitions from JSON without importing toolkits. Notable details:

- tool_context_parameter_name is persisted explicitly. ToolInput's field is exclude=True; without restoring it ToolExecutor.run silently skips context injection for every manifest-loaded tool with a Context arg.
- schema_version is validated on load and raises IncompatibleManifest- Error with a "rebuild" hint on mismatch.
- ARCADE_DISABLED_TOOLS / ARCADE_DISABLED_TOOLKITS apply at load time so deployments can override the manifest without rebuilding it.
- ManifestToolResolutionError wraps stale-manifest ImportError/Attribute- Error so a deleted module/function surfaces with tool identity, not a generic traceback.

New CLI subcommand:

    python -m arcade_mcp_server build-manifest --all --output PATH

discovers installed toolkits, materializes every tool, and writes the manifest JSON.

In arcade_mcp_server.worker, ARCADE_CATALOG_MANIFEST short-circuits discover_tools() and loads the catalog from the manifest. Combining the env var with --tool-package raises a clear error since the manifest pins the served set.

End-to-end (11 toolkits / 278 tools, subprocess boot):
- /worker/tools response: 479ms -> 4ms (120x)
- boot to /worker/tools: 2014ms -> 492ms (4.1x)

2812 tests pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes tool catalog loading/materialization and introduces a new manifest-based startup path; mistakes could surface as missing schema/model generation or tool-resolution failures at runtime rather than at startup.
> 
> **Overview**
> **Improves startup performance by deferring tool schema work and enabling manifest-based catalogs.** `MaterializedTool` is refactored to lazily build `ToolDefinition` + Pydantic input/output models on first access, while `ToolCatalog.add_tool` now does only cheap validation and computes the FQN eagerly.
> 
> **Adds a precomputed catalog manifest flow.** New `arcade_core.manifest` can build/write/load a JSON manifest (with schema-version validation, staleness warnings, and deferred tool import via a resolver), and `ToolCatalog.from_manifest()` loads definitions without importing toolkits while restoring the excluded `tool_context_parameter_name` field.
> 
> **Updates the MCP server to benefit from laziness.** Adds `python -m arcade_mcp_server build-manifest` to generate manifests, makes the worker load from `ARCADE_CATALOG_MANIFEST` (erroring if combined with `--tool-package`), and avoids forcing tool imports/materialization during tool listing and missing-secret checks by building DTOs and secret-key lookups lazily.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c4b27aa53124b1abffcec3f33134c5d5d2ca0ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->