### PR TITLE
fix(arcade-serve): stop logging worker secret on JWT signature failure (TOO-985)

### DIFF
--- a/libs/arcade-serve/arcade_serve/core/auth.py
+++ b/libs/arcade-serve/arcade_serve/core/auth.py
@@ -30,8 +30,8 @@ def validate_engine_token(worker_secret: str, token: str) -> TokenValidationResu
         )
     except jwt.InvalidSignatureError as e:
         logger.warning(
-            "Invalid signature. Is the Arcade Engine configured with the Worker secret '%s'?",
-            worker_secret,
+            "Invalid worker token signature. The Arcade Engine may be configured "
+            "with a different Worker secret than this worker."
         )
         return TokenValidationResult(valid=False, error=str(e))
 

--- a/libs/arcade-serve/pyproject.toml
+++ b/libs/arcade-serve/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "arcade-serve"
-version = "3.2.4"
+version = "3.2.5"
 description = "Arcade Serve - Serving infrastructure for Arcade tools and workers"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
## Summary

`validate_engine_token()` logged the **full worker secret** at `WARNING` level whenever a JWT failed signature verification (`InvalidSignatureError`). The worker secret is the HS256 signing key for the `/worker/*` protocol, so any party with log-read access (centralized logging, log forwarding pipelines, etc.) could recover it and forge valid worker tokens carrying an arbitrary spoofed `ToolContext` (fabricated `user_id`, secrets, OAuth tokens) against `/worker/tools/invoke`.

The message was designed to fire on a legitimate secret mismatch, so the value also leaks into logs during normal misconfiguration debugging, beyond the attacker-triggered case.

## Linear

https://linear.app/arcadedev/issue/TOO-985/worker-auth-secret-logged-on-jwt-validation-failure

## Changes

- **`libs/arcade-serve/arcade_serve/core/auth.py`**: remove `worker_secret` from the `InvalidSignatureError` warning, replacing it with `"Invalid worker token signature. The Arcade Engine may be configured with a different Worker secret than this worker."` (keeps the operator hint, drops the value). The returned `error=str(e)` is PyJWT's `"Signature verification failed"`, which contains no secret.
- Bump `arcade-serve` 3.2.4 to 3.2.5.

This is a logging-hygiene change with no behavioral delta: the token is still rejected exactly as before, and only the log text changes. No bespoke regression test is added, because a per-branch "secret absent from this log line" assertion would guard only this one call site. Durable "secrets must never be logged" coverage belongs in a logging redaction filter, which can be a separate follow-up.

## Testing

- `uv run pytest libs/tests/worker/ -o addopts=""` passes (46 tests).
- `uv run ruff check` and `uv run mypy` on the changed file pass clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only change; no change to auth acceptance or worker protocol behavior.
> 
> **Overview**
> Fixes a **logging leak** in `validate_engine_token()`: on JWT `InvalidSignatureError`, the warning no longer includes the **worker HS256 secret** (it now only explains a possible Engine/worker secret mismatch). Token validation behavior is unchanged—invalid signatures are still rejected with the same error path.
> 
> Bumps **`arcade-serve`** from `3.2.4` to `3.2.5`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14b695e7dcaaef3f9d560c21496709621e8654c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->