### PR TITLE
PLT-1916: ci: pin third-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Test libs
         run: uv run pytest -W ignore -v libs/tests --cov=libs --cov-config=pyproject.toml --cov-report=xml
       - name: Upload coverage reports to Codecov with GitHub Action on Python 3.10
-        uses: codecov/codecov-action@v4.0.1
+        uses: codecov/codecov-action@e0b68c6749509c5f83f984dd99a76a1c1a231044 # v4.0.1
         if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.10' }}
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/release-on-version-change.yml
+++ b/.github/workflows/release-on-version-change.yml
@@ -176,11 +176,11 @@ jobs:
           path: dist/
 
       - name: Publish release distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
 
       - name: Send status to Slack
         if: always()
-        uses: slackapi/slack-github-action@v2.0.0
+        uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
         with:
           webhook: ${{ secrets.PACKAGE_RELEASE_SLACK_WEBHOOK_URL }}
           webhook-type: webhook-trigger


### PR DESCRIPTION
## Summary

- Pin `pypa/gh-action-pypi-publish`, `slackapi/slack-github-action`, and `codecov/codecov-action` to full commit SHAs (original tag/branch retained as a comment).
- Fixes a supply-chain risk where the PyPI publish step ran under a mutable branch ref (`release/v1`) while holding `id-token: write` for OIDC publishing — a compromise upstream would have published attacker-controlled wheels under our PyPI namespace on the next version bump.
- Out of scope: GitHub-published `actions/*` refs.

Linear: https://linear.app/arcadedev/issue/PLT-1916/pin-third-party-github-actions-to-commit-shas

## Test plan

- [ ] CI green on this PR (the `main.yml` codecov step exercises the new pin).
- [ ] On the next merge to `main` that bumps a `pyproject.toml`, confirm `release-on-version-change.yml` resolves `pypa/gh-action-pypi-publish@cef221…` and the publish + Slack steps succeed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only reference changes with no application or runtime behavior changes; reduces CI supply-chain exposure.
> 
> **Overview**
> Pins three third-party GitHub Actions to **immutable commit SHAs** (with the original tag/branch kept in comments) instead of mutable refs like `v4.0.1` or `release/v1`.
> 
> In **`main.yml`**, Codecov upload now uses `codecov/codecov-action@e0b68c6749…`. In **`release-on-version-change.yml`**, PyPI publish and Slack notification use pinned `pypa/gh-action-pypi-publish` and `slackapi/slack-github-action` SHAs respectively—reducing supply-chain risk where a compromised upstream tag could run in jobs that hold **OIDC** (`id-token: write`) for PyPI or post release status to Slack.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b366255a486d05ba6ee9a8c1b897cf3a17057209. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->