### PR TITLE
fix(ci): pin astral-sh/setup-uv to immutable SHA + explicit uv version (TOO-934)

### DIFF
--- a/.github/actions/setup-uv-env/action.yml
+++ b/.github/actions/setup-uv-env/action.yml
@@ -11,8 +11,9 @@ runs:
   using: "composite"
   steps:
     - name: Install uv
-      uses: astral-sh/setup-uv@v6
+      uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
       with:
+        version: "0.11.16"
         python-version: ${{ inputs.python-version }}
 
     - name: Install dependencies

--- a/.github/workflows/pylon-sync.yml
+++ b/.github/workflows/pylon-sync.yml
@@ -29,9 +29,9 @@ jobs:
           python-version: "3.x"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
         with:
-          version: "latest"
+          version: "0.11.16"
 
       - name: Sync with Pylon
         env:


### PR DESCRIPTION
## Summary

Every CI workflow in arcade-mcp installs its toolchain through `astral-sh/setup-uv`, referenced by **mutable major-version tags** (`@v6` in the shared composite action, `@v3` + `version: "latest"` in pylon-sync). GitHub moves major tags forward on each release, so a compromise of the upstream action could silently swap the `uv` binary into every CI run — most critically the release workflow, which holds PyPI OIDC publishing rights (`id-token: write`). This pins both references to an immutable commit SHA and pins the `uv` tool to a fixed version.

## Changes

- `.github/actions/setup-uv-env/action.yml`: `astral-sh/setup-uv@v6` → `@d0cc045… # v6.8.0`; add `version: "0.11.16"`.
- `.github/workflows/pylon-sync.yml`: `astral-sh/setup-uv@v3` + `version: "latest"` → the same `@d0cc045… # v6.8.0` + `version: "0.11.16"`.

## Design decisions

- **Pinned to the SHA behind v6.8.0, which is exactly what `@v6` already resolves to** (`v6` and `v6.8.0` both dereference to `d0cc045d04ccac9d8b7881df0226f9e82c39688e`, verified via the GitHub API). So the composite action's runtime behavior is unchanged — this is a pure immutability change, not a version bump.
- **Deliberately did not jump to the latest v8.1.0.** Bundling a two-major upgrade into a security-pinning PR widens the blast radius and the review surface; the v6→v8 upgrade is filed as a separate follow-up.
- **pylon-sync aligned onto the same v6.8.0 SHA** rather than pinning its 3-major-old `@v3`. Keeping v3 would freeze a stale action for no reason; one reviewed SHA across the repo is easier to maintain and bump.
- **`uv` pinned to 0.11.16** (current latest) to close the floating-`"latest"` half of the finding. Renovate/Dependabot can bump both the SHA and the uv version going forward.
- **The composite action is the single toolchain entry point** for `main.yml`, `release-on-version-change.yml`, `cli-integration-no-auth.yml`, and `test-install.yml`, so these two files cover every workflow that builds or publishes — no other `setup-uv` references exist.

## Scope (not included)

- **Broader action-pinning hygiene is out of scope here.** Other third-party actions still ride version tags: `pypa/gh-action-pypi-publish@release/v1`, `slackapi/slack-github-action@v2.0.0`, `codecov/codecov-action@v4.0.1`, `snok/install-poetry@v1`. The release-workflow ones are arguably higher-value and warrant their own pass — filed as a follow-up ([TOO-938](https://linear.app/arcadedev/issue/TOO-938)). (`tj-actions/changed-files` is already SHA-pinned.)
- The v6→v8 setup-uv upgrade — separate follow-up ([TOO-938](https://linear.app/arcadedev/issue/TOO-938)).

## Risk

Sensitive path — CI/CD workflow files. Blast radius is the CI toolchain itself. Mitigations: the composite-action pin is behavior-identical to the prior `@v6` (same commit), so existing workflows are unaffected; the only functional change is pylon-sync moving v3→v6.8.0 and uv `latest`→`0.11.16`. Verified `setup-uv@v6.8.0` supports the `version` and `python-version` inputs we pass, and both YAML files parse cleanly. CI on this PR exercises the composite action across the full OS × Python matrix.

## Test plan

- [x] `v6` and `v6.8.0` both dereference to `d0cc045d04ccac9d8b7881df0226f9e82c39688e` (GitHub API) — pin is equivalent to current
- [x] `setup-uv@v6.8.0` action.yml declares both `version` and `python-version` inputs
- [x] `uv==0.11.16` exists on PyPI
- [x] Both YAML files parse (`yaml.safe_load`)
- [ ] CI green across the matrix (CLI integration, test-install, debug-leak) — confirms the composite action still provisions uv correctly
- [ ] pylon-sync workflow runs cleanly on its next trigger (post-merge observation)

Refs: TOO-934

---

🤖 Generated with [Claude Code](https://claude.com/claude-code); author is accountable for every line.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI toolchain provisioning for all workflows using the composite action and release-adjacent jobs; supply-chain hardening with small functional drift on pylon-sync (v3→v6.8.0, latest→0.11.16).
> 
> **Overview**
> Pins **`astral-sh/setup-uv`** in CI to an **immutable commit SHA** (`d0cc045…`, annotated as v6.8.0) instead of floating **`@v6`** / **`@v3`** tags, and sets **`uv`** to **`0.11.16`** instead of implicit or **`latest`**.
> 
> The shared composite **`.github/actions/setup-uv-env`** (used by main, release, CLI integration, and test-install workflows) only gains the SHA pin and explicit uv version—intended to match what **`@v6`** already resolved to. **`pylon-sync`** is aligned to the same action SHA and uv pin, replacing an older **`@v3`** + **`latest`** setup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7286da049eb7fe559040f40918089ea929e5be97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->