### PR TITLE
fix(arcade-core): bump PyJWT to >=2.12.0 for CVE-2026-32597 (TOO-933)

### DIFF
--- a/libs/arcade-core/pyproject.toml
+++ b/libs/arcade-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "arcade-core"
-version = "4.7.1"
+version = "4.7.2"
 description = "Arcade Core - Core library for Arcade platform"
 readme = "README.md"
 license = { text = "MIT" }
@@ -20,7 +20,7 @@ dependencies = [
     "pydantic>=2.7.0",
     "pyyaml>=6.0",
     "loguru>=0.7.0",
-    "pyjwt>=2.8.0",
+    "pyjwt>=2.12.0",
     "toml>=0.10.2",
     "httpx>=0.27.0",
     "packaging>=24.1",

--- a/libs/tests/worker/test_auth.py
+++ b/libs/tests/worker/test_auth.py
@@ -1,0 +1,50 @@
+import jwt
+import pytest
+from arcade_serve.core.auth import (
+    SUPPORTED_TOKEN_VER,
+    SigningAlgorithm,
+    validate_engine_token,
+)
+
+WORKER_SECRET = "test-worker-secret-at-least-32-bytes-long"  # noqa: S105 test secret, not a credential
+
+
+def _mint(payload: dict, *, secret: str = WORKER_SECRET, headers: dict | None = None) -> str:
+    return jwt.encode(payload, secret, algorithm=SigningAlgorithm.HS256, headers=headers)
+
+
+def test_valid_token_accepted():
+    token = _mint({"aud": "worker", "ver": SUPPORTED_TOKEN_VER})
+    assert validate_engine_token(WORKER_SECRET, token).valid
+
+
+def test_wrong_secret_rejected():
+    token = _mint({"aud": "worker", "ver": SUPPORTED_TOKEN_VER})
+    result = validate_engine_token("a-different-secret-at-least-32-bytes", token)
+    assert not result.valid
+
+
+def test_wrong_audience_rejected():
+    token = _mint({"aud": "not-worker", "ver": SUPPORTED_TOKEN_VER})
+    assert not validate_engine_token(WORKER_SECRET, token).valid
+
+
+def test_unsupported_token_version_rejected():
+    token = _mint({"aud": "worker", "ver": "999"})
+    result = validate_engine_token(WORKER_SECRET, token)
+    assert not result.valid
+    assert "Unsupported token version" in (result.error or "")
+
+
+def test_unrecognized_crit_header_rejected():
+    """Guards CVE-2026-32597: PyJWT < 2.12.0 silently accepted tokens carrying
+    an unrecognized `crit` header extension instead of rejecting them per
+    RFC 7515 §4.1.11. The pyjwt>=2.12.0 floor must keep rejecting them."""
+    token = _mint({"aud": "worker", "ver": SUPPORTED_TOKEN_VER}, headers={"crit": ["exp"]})
+    result = validate_engine_token(WORKER_SECRET, token)
+    assert not result.valid
+
+
+@pytest.mark.parametrize("garbage", ["", "not-a-jwt", "a.b.c"])
+def test_malformed_token_rejected(garbage):
+    assert not validate_engine_token(WORKER_SECRET, garbage).valid


### PR DESCRIPTION
## Summary

PyJWT versions before 2.12.0 silently accept JWTs carrying an unrecognized `crit` (critical) header extension instead of rejecting them as RFC 7515 §4.1.11 requires — **CVE-2026-32597 / GHSA-752w-5fwx-jx9f** (CVSS 7.5). `arcade-core` declared `pyjwt>=2.8.0`, so the whole 2.8–2.11 vulnerable range was resolvable. arcade-serve's worker-token validation (`validate_engine_token`) decodes engine tokens via PyJWT, so this raises the floor to the fixed release and adds the first regression coverage for that code path.

## Changes

- `libs/arcade-core/pyproject.toml`: `pyjwt>=2.8.0` → `pyjwt>=2.12.0`; package version `4.7.1` → `4.7.2`.
- `libs/tests/worker/test_auth.py` (new): 8 unit tests for `validate_engine_token` — valid token, wrong secret, wrong audience, unsupported version, malformed input, and the `crit`-header regression guard.

## Design decisions

- **Floor at `>=2.12.0`, not a pin or `>=2.13.0`.** 2.12.0 is the exact release that fixes the CVE, so it's the least-restrictive constraint that closes the hole. `>=` is a floor — there's no lockfile in the repo, so uv/pip already resolves to the newest compatible (2.13.0 today). Pinning higher would exclude 2.12.x for no security gain.
- **Version bump to 4.7.2 is deliberate.** `release-on-version-change.yml` only publishes a package when its `version` line changes (`check-version-changes.sh`). A bare dependency edit would land in git but never reach PyPI consumers. Downstream pins (`arcade-serve`, `arcade-mcp-server`, `arcade-tdk` at `>=4.7.1,<5.0.0`) already accept 4.7.2 — no cascade.
- **Test asserts behavior, not version.** `test_unrecognized_crit_header_rejected` fails on PyJWT 2.11.0 (the crafted token is wrongly accepted) and passes on 2.12/2.13, so a future constraint loosening *or* a refactor of the `jwt.decode` call that reopens the bypass breaks CI — independent of the dep floor.

## Scope (not included)

- The deprecated `verify=True` kwarg in `validate_engine_token` (PyJWT prefers `options={"verify_signature": True}`) is **not** changed here — tracked separately.
- `arcade-mcp-server`'s OAuth 2.1 path uses **joserfc**, a different library unaffected by this CVE — untouched.
- TOO-934 (pinning `astral-sh/setup-uv` to SHAs) is a separate PR.

## Risk

Sensitive path — auth. Blast radius is the engine→worker token-validation path only (`arcade-serve/core/auth.py`). Mitigations: all legitimate accept/reject behavior verified identical across 2.11/2.12/2.13 against the real function; the only behavioral change is that malicious `crit` tokens are now rejected, which is the intended fix. No public API or signature change.

## Test plan

- [x] `uv run pytest libs/tests/worker/test_auth.py` — 8 passed (auth.py reaches 100% coverage)
- [x] `uv run pytest libs/tests/worker/` — 46 passed (no neighbor regressions)
- [x] Regression proof: downgraded env to `pyjwt==2.11.0`, crit test **fails** (`assert not True`); restored 2.13.0, passes
- [x] CVE reproduced against the real `validate_engine_token`: 2.11.0 accepts a `{"crit":["exp"]}` token, 2.12/2.13 reject it
- [x] `uv pip compile libs/arcade-core/pyproject.toml` resolves to `pyjwt==2.13.0`
- [x] `ruff check` + `ruff format --check` clean on the new test

Refs: TOO-933

---

🤖 Generated with [Claude Code](https://claude.com/claude-code); author is accountable for every line.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches JWT validation for engine→worker tokens; behavior change only rejects previously mishandled crit-header tokens, with new tests guarding the path.
> 
> **Overview**
> Raises the **PyJWT** dependency floor in `arcade-core` from `>=2.8.0` to **`>=2.12.0`** and bumps the package to **4.7.2**, closing **CVE-2026-32597** where older PyJWT wrongly accepted JWTs with unrecognized `crit` headers. Engine→worker validation via `validate_engine_token` depends on that decode path.
> 
> Adds **`libs/tests/worker/test_auth.py`** with unit coverage for accept/reject cases (secret, audience, version, malformed tokens) and a regression test that tokens with `crit` headers are **rejected**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58964521e322bee6c6e2d932c487caa998779e5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->