### PR TITLE
fix(arcade-mcp-server): withhold ARCADE_WORKER_SECRET/ARCADE_API_KEY from tool secrets (TOO-986)

### DIFF
--- a/libs/arcade-mcp-server/arcade_mcp_server/server.py
+++ b/libs/arcade-mcp-server/arcade_mcp_server/server.py
@@ -68,7 +68,11 @@ from arcade_mcp_server.resource_server.headers import (
     build_insufficient_scope_www_authenticate,
 )
 from arcade_mcp_server.session import InitializationState, NotificationManager, ServerSession
-from arcade_mcp_server.settings import MCPSettings, ServerSettings
+from arcade_mcp_server.settings import (
+    MCPSettings,
+    ServerSettings,
+    is_reserved_tool_secret_key,
+)
 from arcade_mcp_server.types import (
     INTERNAL_ERROR,
     INVALID_PARAMS,
@@ -1036,6 +1040,16 @@ class MCPServer:
         # secrets
         if tool.definition.requirements and tool.definition.requirements.secrets:
             for secret in tool.definition.requirements.secrets:
+                if is_reserved_tool_secret_key(secret.key):
+                    # Framework control-plane credentials authenticate the
+                    # server/worker to Arcade and must never be handed to tool
+                    # code, regardless of whether they live in the tool
+                    # environment pool or the raw process environment.
+                    logger.warning(
+                        f"Tool '{tool.definition.name}' requested reserved secret "
+                        f"'{secret.key}'; refusing to expose it to tool code."
+                    )
+                    continue
                 if secret.key in self.settings.tool_secrets():
                     tool_context.set_secret(secret.key, self.settings.tool_secrets()[secret.key])
                 elif secret.key in os.environ:

--- a/libs/arcade-mcp-server/arcade_mcp_server/server.py
+++ b/libs/arcade-mcp-server/arcade_mcp_server/server.py
@@ -1787,38 +1787,74 @@ class MCPServer:
 
         # Check secrets
         if tool.definition.requirements and tool.definition.requirements.secrets:
+            reserved_secrets = []
             missing_secrets = []
             for secret_requirement in tool.definition.requirements.secrets:
+                if is_reserved_tool_secret_key(secret_requirement.key):
+                    # Reserved framework credentials are intentionally never
+                    # injected (see _create_tool_context). Report them as
+                    # reserved rather than "missing": the variable may already
+                    # be set in the environment, so telling the caller to set
+                    # it would be misleading and impossible to act on.
+                    reserved_secrets.append(secret_requirement.key)
+                    continue
                 try:
                     tool_context.get_secret(secret_requirement.key)
                 except ValueError:
                     missing_secrets.append(secret_requirement.key)
-            if missing_secrets:
-                missing_secrets_str = ", ".join(missing_secrets)
 
-                # Create actionable error message
-                fix_instructions = "\n\n  To fix, either:\n"
-                fix_instructions += "  1. Add to .env file:\n"
-                for secret in missing_secrets:
-                    fix_instructions += f"       {secret}=your_value_here\n"
-                fix_instructions += "  2. Set environment variable:\n"
-                for secret in missing_secrets:
-                    fix_instructions += f"       export {secret}=your_value_here\n"
-                fix_instructions += "\n  Then restart the server."
+            if reserved_secrets or missing_secrets:
+                user_message = ""
+                llm_instructions = ""
 
-                user_message = f"✗ Missing {'secret' if len(missing_secrets) == 1 else 'secrets'}: {missing_secrets_str}\n\n"
-                user_message += f"  Tool '{tool_name}' requires {'this secret' if len(missing_secrets) == 1 else 'these secrets'} but {'it is' if len(missing_secrets) == 1 else 'they are'} not configured."
-                user_message += fix_instructions
+                if reserved_secrets:
+                    reserved_str = ", ".join(reserved_secrets)
+                    one = len(reserved_secrets) == 1
+                    it = "it" if one else "them"
+                    cred = "a framework credential" if one else "framework credentials"
+                    user_message += (
+                        f"✗ Reserved {'secret' if one else 'secrets'}: {reserved_str}\n\n"
+                        f"  Tool '{tool_name}' declares {'this secret' if one else 'these secrets'}, "
+                        f"but Arcade reserves {it} as {cred} for the server's own authentication "
+                        f"and never exposes {it} to tools.\n\n"
+                        f"  To fix, remove {it} from the tool's required secrets."
+                    )
+                    llm_instructions += (
+                        f"The '{tool_name}' tool declares reserved secret(s) {reserved_str} that the "
+                        f"Arcade MCP server never exposes to tools. The developer must remove {it} "
+                        f"from the tool's requires_secrets; setting the environment variable will not help. "
+                    )
 
-                tool_response = {
-                    "message": user_message,
-                    "llm_instructions": (
+                if missing_secrets:
+                    if user_message:
+                        user_message += "\n\n"
+                    missing_secrets_str = ", ".join(missing_secrets)
+
+                    # Create actionable error message
+                    fix_instructions = "\n\n  To fix, either:\n"
+                    fix_instructions += "  1. Add to .env file:\n"
+                    for secret in missing_secrets:
+                        fix_instructions += f"       {secret}=your_value_here\n"
+                    fix_instructions += "  2. Set environment variable:\n"
+                    for secret in missing_secrets:
+                        fix_instructions += f"       export {secret}=your_value_here\n"
+                    fix_instructions += "\n  Then restart the server."
+
+                    user_message += f"✗ Missing {'secret' if len(missing_secrets) == 1 else 'secrets'}: {missing_secrets_str}\n\n"
+                    user_message += f"  Tool '{tool_name}' requires {'this secret' if len(missing_secrets) == 1 else 'these secrets'} but {'it is' if len(missing_secrets) == 1 else 'they are'} not configured."
+                    user_message += fix_instructions
+
+                    llm_instructions += (
                         f"The MCP server is missing required secrets for the '{tool_name}' tool. "
                         f"The developer needs to provide {'this secret' if len(missing_secrets) == 1 else 'these secrets'} by either: "
                         f"1) Adding {'it' if len(missing_secrets) == 1 else 'them'} to a .env file in the server's working directory (e.g., {missing_secrets[0]}=your_secret_value), or "
                         f"2) Setting {'it' if len(missing_secrets) == 1 else 'them'} as environment variable{'s' if len(missing_secrets) > 1 else ''} before starting the server (e.g., export {missing_secrets[0]}=your_secret_value). "
                         "Once the secrets are configured, restart the MCP server for the changes to take effect."
-                    ),
+                    )
+
+                tool_response = {
+                    "message": user_message,
+                    "llm_instructions": llm_instructions.strip(),
                 }
                 return self._create_error_response(message, tool_response)
 

--- a/libs/arcade-mcp-server/arcade_mcp_server/settings.py
+++ b/libs/arcade-mcp-server/arcade_mcp_server/settings.py
@@ -402,13 +402,37 @@ class ArcadeSettings(BaseSettings):
     model_config = {"env_prefix": "ARCADE_"}
 
 
+RESERVED_TOOL_SECRET_KEYS: frozenset[str] = frozenset({
+    "ARCADE_WORKER_SECRET",
+    "ARCADE_API_KEY",
+})
+"""Environment variables that authenticate the server/worker to Arcade itself.
+
+These are never exposed to tool code as secrets. A tool able to read
+``ARCADE_WORKER_SECRET`` could forge worker JWTs and call ``/worker/*`` as any
+user; one able to read ``ARCADE_API_KEY`` could act as the account against the
+Arcade API. This is a narrow, exact-name block list, NOT an ``ARCADE_`` prefix
+exclusion: other ``ARCADE_*`` variables (e.g. ``ARCADE_USER_ID``) remain
+available to tools as secrets.
+"""
+
+
+def is_reserved_tool_secret_key(key: str) -> bool:
+    """Return whether ``key`` names a reserved framework control-plane credential.
+
+    The comparison is case-insensitive because environment variable names are
+    case-insensitive on some platforms. See :data:`RESERVED_TOOL_SECRET_KEYS`.
+    """
+    return key.upper() in RESERVED_TOOL_SECRET_KEYS
+
+
 class ToolEnvironmentSettings(BaseSettings):
     """Tool environment settings.
 
-    Every environment variable that is not prefixed
-    with one of the prefixes for the other settings
-    will be added to the tool environment as an
-    available tool secret in the ToolContext
+    Every environment variable that is not prefixed with one of the prefixes
+    for the other settings is added to the tool environment as an available
+    tool secret in the ToolContext, except the reserved framework credentials
+    in :data:`RESERVED_TOOL_SECRET_KEYS`, which are always withheld from tools.
     """
 
     tool_environment: dict[str, Any] = Field(
@@ -424,6 +448,7 @@ class ToolEnvironmentSettings(BaseSettings):
                 key: value
                 for key, value in os.environ.items()
                 if not any(key.startswith(prefix) for prefix in excluded_prefixes)
+                and not is_reserved_tool_secret_key(key)
             }
 
     model_config = {

--- a/libs/arcade-mcp-server/pyproject.toml
+++ b/libs/arcade-mcp-server/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "arcade-mcp-server"
-version = "1.22.0"
+version = "1.22.1"
 description = "Model Context Protocol (MCP) server framework for Arcade.dev"
 readme = "README.md"
 authors = [{ name = "Arcade.dev" }]

--- a/libs/tests/arcade_mcp_server/test_server.py
+++ b/libs/tests/arcade_mcp_server/test_server.py
@@ -1396,6 +1396,72 @@ class TestReservedToolSecretExclusion:
         with pytest.raises(ValueError):
             tool_context.get_secret("ARCADE_WORKER_SECRET")
 
+    @pytest.mark.asyncio
+    async def test_reserved_secret_reported_as_reserved_not_missing(self, mcp_server, monkeypatch):
+        """A declared reserved secret yields a 'reserved' error, not the misleading
+        'add it to .env' guidance (the variable may be set but is deliberately withheld)."""
+        monkeypatch.setenv("ARCADE_WORKER_SECRET", "super-secret")
+
+        tool = Mock()
+        tool.definition.name = "TestToolkit.greedy_tool"
+        tool.definition.requirements = ToolRequirements(
+            secrets=[ToolSecretRequirement(key="ARCADE_WORKER_SECRET")]
+        )
+        tool_context = mcp_server._create_tool_context(tool)
+        message = CallToolRequest(
+            jsonrpc="2.0",
+            id=1,
+            method="tools/call",
+            params={"name": "TestToolkit.greedy_tool", "arguments": {}},
+        )
+
+        result = await mcp_server._check_tool_requirements(
+            tool, tool_context, message, "TestToolkit.greedy_tool"
+        )
+
+        assert isinstance(result, JSONRPCResponse)
+        assert isinstance(result.result, CallToolResult)
+        assert result.result.isError is True
+        content_text = result.result.content[0].text
+        assert "Reserved" in content_text
+        assert "ARCADE_WORKER_SECRET" in content_text
+        assert "remove" in content_text.lower()
+        # The misleading "set the variable" guidance must NOT appear for it.
+        assert "ARCADE_WORKER_SECRET=your_value_here" not in content_text
+
+    @pytest.mark.asyncio
+    async def test_reserved_and_missing_secrets_reported_separately(self, mcp_server):
+        """A mix of reserved and genuinely-missing secrets keeps each in its own
+        section: only the genuinely-missing one gets the actionable .env guidance."""
+        tool = Mock()
+        tool.definition.name = "TestToolkit.mixed_tool"
+        tool.definition.requirements = ToolRequirements(
+            secrets=[
+                ToolSecretRequirement(key="ARCADE_API_KEY"),
+                ToolSecretRequirement(key="DATABASE_URL"),
+            ]
+        )
+        tool_context = mcp_server._create_tool_context(tool)
+        message = CallToolRequest(
+            jsonrpc="2.0",
+            id=1,
+            method="tools/call",
+            params={"name": "TestToolkit.mixed_tool", "arguments": {}},
+        )
+
+        result = await mcp_server._check_tool_requirements(
+            tool, tool_context, message, "TestToolkit.mixed_tool"
+        )
+
+        content_text = result.result.content[0].text
+        assert "Reserved" in content_text
+        assert "ARCADE_API_KEY" in content_text
+        assert "Missing" in content_text
+        assert "DATABASE_URL" in content_text
+        # The genuinely-missing secret keeps actionable guidance; the reserved one does not.
+        assert "DATABASE_URL=your_value_here" in content_text
+        assert "ARCADE_API_KEY=your_value_here" not in content_text
+
 
 class TestMissingSecretsWarnings:
     """Test startup warnings for missing tool secrets."""

--- a/libs/tests/arcade_mcp_server/test_server.py
+++ b/libs/tests/arcade_mcp_server/test_server.py
@@ -1342,6 +1342,61 @@ class TestParamsMetaValidation:
         assert response.error["code"] == -32602
 
 
+class TestReservedToolSecretExclusion:
+    """Framework control-plane credentials must never reach tool code.
+
+    ``ARCADE_WORKER_SECRET`` and ``ARCADE_API_KEY`` authenticate the
+    server/worker to Arcade itself. A third-party tool that could read them via
+    ``context.get_secret`` could forge worker JWTs or act as the account, so
+    ``_create_tool_context`` refuses to inject them even when a tool declares
+    them in ``requires_secrets``.
+    """
+
+    @pytest.mark.asyncio
+    async def test_reserved_secrets_not_injected_from_environment(self, mcp_server, monkeypatch):
+        """The os.environ fallback must not hand reserved credentials to tools."""
+        monkeypatch.setenv("ARCADE_WORKER_SECRET", "super-secret")
+        monkeypatch.setenv("ARCADE_API_KEY", "api-key-value")
+        monkeypatch.setenv("LEGIT_SECRET", "legit-value")
+
+        tool = Mock()
+        tool.definition.name = "TestToolkit.greedy_tool"
+        tool.definition.requirements = ToolRequirements(
+            secrets=[
+                ToolSecretRequirement(key="ARCADE_WORKER_SECRET"),
+                ToolSecretRequirement(key="ARCADE_API_KEY"),
+                ToolSecretRequirement(key="LEGIT_SECRET"),
+            ]
+        )
+
+        tool_context = mcp_server._create_tool_context(tool)
+
+        with pytest.raises(ValueError):
+            tool_context.get_secret("ARCADE_WORKER_SECRET")
+        with pytest.raises(ValueError):
+            tool_context.get_secret("ARCADE_API_KEY")
+        # Ordinary secrets are still resolved (here via the os.environ fallback).
+        assert tool_context.get_secret("LEGIT_SECRET") == "legit-value"
+
+    @pytest.mark.asyncio
+    async def test_reserved_secrets_not_injected_from_pool(self, mcp_server):
+        """A reserved key sitting in the tool pool is still withheld at injection."""
+        mcp_server.settings.tool_environment.tool_environment["ARCADE_WORKER_SECRET"] = (
+            "super-secret"
+        )
+
+        tool = Mock()
+        tool.definition.name = "TestToolkit.greedy_tool"
+        tool.definition.requirements = ToolRequirements(
+            secrets=[ToolSecretRequirement(key="ARCADE_WORKER_SECRET")]
+        )
+
+        tool_context = mcp_server._create_tool_context(tool)
+
+        with pytest.raises(ValueError):
+            tool_context.get_secret("ARCADE_WORKER_SECRET")
+
+
 class TestMissingSecretsWarnings:
     """Test startup warnings for missing tool secrets."""
 

--- a/libs/tests/arcade_mcp_server/test_settings.py
+++ b/libs/tests/arcade_mcp_server/test_settings.py
@@ -1,7 +1,12 @@
 """Tests for MCP Settings."""
 
 import pytest
-from arcade_mcp_server.settings import MCPSettings, ServerSettings
+from arcade_mcp_server.settings import (
+    MCPSettings,
+    ServerSettings,
+    ToolEnvironmentSettings,
+    is_reserved_tool_secret_key,
+)
 from pydantic import ValidationError
 
 
@@ -144,3 +149,55 @@ class TestServerSettingsVersionValidation:
         monkeypatch.setenv("MCP_SERVER_VERSION", "not-valid")
         with pytest.raises(ValidationError, match="semver"):
             MCPSettings.from_env()
+
+
+class TestReservedToolSecretKeys:
+    """Reserved framework credentials must never be exposed to tools as secrets."""
+
+    def test_is_reserved_tool_secret_key_matches_credentials(self) -> None:
+        """The worker secret and the API key are reserved."""
+        assert is_reserved_tool_secret_key("ARCADE_WORKER_SECRET")
+        assert is_reserved_tool_secret_key("ARCADE_API_KEY")
+
+    def test_is_reserved_tool_secret_key_is_case_insensitive(self) -> None:
+        """Environment variable names are case-insensitive on some platforms."""
+        assert is_reserved_tool_secret_key("arcade_worker_secret")
+        assert is_reserved_tool_secret_key("Arcade_Api_Key")
+
+    def test_is_reserved_tool_secret_key_does_not_overmatch_arcade_prefix(self) -> None:
+        """The block list is exact-name, NOT an ``ARCADE_`` prefix exclusion."""
+        assert not is_reserved_tool_secret_key("ARCADE_USER_ID")
+        assert not is_reserved_tool_secret_key("ARCADE_API_URL")
+        assert not is_reserved_tool_secret_key("ARCADE_ENVIRONMENT")
+        assert not is_reserved_tool_secret_key("MY_TOOL_TOKEN")
+
+    def test_tool_environment_excludes_reserved_credentials(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The collected tool pool drops the worker secret and API key."""
+        monkeypatch.setenv("ARCADE_WORKER_SECRET", "super-secret")
+        monkeypatch.setenv("ARCADE_API_KEY", "api-key-value")
+        monkeypatch.setenv("ARCADE_USER_ID", "user-123")
+        monkeypatch.setenv("MY_TOOL_TOKEN", "tool-token")
+
+        pool = ToolEnvironmentSettings().tool_environment
+
+        assert "ARCADE_WORKER_SECRET" not in pool
+        assert "ARCADE_API_KEY" not in pool
+        # Non-credential ARCADE_* vars and ordinary vars stay available to tools.
+        assert pool.get("ARCADE_USER_ID") == "user-123"
+        assert pool.get("MY_TOOL_TOKEN") == "tool-token"
+
+    def test_mcp_settings_tool_secrets_excludes_reserved_credentials(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``MCPSettings.tool_secrets()`` does not surface reserved credentials."""
+        monkeypatch.setenv("ARCADE_WORKER_SECRET", "super-secret")
+        monkeypatch.setenv("ARCADE_API_KEY", "api-key-value")
+        monkeypatch.setenv("MY_TOOL_TOKEN", "tool-token")
+
+        secrets = MCPSettings().tool_secrets()
+
+        assert "ARCADE_WORKER_SECRET" not in secrets
+        assert "ARCADE_API_KEY" not in secrets
+        assert secrets.get("MY_TOOL_TOKEN") == "tool-token"


### PR DESCRIPTION
## Linear

[TOO-986: Prevent ARCADE_WORKER_SECRET exposure to third-party tools](https://linear.app/arcadedev/issue/TOO-986/prevent-arcade-worker-secret-exposure-to-third-party-tools)

## Summary

`ToolEnvironmentSettings` collects every environment variable not prefixed with `MCP_` or `_` into the tool secret pool. That sweep included the framework control-plane credentials `ARCADE_WORKER_SECRET` and `ARCADE_API_KEY`. A toolkit declaring `requires_secrets=["ARCADE_WORKER_SECRET"]` would then receive the value through `context.get_secret(...)`.

This PR stops those two credentials from being surfaced to tools by name.

## What changed

- New exact-name reserved block list `RESERVED_TOOL_SECRET_KEYS = {ARCADE_WORKER_SECRET, ARCADE_API_KEY}` in `settings.py`, with a small case-insensitive `is_reserved_tool_secret_key()` helper.
- `ToolEnvironmentSettings.model_post_init` excludes reserved keys when building the pool, so they never appear in `tool_secrets()`, the missing-secret warnings, or the startup key logging.
- `MCPServer._create_tool_context` skips reserved keys **before** resolving from either the pool or the `os.environ` fallback. The `elif secret.key in os.environ` fallback is the important part: a pool-only filter would be bypassed by it, so guarding the injection point is what actually closes the path. A `logger.warning` is emitted (to stderr in stdio mode) when a tool requests a reserved key.

### Deliberately scoped to exact names, not the `ARCADE_` prefix

Excluding the whole `ARCADE_` prefix would be too broad: many `ARCADE_*` variables are legitimately available to tools as secrets (e.g. `ARCADE_USER_ID`). Only the two control-plane credentials are blocked; a test locks this in.

## Threat-model note

This is least-privilege hardening, not a sandbox. Tools run as unsandboxed in-process Python (`importlib` load, direct `await func(...)`), so a genuinely malicious in-process toolkit can still read `os.environ` directly. The real boundary against malicious toolkits is supply-chain trust over what gets installed. What this change does buy: it removes the by-name exposure path (so a tool cannot obtain these credentials through the documented `requires_secrets` API), narrows accidental leakage (e.g. a benign-but-buggy tool that logs its own secrets), and keeps the credentials out of the pool listing, warnings, and key logs.

## Tests

- `test_settings.py::TestReservedToolSecretKeys` - helper behavior, case-insensitivity, no over-matching of the `ARCADE_` prefix, pool exclusion, and `MCPSettings.tool_secrets()` exclusion.
- `test_server.py::TestReservedToolSecretExclusion` - `_create_tool_context` withholds reserved keys via both the `os.environ` fallback and the pool, while still injecting ordinary secrets.

All of `test_settings.py` and `test_server.py` pass (205); `make check` clean (ruff, ruff-format, mypy).

## Versioning

`arcade-mcp-server` 1.22.0 -> 1.22.1.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Security hardening on control-plane credentials (worker secret and API key); incorrect blocking could break legitimate tool config, but scope is narrow and well-tested.
> 
> **Overview**
> **arcade-mcp-server** now blocks `ARCADE_WORKER_SECRET` and `ARCADE_API_KEY` from ever reaching tool code via the documented secrets path.
> 
> A case-insensitive exact-name reserved list and `is_reserved_tool_secret_key()` are added in `settings.py`. The auto-built tool secret pool omits those keys, and `_create_tool_context` skips them before pool or `os.environ` injection (with a warning). `_check_tool_requirements` reports reserved secrets separately from missing ones—telling developers to remove them from `requires_secrets`, not to set env vars.
> 
> Other `ARCADE_*` variables (e.g. `ARCADE_USER_ID`) stay available as tool secrets. Package version bumps to **1.22.1** with new settings and server tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe04cc426ad0369b2023d05b5903b26221392e1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->