### PR TITLE
fix(arcade-core,arcade-mcp-server): Nested-object schemas across all tool-schema converters

### DIFF
--- a/libs/arcade-core/arcade_core/catalog.py
+++ b/libs/arcade-core/arcade_core/catalog.py
@@ -867,6 +867,7 @@ def extract_properties(
 
     # Handle Pydantic BaseModel
     if isinstance(type_to_check, type) and issubclass(type_to_check, BaseModel):
+        pydantic_required_keys: list[str] = []
         for field_name, field_info in type_to_check.model_fields.items():
             # Get the field type
             field_type = field_info.annotation
@@ -874,16 +875,23 @@ def extract_properties(
                 continue
 
             # Handle Optional types (Union[T, None])
-            if is_strict_optional(field_type):
+            is_nullable = is_strict_optional(field_type)
+            if is_nullable:
                 # Extract the non-None type from Optional
                 field_type = next(arg for arg in get_args(field_type) if arg is not type(None))
 
             # Get wire type info recursively
             # field_type cannot be None here due to the check above
             wire_info = get_wire_type_info(field_type)
+            if is_nullable:
+                wire_info.nullable = True
             properties[field_name] = wire_info
 
-        return (properties or None, None)
+            # A Pydantic field is required when it has no default (default or factory).
+            if field_info.is_required():
+                pydantic_required_keys.append(field_name)
+
+        return (properties or None, sorted(pydantic_required_keys) or None)
 
     # Handle TypedDict
     elif is_typeddict(type_to_check):

--- a/libs/arcade-core/arcade_core/catalog.py
+++ b/libs/arcade-core/arcade_core/catalog.py
@@ -860,8 +860,11 @@ def extract_properties(
     """
     Extract properties from TypedDict, Pydantic models, or other structured types.
 
-    Returns (properties, required_keys). required_keys is a sorted list of required
-    property names for TypedDict types, or None for other types.
+    Returns (properties, required_keys). For a known structured type (TypedDict or
+    Pydantic model) required_keys is a sorted list of required property names, which is
+    empty when every field is optional. For a type with no known shape (e.g. a freeform
+    ``dict``) required_keys is None, signaling that requiredness is unknown rather than
+    known-empty.
     """
     properties = {}
 
@@ -891,7 +894,7 @@ def extract_properties(
             if field_info.is_required():
                 pydantic_required_keys.append(field_name)
 
-        return (properties or None, sorted(pydantic_required_keys) or None)
+        return (properties or None, sorted(pydantic_required_keys))
 
     # Handle TypedDict
     elif is_typeddict(type_to_check):
@@ -917,8 +920,7 @@ def extract_properties(
 
             properties[field_name] = wire_info
 
-        req = sorted(getattr(type_to_check, "__required_keys__", frozenset()))
-        required_keys = req or None  # normalize empty → None
+        required_keys = sorted(getattr(type_to_check, "__required_keys__", frozenset()))
         return (properties or None, required_keys)
 
     # Handle regular dict with type annotations (e.g., dict[str, Any])

--- a/libs/arcade-core/arcade_core/catalog.py
+++ b/libs/arcade-core/arcade_core/catalog.py
@@ -775,12 +775,13 @@ def get_wire_type_info(_type: type) -> WireTypeInfo:
         inner_info = get_wire_type_info(inner_type)
         inner_wire_type = cast(InnerWireType, inner_info.wire_type)
 
-        # If inner type has properties (it's a complex object), propagate them
-        if inner_info.properties:
+        # If inner type has a known object shape (possibly empty), propagate it. A known-empty
+        # shape ({}) is distinct from None (unknown shape) so converters can close it.
+        if inner_info.properties is not None:
             inner_properties = inner_info.properties
             inner_required_keys = inner_info.required_keys
         # If inner type is array (nested arrays), propagate inner_properties
-        elif inner_info.inner_properties:
+        elif inner_info.inner_properties is not None:
             inner_properties = inner_info.inner_properties
             inner_required_keys = inner_info.inner_required_keys
     else:
@@ -861,10 +862,11 @@ def extract_properties(
     Extract properties from TypedDict, Pydantic models, or other structured types.
 
     Returns (properties, required_keys). For a known structured type (TypedDict or
-    Pydantic model) required_keys is a sorted list of required property names, which is
-    empty when every field is optional. For a type with no known shape (e.g. a freeform
-    ``dict``) required_keys is None, signaling that requiredness is unknown rather than
-    known-empty.
+    Pydantic model) properties is a dict of its fields, empty when the type declares no
+    fields, and required_keys is a sorted list of required property names, empty when every
+    field is optional. A known-empty shape (no fields) therefore yields ``({}, [])``, which
+    converters can distinguish from a type with no known shape (e.g. a freeform ``dict``),
+    which yields ``(None, None)`` to signal that both shape and requiredness are unknown.
     """
     properties = {}
 
@@ -894,7 +896,7 @@ def extract_properties(
             if field_info.is_required():
                 pydantic_required_keys.append(field_name)
 
-        return (properties or None, sorted(pydantic_required_keys))
+        return (properties, sorted(pydantic_required_keys))
 
     # Handle TypedDict
     elif is_typeddict(type_to_check):
@@ -921,7 +923,7 @@ def extract_properties(
             properties[field_name] = wire_info
 
         required_keys = sorted(getattr(type_to_check, "__required_keys__", frozenset()))
-        return (properties or None, required_keys)
+        return (properties, required_keys)
 
     # Handle regular dict with type annotations (e.g., dict[str, Any])
     elif get_origin(type_to_check) is dict:
@@ -935,9 +937,10 @@ def wire_type_info_to_value_schema(wire_info: WireTypeInfo) -> ValueSchema:
     """
     Convert WireTypeInfo to ValueSchema, including nested properties.
     """
-    # Convert nested properties if they exist
+    # Convert nested properties if they exist. A known-empty object shape ({}) is preserved
+    # as {} rather than collapsed to None so converters can emit it as a closed object.
     properties = None
-    if wire_info.properties:
+    if wire_info.properties is not None:
         properties = {
             name: wire_type_info_to_value_schema(nested_info)
             for name, nested_info in wire_info.properties.items()
@@ -945,7 +948,7 @@ def wire_type_info_to_value_schema(wire_info: WireTypeInfo) -> ValueSchema:
 
     # Convert inner properties for array items
     inner_properties = None
-    if wire_info.inner_properties:
+    if wire_info.inner_properties is not None:
         inner_properties = {
             name: wire_type_info_to_value_schema(nested_info)
             for name, nested_info in wire_info.inner_properties.items()

--- a/libs/arcade-core/arcade_core/converters/anthropic.py
+++ b/libs/arcade-core/arcade_core/converters/anthropic.py
@@ -172,7 +172,7 @@ def _convert_value_schema_to_json_schema(
 
     if value_schema.val_type == "array" and value_schema.inner_val_type:
         schema = {"type": "array"}
-        if value_schema.inner_val_type == "json" and value_schema.inner_properties:
+        if value_schema.inner_val_type == "json" and value_schema.inner_properties is not None:
             schema["items"] = _build_object_schema(
                 value_schema.inner_properties, value_schema.inner_required_keys
             )
@@ -186,7 +186,7 @@ def _convert_value_schema_to_json_schema(
             schema["items"] = items_schema
         return schema
 
-    if value_schema.val_type == "json" and value_schema.properties:
+    if value_schema.val_type == "json" and value_schema.properties is not None:
         return _build_object_schema(value_schema.properties, value_schema.required_keys)
 
     schema = {"type": type_mapping[value_schema.val_type]}

--- a/libs/arcade-core/arcade_core/converters/anthropic.py
+++ b/libs/arcade-core/arcade_core/converters/anthropic.py
@@ -26,7 +26,7 @@ class AnthropicInputSchemaProperty(TypedDict, total=False):
     enum: list[Any]
     """Allowed values for enum properties."""
 
-    items: dict[str, Any]
+    items: "AnthropicInputSchemaProperty"
     """Schema for array items when type is 'array'."""
 
     properties: dict[str, "AnthropicInputSchemaProperty"]
@@ -112,6 +112,28 @@ def _create_tool_schema(
     return tool
 
 
+def _build_object_schema(
+    properties: dict[str, ValueSchema],
+    required_keys: list[str] | None,
+) -> AnthropicInputSchemaProperty:
+    """Build an object schema from a structured type's fields.
+
+    Anthropic uses standard JSON Schema: only the actually-required fields appear in
+    ``required`` and there is no ``additionalProperties`` constraint.
+    """
+    field_schemas: dict[str, AnthropicInputSchemaProperty] = {}
+    for name, field_value_schema in properties.items():
+        field_schema = _convert_value_schema_to_json_schema(field_value_schema)
+        if field_value_schema.description:
+            field_schema["description"] = field_value_schema.description
+        field_schemas[name] = field_schema
+
+    schema: AnthropicInputSchemaProperty = {"type": "object", "properties": field_schemas}
+    if required_keys:
+        schema["required"] = list(required_keys)
+    return schema
+
+
 def _convert_value_schema_to_json_schema(
     value_schema: ValueSchema,
 ) -> AnthropicInputSchemaProperty:
@@ -125,28 +147,30 @@ def _convert_value_schema_to_json_schema(
         "array": "array",
     }
 
-    schema: AnthropicInputSchemaProperty = {"type": type_mapping[value_schema.val_type]}
+    schema: AnthropicInputSchemaProperty
 
     if value_schema.val_type == "array" and value_schema.inner_val_type:
-        items_schema: dict[str, Any] = {"type": type_mapping[value_schema.inner_val_type]}
+        schema = {"type": "array"}
+        if value_schema.inner_val_type == "json" and value_schema.inner_properties:
+            schema["items"] = _build_object_schema(
+                value_schema.inner_properties, value_schema.inner_required_keys
+            )
+        else:
+            items_schema: AnthropicInputSchemaProperty = {
+                "type": type_mapping[value_schema.inner_val_type]
+            }
+            # For arrays of scalars, enum applies to the items, not the array itself
+            if value_schema.enum:
+                items_schema["enum"] = value_schema.enum
+            schema["items"] = items_schema
+        return schema
 
-        # For arrays, enum should be applied to the items, not the array itself
-        if value_schema.enum:
-            items_schema["enum"] = value_schema.enum
-
-        schema["items"] = items_schema
-    else:
-        # Handle enum for non-array types
-        if value_schema.enum:
-            schema["enum"] = value_schema.enum
-
-    # Handle object properties
     if value_schema.val_type == "json" and value_schema.properties:
-        schema["properties"] = {
-            name: _convert_value_schema_to_json_schema(nested_schema)
-            for name, nested_schema in value_schema.properties.items()
-        }
+        return _build_object_schema(value_schema.properties, value_schema.required_keys)
 
+    schema = {"type": type_mapping[value_schema.val_type]}
+    if value_schema.enum:
+        schema["enum"] = value_schema.enum
     return schema
 
 

--- a/libs/arcade-core/arcade_core/converters/anthropic.py
+++ b/libs/arcade-core/arcade_core/converters/anthropic.py
@@ -17,8 +17,8 @@ from arcade_core.schema import InputParameter, ValueSchema
 class AnthropicInputSchemaProperty(TypedDict, total=False):
     """Type definition for a property within Anthropic input schema."""
 
-    type: str
-    """The JSON Schema type for this property."""
+    type: str | list[str]
+    """The JSON Schema type(s) for this property. A list expresses a union (e.g. ["string", "null"])."""
 
     description: str
     """Description of the property."""
@@ -112,6 +112,24 @@ def _create_tool_schema(
     return tool
 
 
+def _add_null_to_type(schema: AnthropicInputSchemaProperty) -> None:
+    """Union a field's type with "null" so a null value validates.
+
+    A nested field can be required yet nullable (``str | None`` with no default): it must
+    stay required while still accepting null. When the field is an enum, ``None`` is
+    appended to the enum too, since ``type`` and ``enum`` are independent assertions.
+    """
+    field_type = schema.get("type")
+    if isinstance(field_type, str):
+        schema["type"] = [field_type, "null"]
+    elif isinstance(field_type, list) and "null" not in field_type:
+        schema["type"] = [*field_type, "null"]
+
+    enum_values = schema.get("enum")
+    if isinstance(enum_values, list) and None not in enum_values:
+        schema["enum"] = [*enum_values, None]
+
+
 def _build_object_schema(
     properties: dict[str, ValueSchema],
     required_keys: list[str] | None,
@@ -119,13 +137,16 @@ def _build_object_schema(
     """Build an object schema from a structured type's fields.
 
     Anthropic uses standard JSON Schema: only the actually-required fields appear in
-    ``required`` and there is no ``additionalProperties`` constraint.
+    ``required`` and there is no ``additionalProperties`` constraint. A nullable field
+    unions ``null`` into its type so a null value validates even when the field is required.
     """
     field_schemas: dict[str, AnthropicInputSchemaProperty] = {}
     for name, field_value_schema in properties.items():
         field_schema = _convert_value_schema_to_json_schema(field_value_schema)
         if field_value_schema.description:
             field_schema["description"] = field_value_schema.description
+        if field_value_schema.nullable:
+            _add_null_to_type(field_schema)
         field_schemas[name] = field_schema
 
     schema: AnthropicInputSchemaProperty = {"type": "object", "properties": field_schemas}

--- a/libs/arcade-core/arcade_core/converters/openai.py
+++ b/libs/arcade-core/arcade_core/converters/openai.py
@@ -209,7 +209,7 @@ def _convert_value_schema_to_json_schema(
 
     if value_schema.val_type == "array" and value_schema.inner_val_type:
         schema = {"type": "array"}
-        if value_schema.inner_val_type == "json" and value_schema.inner_properties:
+        if value_schema.inner_val_type == "json" and value_schema.inner_properties is not None:
             schema["items"] = _build_object_schema(
                 value_schema.inner_properties, value_schema.inner_required_keys
             )
@@ -223,7 +223,7 @@ def _convert_value_schema_to_json_schema(
             schema["items"] = items_schema
         return schema
 
-    if value_schema.val_type == "json" and value_schema.properties:
+    if value_schema.val_type == "json" and value_schema.properties is not None:
         return _build_object_schema(value_schema.properties, value_schema.required_keys)
 
     schema = {"type": type_mapping[value_schema.val_type]}

--- a/libs/arcade-core/arcade_core/converters/openai.py
+++ b/libs/arcade-core/arcade_core/converters/openai.py
@@ -25,7 +25,7 @@ class OpenAIFunctionParameterProperty(TypedDict, total=False):
     enum: list[Any]
     """Allowed values for enum properties."""
 
-    items: dict[str, Any]
+    items: "OpenAIFunctionParameterProperty"
     """Schema for array items when type is 'array'."""
 
     properties: dict[str, "OpenAIFunctionParameterProperty"]
@@ -136,6 +136,56 @@ def _create_tool_schema(
     return tool
 
 
+def _add_null_to_type(schema: OpenAIFunctionParameterProperty) -> None:
+    """Union a property's type with "null" so it may be omitted in strict mode.
+
+    Strict mode lists every property in ``required``; an optional property is then
+    expressed by allowing ``null`` rather than by leaving it out of ``required``.
+    """
+    param_type = schema.get("type")
+    if isinstance(param_type, str):
+        schema["type"] = [param_type, "null"]
+    elif isinstance(param_type, list) and "null" not in param_type:
+        schema["type"] = [*param_type, "null"]
+
+
+def _build_object_schema(
+    properties: dict[str, ValueSchema],
+    required_keys: list[str] | None,
+) -> OpenAIFunctionParameterProperty:
+    """Build a strict-mode object schema from a structured type's fields.
+
+    Strict mode requires ``additionalProperties: false`` on every object and every
+    property listed in ``required``. Fields that are not actually required are unioned
+    with ``null`` so the model may omit them. When ``required_keys`` is known (TypedDict)
+    a field is required iff it appears there; when it is unknown (e.g. a Pydantic model,
+    which does not expose required keys here) the field's ``nullable`` flag decides.
+    """
+    required_set = set(required_keys or [])
+    field_schemas: dict[str, OpenAIFunctionParameterProperty] = {}
+
+    for name, field_value_schema in properties.items():
+        field_schema = _convert_value_schema_to_json_schema(field_value_schema)
+        if field_value_schema.description:
+            field_schema["description"] = field_value_schema.description
+
+        if required_keys is None:
+            is_required = not field_value_schema.nullable
+        else:
+            is_required = name in required_set
+        if field_value_schema.nullable or not is_required:
+            _add_null_to_type(field_schema)
+
+        field_schemas[name] = field_schema
+
+    return {
+        "type": "object",
+        "properties": field_schemas,
+        "required": list(properties.keys()),
+        "additionalProperties": False,
+    }
+
+
 def _convert_value_schema_to_json_schema(
     value_schema: ValueSchema,
 ) -> OpenAIFunctionParameterProperty:
@@ -149,28 +199,30 @@ def _convert_value_schema_to_json_schema(
         "array": "array",
     }
 
-    schema: OpenAIFunctionParameterProperty = {"type": type_mapping[value_schema.val_type]}
+    schema: OpenAIFunctionParameterProperty
 
     if value_schema.val_type == "array" and value_schema.inner_val_type:
-        items_schema: dict[str, Any] = {"type": type_mapping[value_schema.inner_val_type]}
+        schema = {"type": "array"}
+        if value_schema.inner_val_type == "json" and value_schema.inner_properties:
+            schema["items"] = _build_object_schema(
+                value_schema.inner_properties, value_schema.inner_required_keys
+            )
+        else:
+            items_schema: OpenAIFunctionParameterProperty = {
+                "type": type_mapping[value_schema.inner_val_type]
+            }
+            # For arrays of scalars, enum applies to the items, not the array itself
+            if value_schema.enum:
+                items_schema["enum"] = value_schema.enum
+            schema["items"] = items_schema
+        return schema
 
-        # For arrays, enum should be applied to the items, not the array itself
-        if value_schema.enum:
-            items_schema["enum"] = value_schema.enum
-
-        schema["items"] = items_schema
-    else:
-        # Handle enum for non-array types
-        if value_schema.enum:
-            schema["enum"] = value_schema.enum
-
-    # Handle object properties
     if value_schema.val_type == "json" and value_schema.properties:
-        schema["properties"] = {
-            name: _convert_value_schema_to_json_schema(nested_schema)
-            for name, nested_schema in value_schema.properties.items()
-        }
+        return _build_object_schema(value_schema.properties, value_schema.required_keys)
 
+    schema = {"type": type_mapping[value_schema.val_type]}
+    if value_schema.enum:
+        schema["enum"] = value_schema.enum
     return schema
 
 
@@ -192,21 +244,15 @@ def _convert_input_parameters_to_json_schema(
     for parameter in parameters:
         param_schema = _convert_value_schema_to_json_schema(parameter.value_schema)
 
-        # For optional parameters in strict mode, we need to add "null" as a type option
+        # In strict mode every parameter is listed in `required`; optional ones are
+        # expressed by allowing "null" rather than by omission.
         if not parameter.required:
-            param_type = param_schema.get("type")
-            if isinstance(param_type, str):
-                # Convert single type to union with null
-                param_schema["type"] = [param_type, "null"]
-            elif isinstance(param_type, list) and "null" not in param_type:
-                param_schema["type"] = [*param_type, "null"]
+            _add_null_to_type(param_schema)
 
         if parameter.description:
             param_schema["description"] = parameter.description
         properties[parameter.name] = param_schema
 
-        # In strict mode, all parameters (including optional ones) go in required array
-        # Optional parameters are handled by adding "null" to their type
         required.append(parameter.name)
 
     json_schema: OpenAIFunctionParameters = {

--- a/libs/arcade-core/arcade_core/converters/openai.py
+++ b/libs/arcade-core/arcade_core/converters/openai.py
@@ -140,13 +140,19 @@ def _add_null_to_type(schema: OpenAIFunctionParameterProperty) -> None:
     """Union a property's type with "null" so it may be omitted in strict mode.
 
     Strict mode lists every property in ``required``; an optional property is then
-    expressed by allowing ``null`` rather than by leaving it out of ``required``.
+    expressed by allowing ``null`` rather than by leaving it out of ``required``. When the
+    property is an enum, ``None`` is appended to the enum too: ``type`` and ``enum`` are
+    independent assertions, so a null value must satisfy both.
     """
     param_type = schema.get("type")
     if isinstance(param_type, str):
         schema["type"] = [param_type, "null"]
     elif isinstance(param_type, list) and "null" not in param_type:
         schema["type"] = [*param_type, "null"]
+
+    enum_values = schema.get("enum")
+    if isinstance(enum_values, list) and None not in enum_values:
+        schema["enum"] = [*enum_values, None]
 
 
 def _build_object_schema(
@@ -157,9 +163,9 @@ def _build_object_schema(
 
     Strict mode requires ``additionalProperties: false`` on every object and every
     property listed in ``required``. Fields that are not actually required are unioned
-    with ``null`` so the model may omit them. When ``required_keys`` is known (TypedDict)
-    a field is required iff it appears there; when it is unknown (e.g. a Pydantic model,
-    which does not expose required keys here) the field's ``nullable`` flag decides.
+    with ``null`` so the model may omit them. When ``required_keys`` is a list (a known
+    shape, possibly empty) a field is required iff it appears there; when it is ``None``
+    (an unknown shape) the field's ``nullable`` flag decides.
     """
     required_set = set(required_keys or [])
     field_schemas: dict[str, OpenAIFunctionParameterProperty] = {}

--- a/libs/arcade-core/pyproject.toml
+++ b/libs/arcade-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "arcade-core"
-version = "4.7.2"
+version = "4.7.3"
 description = "Arcade Core - Core library for Arcade platform"
 readme = "README.md"
 license = { text = "MIT" }

--- a/libs/arcade-mcp-server/arcade_mcp_server/convert.py
+++ b/libs/arcade-mcp-server/arcade_mcp_server/convert.py
@@ -281,6 +281,9 @@ def _value_schema_to_json_schema(value_schema: Any) -> dict[str, Any]:
                 schema["properties"][prop_name] = _value_schema_to_json_schema(prop_schema)
                 if getattr(prop_schema, "description", None):
                     schema["properties"][prop_name]["description"] = prop_schema.description
+            # Close objects with a known shape so the schema is valid under OpenAI strict
+            # mode. Open dicts (no properties) stay open, since they accept arbitrary keys.
+            schema["additionalProperties"] = False
         if getattr(value_schema, "required_keys", None):
             schema["required"] = list(value_schema.required_keys)
         return _apply_nullable(schema, value_schema)
@@ -297,6 +300,8 @@ def _value_schema_to_json_schema(value_schema: Any) -> dict[str, Any]:
                 items_schema["properties"][prop_name] = _value_schema_to_json_schema(prop_schema)
                 if getattr(prop_schema, "description", None):
                     items_schema["properties"][prop_name]["description"] = prop_schema.description
+            # Close array-of-object items with a known shape (see object branch above).
+            items_schema["additionalProperties"] = False
             if getattr(value_schema, "inner_required_keys", None):
                 items_schema["required"] = list(value_schema.inner_required_keys)
         schema["items"] = items_schema

--- a/libs/arcade-mcp-server/arcade_mcp_server/convert.py
+++ b/libs/arcade-mcp-server/arcade_mcp_server/convert.py
@@ -275,14 +275,15 @@ def _value_schema_to_json_schema(value_schema: Any) -> dict[str, Any]:
         schema: dict[str, Any] = {"type": "object"}
         if getattr(value_schema, "enum", None):
             schema["enum"] = list(value_schema.enum)
-        if getattr(value_schema, "properties", None):
+        if getattr(value_schema, "properties", None) is not None:
             schema["properties"] = {}
             for prop_name, prop_schema in value_schema.properties.items():
                 schema["properties"][prop_name] = _value_schema_to_json_schema(prop_schema)
                 if getattr(prop_schema, "description", None):
                     schema["properties"][prop_name]["description"] = prop_schema.description
-            # Close objects with a known shape so the schema is valid under OpenAI strict
-            # mode. Open dicts (no properties) stay open, since they accept arbitrary keys.
+            # Close objects with a known shape (including a known-empty one) so the schema is
+            # valid under OpenAI strict mode. A freeform dict has no properties (None) and stays
+            # open, since it accepts arbitrary keys.
             schema["additionalProperties"] = False
         if getattr(value_schema, "required_keys", None):
             schema["required"] = list(value_schema.required_keys)
@@ -294,7 +295,7 @@ def _value_schema_to_json_schema(value_schema: Any) -> dict[str, Any]:
     if val_type == "array" and getattr(value_schema, "inner_val_type", None):
         inner_type = value_schema.inner_val_type
         items_schema: dict[str, Any] = {"type": _map_type_to_json_schema_type(inner_type)}
-        if inner_type == "json" and getattr(value_schema, "inner_properties", None):
+        if inner_type == "json" and getattr(value_schema, "inner_properties", None) is not None:
             items_schema["properties"] = {}
             for prop_name, prop_schema in value_schema.inner_properties.items():
                 items_schema["properties"][prop_name] = _value_schema_to_json_schema(prop_schema)

--- a/libs/arcade-mcp-server/arcade_mcp_server/convert.py
+++ b/libs/arcade-mcp-server/arcade_mcp_server/convert.py
@@ -281,9 +281,9 @@ def _value_schema_to_json_schema(value_schema: Any) -> dict[str, Any]:
                 schema["properties"][prop_name] = _value_schema_to_json_schema(prop_schema)
                 if getattr(prop_schema, "description", None):
                     schema["properties"][prop_name]["description"] = prop_schema.description
-            # Close objects with a known shape (including a known-empty one) so the schema is
-            # valid under OpenAI strict mode. A freeform dict has no properties (None) and stays
-            # open, since it accepts arbitrary keys.
+            # A known shape has a fixed set of keys, so close the object with
+            # additionalProperties: false. A freeform dict has no properties (None) and
+            # stays open, since it accepts arbitrary keys.
             schema["additionalProperties"] = False
         if getattr(value_schema, "required_keys", None):
             schema["required"] = list(value_schema.required_keys)

--- a/libs/arcade-mcp-server/pyproject.toml
+++ b/libs/arcade-mcp-server/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "arcade-mcp-server"
-version = "1.22.1"
+version = "1.22.2"
 description = "Model Context Protocol (MCP) server framework for Arcade.dev"
 readme = "README.md"
 authors = [{ name = "Arcade.dev" }]
@@ -21,7 +21,7 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "arcade-core>=4.7.1,<5.0.0",
+    "arcade-core>=4.7.3,<5.0.0",
     "arcade-serve>=3.2.4,<4.0.0",
     "arcade-tdk>=3.7.0,<4.0.0",
     "arcadepy>=1.5.0",

--- a/libs/tests/arcade_mcp_server/test_convert.py
+++ b/libs/tests/arcade_mcp_server/test_convert.py
@@ -545,6 +545,35 @@ class TestCreateMCPTool:
         assert "properties" not in param
         assert "additionalProperties" not in param
 
+    def test_input_schema_empty_object_is_closed(self):
+        """An object with a known-empty shape (properties == {}) is closed: it carries
+        `properties: {}` and `additionalProperties: false`, valid under OpenAI strict mode."""
+        mcp_tool = self._make_tool_with_param(
+            ValueSchema(val_type="json", properties={}, required_keys=[])
+        )
+        param = mcp_tool.inputSchema["properties"]["param"]
+
+        assert param["type"] == "object"
+        assert param["properties"] == {}
+        assert param["additionalProperties"] is False
+
+    def test_input_schema_array_of_empty_object_items_are_closed(self):
+        """`list[<empty object>]` item schemas carry `properties: {}` and
+        `additionalProperties: false`."""
+        mcp_tool = self._make_tool_with_param(
+            ValueSchema(
+                val_type="array",
+                inner_val_type="json",
+                inner_properties={},
+                inner_required_keys=[],
+            )
+        )
+        items = mcp_tool.inputSchema["properties"]["param"]["items"]
+
+        assert items["type"] == "object"
+        assert items["properties"] == {}
+        assert items["additionalProperties"] is False
+
     @pytest.mark.parametrize(
         "val_type",
         ["string", "integer", "number", "boolean"],

--- a/libs/tests/arcade_mcp_server/test_convert.py
+++ b/libs/tests/arcade_mcp_server/test_convert.py
@@ -461,6 +461,90 @@ class TestCreateMCPTool:
         )
         return create_mcp_tool(mat_tool)
 
+    def _make_tool_with_param(self, value_schema: ValueSchema, *, required: bool = True):
+        """Helper to create a materialized tool with a single input param ValueSchema."""
+        tool_def = ToolDefinition(
+            name="test",
+            fully_qualified_name="Test.test",
+            description="Test",
+            toolkit=ToolkitDefinition(name="Test"),
+            input=ToolInput(
+                parameters=[
+                    InputParameter(
+                        name="param",
+                        required=required,
+                        description="A param",
+                        value_schema=value_schema,
+                    )
+                ]
+            ),
+            output=ToolOutput(),
+            requirements=ToolRequirements(),
+        )
+
+        @tool
+        def f(param: Annotated[str, "A param"]):
+            return param
+
+        input_model, output_model = create_func_models(f)
+        meta = ToolMeta(module=f.__module__, toolkit=tool_def.toolkit.name)
+        mat_tool = MaterializedTool(
+            tool=f,
+            definition=tool_def,
+            meta=meta,
+            input_model=input_model,
+            output_model=output_model,
+        )
+        return create_mcp_tool(mat_tool)
+
+    def test_input_schema_nested_object_is_closed(self):
+        """Objects with a known shape must set additionalProperties: false at every level, so
+        the schema is valid when an MCP host forwards it to OpenAI strict mode."""
+        inner = {
+            "source": ValueSchema(val_type="string"),
+            "meta": ValueSchema(
+                val_type="json",
+                properties={"key": ValueSchema(val_type="string")},
+                required_keys=["key"],
+            ),
+        }
+        mcp_tool = self._make_tool_with_param(
+            ValueSchema(val_type="json", properties=inner, required_keys=["source"])
+        )
+        param = mcp_tool.inputSchema["properties"]["param"]
+
+        assert param["additionalProperties"] is False
+        assert param["properties"]["meta"]["additionalProperties"] is False
+
+    def test_input_schema_array_of_object_items_are_closed(self):
+        """list[<object>] item schemas must carry properties AND additionalProperties: false."""
+        mcp_tool = self._make_tool_with_param(
+            ValueSchema(
+                val_type="array",
+                inner_val_type="json",
+                inner_properties={
+                    "source": ValueSchema(val_type="string"),
+                    "filename": ValueSchema(val_type="string"),
+                },
+                inner_required_keys=["source"],
+            )
+        )
+        items = mcp_tool.inputSchema["properties"]["param"]["items"]
+
+        assert items["properties"].keys() == {"source", "filename"}
+        assert items["required"] == ["source"]
+        assert items["additionalProperties"] is False
+
+    def test_input_schema_open_dict_stays_open(self):
+        """A freeform dict (json with no properties) must stay open: closing it would reject
+        every key. additionalProperties: false applies only to objects with a known shape."""
+        mcp_tool = self._make_tool_with_param(ValueSchema(val_type="json"))
+        param = mcp_tool.inputSchema["properties"]["param"]
+
+        assert param["type"] == "object"
+        assert "properties" not in param
+        assert "additionalProperties" not in param
+
     @pytest.mark.parametrize(
         "val_type",
         ["string", "integer", "number", "boolean"],

--- a/libs/tests/arcade_mcp_server/test_convert.py
+++ b/libs/tests/arcade_mcp_server/test_convert.py
@@ -498,8 +498,8 @@ class TestCreateMCPTool:
         return create_mcp_tool(mat_tool)
 
     def test_input_schema_nested_object_is_closed(self):
-        """Objects with a known shape must set additionalProperties: false at every level, so
-        the schema is valid when an MCP host forwards it to OpenAI strict mode."""
+        """Objects with a known shape close at every level (additionalProperties: false),
+        because a known shape has a fixed set of keys."""
         inner = {
             "source": ValueSchema(val_type="string"),
             "meta": ValueSchema(
@@ -547,7 +547,7 @@ class TestCreateMCPTool:
 
     def test_input_schema_empty_object_is_closed(self):
         """An object with a known-empty shape (properties == {}) is closed: it carries
-        `properties: {}` and `additionalProperties: false`, valid under OpenAI strict mode."""
+        `properties: {}` and `additionalProperties: false`, the same as any known shape."""
         mcp_tool = self._make_tool_with_param(
             ValueSchema(val_type="json", properties={}, required_keys=[])
         )

--- a/libs/tests/arcade_mcp_server/test_schema_consistency.py
+++ b/libs/tests/arcade_mcp_server/test_schema_consistency.py
@@ -1,0 +1,115 @@
+"""Cross-converter guard: one tool, three schema dialects, one shared invariant.
+
+Arcade renders a tool's `ValueSchema` into JSON Schema in three independent places that have
+historically drifted into the same class of bug (incompletely-expanded nested objects):
+
+- ``to_openai``      -> OpenAI strict dialect (every object closed; ALL keys required; optionals nullable)
+- ``to_anthropic``   -> standard dialect (only actually-required keys; no ``additionalProperties``)
+- ``create_mcp_tool``-> MCP inputSchema (standard, but closed objects carry ``additionalProperties: false``)
+
+This builds a single realistic tool exercising a Pydantic-model param, a ``list[TypedDict]`` with a
+nested TypedDict, and optional/nullable fields, then asserts each dialect's invariant end-to-end
+(catalog -> converter). If any path regresses to bare ``{"type": "object"}`` items or forgets
+``additionalProperties`` on closed objects, exactly one of these tests fails.
+"""
+
+from typing import Annotated, Optional
+
+from arcade_core.catalog import ToolCatalog
+from arcade_core.converters.anthropic import to_anthropic
+from arcade_core.converters.openai import to_openai
+from arcade_mcp_server.convert import create_mcp_tool
+from arcade_tdk import tool
+from pydantic import BaseModel
+from typing_extensions import TypedDict
+
+
+class Recipient(BaseModel):
+    """An email recipient."""
+
+    email: str
+    name: Optional[str] = None
+
+
+class FileMeta(TypedDict):
+    """Metadata for an attachment."""
+
+    key: str
+    label: str
+
+
+class AttachmentTD(TypedDict):
+    """A file attachment with nested metadata."""
+
+    source: str
+    meta: FileMeta
+
+
+@tool(desc="Send an email with structured params")
+def send_email(
+    recipient: Annotated[Recipient, "Who to send to"],
+    attachments: Annotated[list[AttachmentTD], "Files to attach"],
+    subject: Annotated[Optional[str], "Subject line"] = None,
+) -> str:
+    return "sent"
+
+
+def _materialize():
+    catalog = ToolCatalog()
+    catalog.add_tool(send_email, "consistency")
+    return next(iter(catalog))
+
+
+def _assert_openai_strict(schema: dict) -> None:
+    """Recursively: every object subschema is closed and lists ALL its properties as required."""
+    types = schema["type"] if isinstance(schema.get("type"), list) else [schema.get("type")]
+    if "object" in types and "properties" in schema:
+        assert schema.get("additionalProperties") is False, schema
+        assert set(schema.get("required", [])) == set(schema["properties"]), schema
+        for sub in schema["properties"].values():
+            _assert_openai_strict(sub)
+    if "array" in types and isinstance(schema.get("items"), dict):
+        _assert_openai_strict(schema["items"])
+
+
+def test_openai_strict_invariant_holds_end_to_end():
+    params = to_openai(_materialize())["function"]["parameters"]
+    _assert_openai_strict(params)
+
+    recipient = params["properties"]["recipient"]
+    assert recipient["additionalProperties"] is False
+    assert set(recipient["required"]) == {"email", "name"}  # strict lists every key
+    assert recipient["properties"]["name"]["type"] == ["string", "null"]  # optional -> nullable
+
+    items = params["properties"]["attachments"]["items"]
+    assert items["additionalProperties"] is False
+    assert set(items["required"]) == {"source", "meta"}
+    assert items["properties"]["meta"]["additionalProperties"] is False
+
+
+def test_anthropic_standard_invariant_holds_end_to_end():
+    schema = to_anthropic(_materialize())["input_schema"]
+
+    recipient = schema["properties"]["recipient"]
+    assert recipient["properties"].keys() == {"email", "name"}
+    assert recipient["required"] == ["email"]  # only the actually-required field
+    assert "additionalProperties" not in recipient
+
+    items = schema["properties"]["attachments"]["items"]
+    assert items["required"] == ["meta", "source"]  # sorted required keys
+    assert items["properties"]["meta"]["required"] == ["key", "label"]
+    assert "additionalProperties" not in items
+
+
+def test_mcp_inputschema_closes_known_objects_end_to_end():
+    schema = create_mcp_tool(_materialize()).inputSchema
+
+    recipient = schema["properties"]["recipient"]
+    assert recipient["additionalProperties"] is False
+    assert recipient["required"] == ["email"]
+    assert recipient["properties"]["name"]["type"] == ["string", "null"]  # nullable optional
+
+    items = schema["properties"]["attachments"]["items"]
+    assert items["additionalProperties"] is False
+    assert items["required"] == ["meta", "source"]
+    assert items["properties"]["meta"]["additionalProperties"] is False

--- a/libs/tests/core/converters/test_anthropic.py
+++ b/libs/tests/core/converters/test_anthropic.py
@@ -473,6 +473,79 @@ class TestAnthropicConverter:
         assert result["input_schema"]["required"] == ["query"]
 
 
+class TestAnthropicNullableFields:
+    """Nullable nested fields must accept null in the standard-dialect schema."""
+
+    def test_required_nullable_nested_field_allows_null(self):
+        """A nested field that is required yet nullable (`str | None` with no default) must
+        stay in `required` while its type unions `null`, so a null value validates."""
+        param = InputParameter(
+            name="record",
+            required=True,
+            description="A record.",
+            value_schema=ValueSchema(
+                val_type="json",
+                properties={
+                    "name": ValueSchema(val_type="string"),
+                    "note": ValueSchema(val_type="string", nullable=True),
+                },
+                required_keys=["name", "note"],
+            ),
+        )
+
+        schema = _convert_input_parameters_to_json_schema([param])["properties"]["record"]
+
+        assert set(schema["required"]) == {"name", "note"}
+        assert schema["properties"]["name"]["type"] == "string"
+        assert schema["properties"]["note"]["type"] == ["string", "null"]
+
+    def test_nullable_nested_enum_field_allows_null_in_enum(self):
+        """A nullable nested enum field unions `null` into its type and appends `None` to enum."""
+        param = InputParameter(
+            name="record",
+            required=True,
+            description="A record.",
+            value_schema=ValueSchema(
+                val_type="json",
+                properties={
+                    "status": ValueSchema(
+                        val_type="string", enum=["open", "closed"], nullable=True
+                    ),
+                },
+                required_keys=["status"],
+            ),
+        )
+
+        schema = _convert_input_parameters_to_json_schema([param])["properties"]["record"]
+        status = schema["properties"]["status"]
+
+        assert status["type"] == ["string", "null"]
+        assert status["enum"] == ["open", "closed", None]
+
+    def test_required_nullable_nested_field_end_to_end(self):
+        """A Pydantic field typed `str | None` with no default is required and nullable;
+        Anthropic must emit it nullable rather than a bare single-type schema."""
+        from arcade_core.catalog import ToolCatalog
+        from arcade_tdk import tool
+        from pydantic import BaseModel
+
+        class Record(BaseModel):
+            name: str
+            note: str | None
+
+        @tool(desc="t")
+        def f(record: Annotated[Record, "record"]) -> str:
+            return ""
+
+        catalog = ToolCatalog()
+        catalog.add_tool(f, "endtoend")
+        mat_tool = next(iter(catalog))
+        schema = to_anthropic(mat_tool)["input_schema"]["properties"]["record"]
+
+        assert set(schema["required"]) == {"name", "note"}
+        assert schema["properties"]["note"]["type"] == ["string", "null"]
+
+
 class TestHelperFunctions:
     """Test helper functions used by the converter."""
 

--- a/libs/tests/core/converters/test_anthropic.py
+++ b/libs/tests/core/converters/test_anthropic.py
@@ -750,3 +750,56 @@ class TestAnthropicVsOpenAIDifferences:
         # OpenAI strict mode requires: "additionalProperties": false
         # Anthropic should NOT have this constraint
         assert "additionalProperties" not in result
+
+    def test_array_of_object_items_expand_item_fields(self):
+        """`list[<object>]` parameters expand the object's fields into the array `items`
+        schema. Anthropic uses standard JSON Schema, so only the actually-required fields
+        appear in `required` and optional fields keep a single (non-nullable) type."""
+        param = InputParameter(
+            name="attachments",
+            required=False,
+            description="Files to attach.",
+            value_schema=ValueSchema(
+                val_type="array",
+                inner_val_type="json",
+                inner_properties={
+                    "source": ValueSchema(val_type="string"),
+                    "filename": ValueSchema(val_type="string"),
+                    "mime_type": ValueSchema(val_type="string"),
+                },
+                inner_required_keys=["source"],
+            ),
+        )
+
+        items = _convert_input_parameters_to_json_schema([param])["properties"]["attachments"][
+            "items"
+        ]
+
+        assert items.get("properties", {}).keys() == {"source", "filename", "mime_type"}
+        assert items["required"] == ["source"]
+        assert items["properties"]["source"]["type"] == "string"
+        assert items["properties"]["filename"]["type"] == "string"
+        assert "additionalProperties" not in items
+
+    def test_object_param_includes_required_keys(self):
+        """A top-level object parameter lists only its actually-required fields in
+        `required` and adds no `additionalProperties` constraint."""
+        param = InputParameter(
+            name="recipient",
+            required=True,
+            description="Message recipient.",
+            value_schema=ValueSchema(
+                val_type="json",
+                properties={
+                    "email": ValueSchema(val_type="string"),
+                    "name": ValueSchema(val_type="string"),
+                },
+                required_keys=["email"],
+            ),
+        )
+
+        schema = _convert_input_parameters_to_json_schema([param])["properties"]["recipient"]
+
+        assert schema["required"] == ["email"]
+        assert "additionalProperties" not in schema
+        assert schema["properties"]["name"]["type"] == "string"

--- a/libs/tests/core/converters/test_anthropic.py
+++ b/libs/tests/core/converters/test_anthropic.py
@@ -876,3 +876,55 @@ class TestAnthropicVsOpenAIDifferences:
         assert schema["required"] == ["email"]
         assert "additionalProperties" not in schema
         assert schema["properties"]["name"]["type"] == "string"
+
+    def test_empty_object_param_is_object_with_empty_properties(self):
+        """An object with a known-empty shape (properties == {}) is emitted as a typed object
+        with empty `properties` and no `required` (no fields are required)."""
+        param = InputParameter(
+            name="cfg",
+            required=True,
+            description="Empty config.",
+            value_schema=ValueSchema(val_type="json", properties={}, required_keys=[]),
+        )
+
+        schema = _convert_input_parameters_to_json_schema([param])["properties"]["cfg"]
+
+        assert schema["type"] == "object"
+        assert schema["properties"] == {}
+        assert "required" not in schema
+
+    def test_array_of_empty_object_items_have_empty_properties(self):
+        """`list[<empty object>]` items are typed objects with empty `properties`."""
+        param = InputParameter(
+            name="items",
+            required=True,
+            description="Empty items.",
+            value_schema=ValueSchema(
+                val_type="array",
+                inner_val_type="json",
+                inner_properties={},
+                inner_required_keys=[],
+            ),
+        )
+
+        items = _convert_input_parameters_to_json_schema([param])["properties"]["items"]["items"]
+
+        assert items["type"] == "object"
+        assert items["properties"] == {}
+        assert "required" not in items
+
+    def test_freeform_dict_param_stays_open(self):
+        """A freeform dict (json with no properties, unknown shape) stays an open object: no
+        `properties` key and no `additionalProperties` constraint."""
+        param = InputParameter(
+            name="payload",
+            required=True,
+            description="Arbitrary JSON.",
+            value_schema=ValueSchema(val_type="json"),
+        )
+
+        schema = _convert_input_parameters_to_json_schema([param])["properties"]["payload"]
+
+        assert schema["type"] == "object"
+        assert "properties" not in schema
+        assert "additionalProperties" not in schema

--- a/libs/tests/core/converters/test_openai.py
+++ b/libs/tests/core/converters/test_openai.py
@@ -464,6 +464,136 @@ class TestOpenAIConverter:
         }
 
 
+class TestOpenAIStrictNullability:
+    """Strict-mode nullability for structured objects and optional enums."""
+
+    def test_object_with_empty_required_keys_makes_fields_nullable(self):
+        """An object whose required set is known-empty (all fields defaulted) must list every
+        field in `required` but render each as a nullable union so the model may omit it."""
+        param = InputParameter(
+            name="config",
+            required=True,
+            description="All-defaulted config.",
+            value_schema=ValueSchema(
+                val_type="json",
+                properties={
+                    "count": ValueSchema(val_type="integer"),
+                    "label": ValueSchema(val_type="string"),
+                },
+                required_keys=[],
+            ),
+        )
+
+        schema = _convert_input_parameters_to_json_schema([param])["properties"]["config"]
+
+        assert schema["additionalProperties"] is False
+        assert set(schema["required"]) == {"count", "label"}
+        assert schema["properties"]["count"]["type"] == ["integer", "null"]
+        assert schema["properties"]["label"]["type"] == ["string", "null"]
+
+    def test_freeform_dict_param_stays_open(self):
+        """A freeform dict (json with no properties and unknown shape) must stay open: no
+        `properties`, no `additionalProperties: false`, no forced `required`."""
+        param = InputParameter(
+            name="payload",
+            required=True,
+            description="Arbitrary JSON.",
+            value_schema=ValueSchema(val_type="json"),
+        )
+
+        schema = _convert_input_parameters_to_json_schema([param])["properties"]["payload"]
+
+        assert schema["type"] == "object"
+        assert "properties" not in schema
+        assert "additionalProperties" not in schema
+        assert "required" not in schema
+
+    def test_optional_enum_param_allows_null_in_enum(self):
+        """An optional enum param gets `null` in its type AND `None` appended to its enum, so
+        a null value satisfies both the type and enum assertions."""
+        param = InputParameter(
+            name="status",
+            required=False,
+            description="Status choice.",
+            value_schema=ValueSchema(val_type="string", enum=["open", "closed"]),
+        )
+
+        schema = _convert_input_parameters_to_json_schema([param])["properties"]["status"]
+
+        assert schema["type"] == ["string", "null"]
+        assert schema["enum"] == ["open", "closed", None]
+
+    def test_nullable_enum_nested_field_allows_null_in_enum(self):
+        """A nullable enum field inside an object gets `null` in type AND `None` in enum."""
+        param = InputParameter(
+            name="filter",
+            required=True,
+            description="Filter object.",
+            value_schema=ValueSchema(
+                val_type="json",
+                properties={
+                    "status": ValueSchema(
+                        val_type="string", enum=["open", "closed"], nullable=True
+                    ),
+                },
+                required_keys=["status"],
+            ),
+        )
+
+        schema = _convert_input_parameters_to_json_schema([param])["properties"]["filter"]
+        status = schema["properties"]["status"]
+
+        assert status["type"] == ["string", "null"]
+        assert status["enum"] == ["open", "closed", None]
+
+
+class TestOpenAIEndToEnd:
+    """Catalog-to-converter checks for structured params."""
+
+    def _to_openai_first_param(self, func, param_name):
+        from arcade_core.catalog import ToolCatalog
+
+        catalog = ToolCatalog()
+        catalog.add_tool(func, "endtoend")
+        mat_tool = next(iter(catalog))
+        return to_openai(mat_tool)["function"]["parameters"]["properties"][param_name]
+
+    def test_all_defaulted_pydantic_model_fields_not_forced(self):
+        """A Pydantic model whose fields all have defaults must not force a value for any field:
+        each field is rendered nullable even though its Python type is not `T | None`."""
+        from arcade_tdk import tool
+        from pydantic import BaseModel
+
+        class AllDefaulted(BaseModel):
+            count: int = 5
+            label: str = "x"
+
+        @tool(desc="t")
+        def f(cfg: Annotated[AllDefaulted, "cfg"]) -> str:
+            return ""
+
+        schema = self._to_openai_first_param(f, "cfg")
+
+        assert schema["additionalProperties"] is False
+        assert set(schema["required"]) == {"count", "label"}
+        assert schema["properties"]["count"]["type"] == ["integer", "null"]
+        assert schema["properties"]["label"]["type"] == ["string", "null"]
+
+    def test_freeform_dict_param_stays_open_end_to_end(self):
+        """A `dict` param has an unknown shape and must stay an open object."""
+        from arcade_tdk import tool
+
+        @tool(desc="t")
+        def f(payload: Annotated[dict, "payload"]) -> str:
+            return ""
+
+        schema = self._to_openai_first_param(f, "payload")
+
+        assert schema["type"] == "object"
+        assert "properties" not in schema
+        assert "additionalProperties" not in schema
+
+
 class TestHelperFunctions:
     """Test helper functions used by the converter."""
 

--- a/libs/tests/core/converters/test_openai.py
+++ b/libs/tests/core/converters/test_openai.py
@@ -547,6 +547,49 @@ class TestOpenAIStrictNullability:
         assert status["enum"] == ["open", "closed", None]
 
 
+class TestOpenAIStrictEmptyObjects:
+    """A known-empty object shape ({}) must close in strict mode; a freeform dict stays open."""
+
+    def test_empty_object_param_is_closed(self):
+        """An object with a known-empty shape (properties == {}) is emitted closed: it carries
+        `properties: {}`, `additionalProperties: false`, and an empty `required`."""
+        param = InputParameter(
+            name="cfg",
+            required=True,
+            description="Empty config.",
+            value_schema=ValueSchema(val_type="json", properties={}, required_keys=[]),
+        )
+
+        schema = _convert_input_parameters_to_json_schema([param])["properties"]["cfg"]
+
+        assert schema["type"] == "object"
+        assert schema["properties"] == {}
+        assert schema["additionalProperties"] is False
+        assert schema["required"] == []
+
+    def test_array_of_empty_object_items_are_closed(self):
+        """`list[<empty object>]` item schemas close the same way: `properties: {}`,
+        `additionalProperties: false`, empty `required`."""
+        param = InputParameter(
+            name="items",
+            required=True,
+            description="Empty items.",
+            value_schema=ValueSchema(
+                val_type="array",
+                inner_val_type="json",
+                inner_properties={},
+                inner_required_keys=[],
+            ),
+        )
+
+        items = _convert_input_parameters_to_json_schema([param])["properties"]["items"]["items"]
+
+        assert items["type"] == "object"
+        assert items["properties"] == {}
+        assert items["additionalProperties"] is False
+        assert items["required"] == []
+
+
 class TestOpenAIEndToEnd:
     """Catalog-to-converter checks for structured params."""
 
@@ -592,6 +635,63 @@ class TestOpenAIEndToEnd:
         assert schema["type"] == "object"
         assert "properties" not in schema
         assert "additionalProperties" not in schema
+
+    def test_zero_field_pydantic_model_param_is_closed_end_to_end(self):
+        """A zero-field Pydantic model has a known-empty shape and must close in strict mode."""
+        from arcade_tdk import tool
+        from pydantic import BaseModel
+
+        class EmptyModel(BaseModel):
+            pass
+
+        @tool(desc="t")
+        def f(cfg: Annotated[EmptyModel, "cfg"]) -> str:
+            return ""
+
+        schema = self._to_openai_first_param(f, "cfg")
+
+        assert schema["type"] == "object"
+        assert schema["properties"] == {}
+        assert schema["additionalProperties"] is False
+        assert schema["required"] == []
+
+    def test_empty_typeddict_param_is_closed_end_to_end(self):
+        """An empty TypedDict has a known-empty shape and must close in strict mode."""
+        from arcade_tdk import tool
+        from typing_extensions import TypedDict
+
+        class EmptyTD(TypedDict):
+            pass
+
+        @tool(desc="t")
+        def f(td: Annotated[EmptyTD, "td"]) -> str:
+            return ""
+
+        schema = self._to_openai_first_param(f, "td")
+
+        assert schema["type"] == "object"
+        assert schema["properties"] == {}
+        assert schema["additionalProperties"] is False
+        assert schema["required"] == []
+
+    def test_list_of_empty_model_items_are_closed_end_to_end(self):
+        """`list[<zero-field model>]` array items must close in strict mode."""
+        from arcade_tdk import tool
+        from pydantic import BaseModel
+
+        class EmptyModel(BaseModel):
+            pass
+
+        @tool(desc="t")
+        def f(items: Annotated[list[EmptyModel], "items"]) -> str:
+            return ""
+
+        items = self._to_openai_first_param(f, "items")["items"]
+
+        assert items["type"] == "object"
+        assert items["properties"] == {}
+        assert items["additionalProperties"] is False
+        assert items["required"] == []
 
 
 class TestHelperFunctions:

--- a/libs/tests/core/converters/test_openai.py
+++ b/libs/tests/core/converters/test_openai.py
@@ -545,3 +545,61 @@ class TestHelperFunctions:
 
         # Optional parameter should have union type with null
         assert result["properties"]["optional_param"]["type"] == ["integer", "null"]
+
+    def test_array_of_object_items_expand_item_fields(self):
+        """`list[<object>]` parameters expand the object's fields into the array `items`
+        schema. OpenAI strict mode requires every field in `required` and
+        `additionalProperties: false` on each item object; fields absent from
+        `inner_required_keys` are expressed as nullable unions so they may be omitted."""
+        param = InputParameter(
+            name="attachments",
+            required=False,
+            description="Files to attach.",
+            value_schema=ValueSchema(
+                val_type="array",
+                inner_val_type="json",
+                inner_properties={
+                    "source": ValueSchema(val_type="string"),
+                    "filename": ValueSchema(val_type="string"),
+                    "mime_type": ValueSchema(val_type="string"),
+                },
+                inner_required_keys=["source"],
+            ),
+        )
+
+        items = _convert_input_parameters_to_json_schema([param])["properties"]["attachments"][
+            "items"
+        ]
+
+        assert items.get("properties", {}).keys() == {"source", "filename", "mime_type"}
+        assert items["additionalProperties"] is False
+        assert set(items["required"]) == {"source", "filename", "mime_type"}
+        assert items["properties"]["source"]["type"] == "string"
+        assert items["properties"]["filename"]["type"] == ["string", "null"]
+        assert items["properties"]["mime_type"]["type"] == ["string", "null"]
+
+    def test_object_param_expands_with_strict_fields(self):
+        """A top-level (and nested) object parameter is a full strict-mode object: every
+        property in `required`, `additionalProperties: false`, and properties absent from
+        `required_keys` expressed as nullable unions."""
+        param = InputParameter(
+            name="recipient",
+            required=True,
+            description="Message recipient.",
+            value_schema=ValueSchema(
+                val_type="json",
+                properties={
+                    "email": ValueSchema(val_type="string"),
+                    "name": ValueSchema(val_type="string"),
+                },
+                required_keys=["email"],
+            ),
+        )
+
+        schema = _convert_input_parameters_to_json_schema([param])["properties"]["recipient"]
+
+        assert schema["type"] == "object"
+        assert schema["additionalProperties"] is False
+        assert set(schema["required"]) == {"email", "name"}
+        assert schema["properties"]["email"]["type"] == "string"
+        assert schema["properties"]["name"]["type"] == ["string", "null"]

--- a/libs/tests/tool/test_create_tool_definition_pydantic.py
+++ b/libs/tests/tool/test_create_tool_definition_pydantic.py
@@ -507,3 +507,30 @@ def test_nested_pydantic_required_keys_are_recursive():
     # `label` defaults, so the outer object only requires `variables`.
     assert vs.required_keys == ["variables"]
     assert vs.properties["variables"].required_keys == ["gene"]
+
+
+class AllDefaultedModel(BaseModel):
+    """A model where every field has a default."""
+
+    count: int = 5
+    label: str = "x"
+
+
+@tool(desc="Take an all-defaulted Pydantic model")
+def run_all_defaulted(cfg: Annotated[AllDefaultedModel, "Config"]) -> str:
+    return "ok"
+
+
+def test_pydantic_all_defaulted_has_empty_required_keys():
+    vs = _first_param_value_schema(run_all_defaulted)
+    # A structured model with no required fields is a known-empty required set, not an
+    # unknown shape: required_keys is an empty list, distinct from a freeform dict's None.
+    assert vs.required_keys == []
+
+
+def test_freeform_dict_has_none_required_keys():
+    from arcade_core.catalog import extract_properties
+
+    properties, required_keys = extract_properties(dict)
+    assert properties is None
+    assert required_keys is None

--- a/libs/tests/tool/test_create_tool_definition_pydantic.py
+++ b/libs/tests/tool/test_create_tool_definition_pydantic.py
@@ -211,6 +211,7 @@ def read_products(
                             "price": ValueSchema(val_type="integer", enum=None),
                             "stock_quantity": ValueSchema(val_type="integer", enum=None),
                         },
+                        required_keys=["price", "product_name", "stock_quantity"],
                     ),
                     available_modes=["value", "error"],
                     description="The product, price, and quantity",
@@ -379,6 +380,8 @@ def read_products(
                                                 val_type="integer", enum=None
                                             ),
                                         },
+                                        required_keys=["column", "greater_than"],
+                                        nullable=True,
                                     ),
                                     "highest_price": ValueSchema(
                                         val_type="json",
@@ -387,6 +390,8 @@ def read_products(
                                             "column": ValueSchema(val_type="string", enum=None),
                                             "price": ValueSchema(val_type="integer", enum=None),
                                         },
+                                        required_keys=["column", "price"],
+                                        nullable=True,
                                     ),
                                     "lowest_price": ValueSchema(
                                         val_type="json",
@@ -395,8 +400,11 @@ def read_products(
                                             "column": ValueSchema(val_type="string", enum=None),
                                             "price": ValueSchema(val_type="integer", enum=None),
                                         },
+                                        required_keys=["column", "price"],
+                                        nullable=True,
                                     ),
                                 },
+                                required_keys=["column", "query"],
                             ),
                         ),
                         InputParameter(
@@ -420,6 +428,7 @@ def read_products(
                             "price": ValueSchema(val_type="integer", enum=None),
                             "stock_quantity": ValueSchema(val_type="integer", enum=None),
                         },
+                        inner_required_keys=["price", "product_name", "stock_quantity"],
                     ),
                     available_modes=["value", "error"],
                     description="Data with the selected columns",
@@ -434,3 +443,67 @@ def test_create_tool_def_from_pydantic(func_under_test, expected_tool_def_fields
 
     for field, expected_value in expected_tool_def_fields.items():
         assert getattr(tool_def, field) == expected_value
+
+
+class QueryVariables(BaseModel):
+    """Variables for a single query."""
+
+    gene: str
+    organism: str = "human"
+    limit: int | None = None
+
+
+class BatchRequest(BaseModel):
+    """A batch request wrapping query variables."""
+
+    variables: QueryVariables
+    label: str | None = None
+
+
+@tool(desc="Run a query with Pydantic-model variables")
+def run_query(variables: Annotated[QueryVariables, "The query variables"]) -> str:
+    return "ok"
+
+
+@tool(desc="Run a batch of queries (list of Pydantic models)")
+def run_batch(variables_list: Annotated[list[QueryVariables], "Variables per query"]) -> str:
+    return "ok"
+
+
+@tool(desc="Run a query with a nested Pydantic model")
+def run_nested(request: Annotated[BatchRequest, "The batch request"]) -> str:
+    return "ok"
+
+
+def _first_param_value_schema(func):
+    return ToolCatalog.create_tool_definition(func, "1.0").input.parameters[0].value_schema
+
+
+def test_pydantic_required_keys_excludes_defaulted_fields():
+    vs = _first_param_value_schema(run_query)
+    assert vs.val_type == "json"
+    assert set(vs.properties.keys()) == {"gene", "organism", "limit"}
+    # Only `gene` lacks a default; `organism` and `limit` default, so are not required.
+    assert vs.required_keys == ["gene"]
+
+
+def test_pydantic_optional_field_is_nullable():
+    vs = _first_param_value_schema(run_query)
+    assert vs.properties["limit"].nullable is True
+    assert vs.properties["gene"].nullable is None
+    assert vs.properties["organism"].nullable is None
+
+
+def test_list_of_pydantic_carries_inner_required_keys():
+    vs = _first_param_value_schema(run_batch)
+    assert vs.val_type == "array"
+    assert vs.inner_val_type == "json"
+    assert vs.inner_required_keys == ["gene"]
+    assert vs.inner_properties["limit"].nullable is True
+
+
+def test_nested_pydantic_required_keys_are_recursive():
+    vs = _first_param_value_schema(run_nested)
+    # `label` defaults, so the outer object only requires `variables`.
+    assert vs.required_keys == ["variables"]
+    assert vs.properties["variables"].required_keys == ["gene"]

--- a/libs/tests/tool/test_create_tool_definition_pydantic.py
+++ b/libs/tests/tool/test_create_tool_definition_pydantic.py
@@ -534,3 +534,28 @@ def test_freeform_dict_has_none_required_keys():
     properties, required_keys = extract_properties(dict)
     assert properties is None
     assert required_keys is None
+
+
+class EmptyModel(BaseModel):
+    """A model that declares no fields."""
+
+
+@tool(desc="Take a zero-field Pydantic model")
+def run_empty_model(cfg: Annotated[EmptyModel, "Config"]) -> str:
+    return "ok"
+
+
+def test_zero_field_pydantic_model_extract_properties_is_known_empty():
+    from arcade_core.catalog import extract_properties
+
+    properties, required_keys = extract_properties(EmptyModel)
+    # A zero-field model has a known-empty shape ({}, []), distinct from a freeform dict's
+    # unknown shape (None, None), so converters can emit it as a closed object.
+    assert properties == {}
+    assert required_keys == []
+
+
+def test_zero_field_pydantic_model_value_schema_has_empty_properties():
+    vs = _first_param_value_schema(run_empty_model)
+    assert vs.properties == {}
+    assert vs.required_keys == []

--- a/libs/tests/tool/test_create_tool_definition_typeddict.py
+++ b/libs/tests/tool/test_create_tool_definition_typeddict.py
@@ -285,6 +285,7 @@ def func_returns_nested_typedicts() -> Annotated[CustomerDict, "Customer informa
                             "description": ValueSchema(val_type="string", enum=None),
                             "price": ValueSchema(val_type="integer", enum=None),
                         },
+                        required_keys=[],
                     ),
                     available_modes=["value", "error"],
                     description="Product info with optional fields",
@@ -328,3 +329,22 @@ def test_create_tool_def_from_typeddict(func_under_test, expected_tool_def_field
 
     for field, expected_value in expected_tool_def_fields.items():
         assert getattr(tool_def, field) == expected_value
+
+
+class AllOptionalDict(TypedDict, total=False):
+    """A TypedDict where every field is optional."""
+
+    name: str
+    count: int
+
+
+@tool(desc="Take an all-optional TypedDict")
+def run_all_optional_td(cfg: Annotated[AllOptionalDict, "Config"]) -> str:
+    return "ok"
+
+
+def test_typeddict_all_optional_has_empty_required_keys():
+    vs = ToolCatalog.create_tool_definition(run_all_optional_td, "1.0").input.parameters[0].value_schema
+    # total=False with no required keys is a known-empty required set (empty list), distinct
+    # from a freeform dict whose shape is unknown (None).
+    assert vs.required_keys == []

--- a/libs/tests/tool/test_create_tool_definition_typeddict.py
+++ b/libs/tests/tool/test_create_tool_definition_typeddict.py
@@ -348,3 +348,28 @@ def test_typeddict_all_optional_has_empty_required_keys():
     # total=False with no required keys is a known-empty required set (empty list), distinct
     # from a freeform dict whose shape is unknown (None).
     assert vs.required_keys == []
+
+
+class EmptyDict(TypedDict):
+    """A TypedDict that declares no fields."""
+
+
+@tool(desc="Take an empty TypedDict")
+def run_empty_td(cfg: Annotated[EmptyDict, "Config"]) -> str:
+    return "ok"
+
+
+def test_empty_typeddict_extract_properties_is_known_empty():
+    from arcade_core.catalog import extract_properties
+
+    properties, required_keys = extract_properties(EmptyDict)
+    # An empty TypedDict has a known-empty shape ({}, []), distinct from a freeform dict's
+    # unknown shape (None, None), so converters can emit it as a closed object.
+    assert properties == {}
+    assert required_keys == []
+
+
+def test_empty_typeddict_value_schema_has_empty_properties():
+    vs = ToolCatalog.create_tool_definition(run_empty_td, "1.0").input.parameters[0].value_schema
+    assert vs.properties == {}
+    assert vs.required_keys == []


### PR DESCRIPTION
## Summary

Arcade renders a tool's `ValueSchema` into JSON Schema in three independent places, and they had drifted into the same class of bug: nested object subschemas (especially `list[<TypedDict>]` items) were emitted incompletely, producing OpenAI-strict-invalid schemas that the OpenAI Responses API rejects with a hard 400. Because OpenAI rejects the whole tool list when one schema is invalid, every eval/tool batch containing that tool fails.

This PR fixes all three converter paths and the shared root cause they all read from, so correct schemas come from one corrected source rather than per-converter patches.

Resolves: https://linear.app/arcadedev/issue/TOO-990/arcade-core-tool-schema-converters-drop-nested-object-fields-for

## What was wrong (three layers)

1. **`arcade_core/converters/openai.py`** (OpenAI strict) and **`anthropic.py`** (standard) built array `items` from the inner scalar type alone, emitting bare `{"type": "object"}` and dropping object fields. OpenAI strict also requires `additionalProperties: false` + every key in `required` on each object.
2. **`arcade_mcp_server/convert.py`** (MCP `inputSchema`) preserved nested properties/required but never set `additionalProperties: false` on nested objects or array-of-object items (only the top-level wrapper did). This is the path consumers monkey-patch when feeding MCP tool schemas to OpenAI strict mode.
3. **`arcade_core/catalog.py::extract_properties`** extracted `required_keys`/`nullable` for **TypedDict** params but not for **Pydantic** models, so every converter received imprecise data for Pydantic object params (no `required`, no nullability).

## Changes

- **OpenAI + Anthropic converters** (commit 1): expand every object recursively at any depth (top-level param, nested object, array-of-object items). OpenAI strict closes every object (`additionalProperties: false`), lists all keys in `required`, and renders optionals as nullable unions; Anthropic uses standard JSON Schema (only required keys).
- **MCP converter** (commit 2): set `additionalProperties: false` on objects with a known shape, at every depth. Freeform `dict` params (no properties) stay open, since closing them would reject all keys.
- **Root cause** (commit 2): `extract_properties` now populates `required_keys` for Pydantic models via `FieldInfo.is_required()` and marks `nullable` on `Optional` fields, matching the existing TypedDict handling. All three converters get accurate metadata from one place.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared schema extraction and all three tool-schema emitters, which can alter API/MCP validation behavior for nested Pydantic/TypedDict params; mitigated by extensive new tests but still user-visible for existing tools.
> 
> **Overview**
> Fixes **incomplete nested object JSON Schema** for tool inputs so OpenAI strict, Anthropic, and MCP paths stay aligned and OpenAI no longer 400s on invalid tool lists.
> 
> **`arcade_core/catalog`:** Pydantic params now get **`required_keys`** and **`nullable`** like TypedDict; known shapes use **`({}, [])`** instead of collapsing to `None`, so empty/zero-field models differ from freeform **`dict`**. List and **`ValueSchema`** conversion propagate nested shapes when **`properties` / `inner_properties` is not `None`**.
> 
> **OpenAI & Anthropic converters:** Shared **`_build_object_schema`** recursively expands **`json`** and **`list[object]`** items (no more bare **`{"type": "object"}`**). OpenAI strict closes objects, lists all keys in **`required`**, and uses **`null`** unions (including enums); Anthropic lists only real required keys and unions **`null`** on nullable nested fields.
> 
> **MCP `convert`:** Known-shape objects and array-of-object items get **`additionalProperties: false`** at every depth; unknown **`dict`** shapes stay open.
> 
> Bumps **`arcade-core` 4.7.3** and **`arcade-mcp-server` 1.22.2** with broad converter/catalog tests plus a cross-dialect consistency test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46dee1d08e0421e1fe06e375ba300b4a50d57594. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->