### PR TITLE
feat(arcade-serve): optional pluggable telemetry library integration

### DIFF
--- a/libs/arcade-mcp-server/arcade_mcp_server/worker.py
+++ b/libs/arcade-mcp-server/arcade_mcp_server/worker.py
@@ -18,6 +18,7 @@ from arcade_core.catalog import ToolCatalog
 from arcade_core.discovery import discover_tools
 from arcade_core.toolkit import ToolkitLoadError
 from arcade_serve.fastapi import FastAPIWorker, TaskTrackerMiddleware
+from arcade_serve.fastapi import _arcade_telemetry as _arcade_telemetry_bridge
 from arcade_serve.fastapi.telemetry import OTELHandler
 from fastapi import FastAPI
 from loguru import logger
@@ -159,6 +160,8 @@ def create_arcade_mcp(
     otel_handler = OTELHandler(
         enable=otel_enable,
         log_level=logging.DEBUG if debug else logging.INFO,
+        service_name=mcp_settings.server.name or "worker",
+        service_version=mcp_settings.server.version or "",
     )
 
     @asynccontextmanager
@@ -195,6 +198,10 @@ def create_arcade_mcp(
         lifespan=lifespan,
     )
     otel_handler.instrument_app(app)
+
+    _correlation_mw = _arcade_telemetry_bridge.correlation_middleware_cls()
+    if _correlation_mw is not None:
+        app.add_middleware(_correlation_mw)  # type: ignore[arg-type]
 
     task_tracker = TaskTrackerMiddleware(app)
     app.state.task_tracker = task_tracker

--- a/libs/arcade-mcp-server/arcade_mcp_server/worker.py
+++ b/libs/arcade-mcp-server/arcade_mcp_server/worker.py
@@ -199,11 +199,6 @@ def create_arcade_mcp(
     )
     otel_handler.instrument_app(app)
 
-    if otel_enable:
-        _correlation_mw = _arcade_telemetry_bridge.correlation_middleware_cls()
-        if _correlation_mw is not None:
-            app.add_middleware(_correlation_mw)  # type: ignore[arg-type]
-
     task_tracker = TaskTrackerMiddleware(app)
     app.state.task_tracker = task_tracker
 
@@ -215,6 +210,16 @@ def create_arcade_mcp(
         return await task_tracker.dispatch(request, call_next)
 
     app.add_middleware(AddTrailingSlashToPathMiddleware)
+
+    # Register CorrelationMiddleware last so it lands outermost in the
+    # Starlette stack — `add_middleware` order is innermost-first, so the
+    # final call wraps everything else. This ensures every other middleware
+    # (task tracker, trailing-slash, auth) runs with the X-Request-Id
+    # contextvar already populated.
+    if otel_enable:
+        _correlation_mw = _arcade_telemetry_bridge.correlation_middleware_cls()
+        if _correlation_mw is not None:
+            app.add_middleware(_correlation_mw)  # type: ignore[arg-type]
 
     # Add OAuth discovery endpoint if auth is enabled
     if resource_server_validator and resource_server_validator.supports_oauth_discovery():

--- a/libs/arcade-mcp-server/arcade_mcp_server/worker.py
+++ b/libs/arcade-mcp-server/arcade_mcp_server/worker.py
@@ -160,8 +160,8 @@ def create_arcade_mcp(
     otel_handler = OTELHandler(
         enable=otel_enable,
         log_level=logging.DEBUG if debug else logging.INFO,
-        service_name=mcp_settings.server.name or "worker",
-        service_version=mcp_settings.server.version or "",
+        service_name=mcp_settings.server.name,
+        service_version=mcp_settings.server.version,
     )
 
     @asynccontextmanager

--- a/libs/arcade-mcp-server/arcade_mcp_server/worker.py
+++ b/libs/arcade-mcp-server/arcade_mcp_server/worker.py
@@ -199,9 +199,10 @@ def create_arcade_mcp(
     )
     otel_handler.instrument_app(app)
 
-    _correlation_mw = _arcade_telemetry_bridge.correlation_middleware_cls()
-    if _correlation_mw is not None:
-        app.add_middleware(_correlation_mw)  # type: ignore[arg-type]
+    if otel_enable:
+        _correlation_mw = _arcade_telemetry_bridge.correlation_middleware_cls()
+        if _correlation_mw is not None:
+            app.add_middleware(_correlation_mw)  # type: ignore[arg-type]
 
     task_tracker = TaskTrackerMiddleware(app)
     app.state.task_tracker = task_tracker

--- a/libs/arcade-serve/arcade_serve/fastapi/_arcade_telemetry.py
+++ b/libs/arcade-serve/arcade_serve/fastapi/_arcade_telemetry.py
@@ -58,6 +58,36 @@ def init_providers(
     )
 
 
+def install_loguru_integration(
+    *,
+    service_name: str,
+    environment: str,
+    version: str,
+    log_format: str = "json",
+    log_level: str | int = "INFO",
+) -> bool:
+    """Thin wrapper around ``arcade_telemetry.loguru.install_loguru_integration``.
+
+    Returns True if arcade-telemetry (with its ``loguru`` extra) is installed
+    and the integration was wired; False if either is absent, in which case
+    arcade-serve leaves loguru on its default ANSI stdout sink.
+    """
+    module = _try_import(f"{_TELEMETRY_MODULE}.loguru")
+    if module is None:
+        return False
+    fn = getattr(module, "install_loguru_integration", None)
+    if fn is None:
+        return False
+    fn(
+        service=service_name,
+        environment=environment,
+        version=version,
+        log_format=log_format,
+        log_level=log_level,
+    )
+    return True
+
+
 def correlation_middleware_cls() -> type | None:
     """Return arcade-telemetry's ASGI CorrelationMiddleware class, or None."""
     module = _try_import(_STARLETTE_MODULE)

--- a/libs/arcade-serve/arcade_serve/fastapi/_arcade_telemetry.py
+++ b/libs/arcade-serve/arcade_serve/fastapi/_arcade_telemetry.py
@@ -57,6 +57,11 @@ def init_providers(
         version=version,
         log_level=log_level,
     )
+    if tel is None:
+        # arcade-telemetry opted out (e.g. all signals routed to NONE) — skip
+        # the loguru bridge too, otherwise OTELHandler's fallthrough to the
+        # in-house OTLP path would attach loguru AND stdlib handlers.
+        return None
     loguru_module = _try_import(f"{_TELEMETRY_MODULE}.loguru")
     if loguru_module is not None:
         loguru_module.install_loguru_integration(

--- a/libs/arcade-serve/arcade_serve/fastapi/_arcade_telemetry.py
+++ b/libs/arcade-serve/arcade_serve/fastapi/_arcade_telemetry.py
@@ -1,0 +1,78 @@
+"""Optional bridge to the ``arcade-telemetry`` library.
+
+When ``arcade-telemetry`` is installed alongside ``arcade-serve``, the OTel
+tracer/meter/logger providers are set up by ``arcade_telemetry.new_telemetry``
+instead of ``OTELHandler``'s built-in OTLP exporters. ``OTELHandler`` still
+attaches the FastAPI / HTTPX / aiohttp / Requests auto-instrumentors against
+whatever the global providers happen to be, so spans flow through the
+arcade-telemetry pipeline.
+
+When ``arcade-telemetry`` is not installed, every helper here is a no-op and
+``OTELHandler`` runs its original code path.
+"""
+
+from __future__ import annotations
+
+import importlib
+from typing import Any
+
+_TELEMETRY_MODULE = "arcade_telemetry"
+_STARLETTE_MODULE = "arcade_telemetry.starlette"
+
+
+def _try_import(module_name: str) -> Any | None:
+    try:
+        return importlib.import_module(module_name)
+    except ImportError:
+        return None
+
+
+def is_available() -> bool:
+    """Return True iff ``arcade_telemetry`` can be imported."""
+    return _try_import(_TELEMETRY_MODULE) is not None
+
+
+def init_providers(
+    *,
+    service_name: str,
+    environment: str,
+    version: str,
+    log_level: int,
+) -> Any | None:
+    """Initialize global OTel providers via arcade-telemetry.
+
+    Returns the arcade-telemetry ``Telemetry`` handle on success, or ``None``
+    if arcade-telemetry is not installed. Callers should treat ``None`` as "do
+    the OTELHandler in-house setup instead". The return type is intentionally
+    ``Any`` so this module doesn't pull arcade-telemetry types into the
+    public arcade-serve API.
+    """
+    module = _try_import(_TELEMETRY_MODULE)
+    if module is None:
+        return None
+    return module.new_telemetry(
+        service_name=service_name,
+        environment=environment,
+        version=version,
+        log_level=log_level,
+    )
+
+
+def correlation_middleware_cls() -> type | None:
+    """Return arcade-telemetry's ASGI CorrelationMiddleware class, or None."""
+    module = _try_import(_STARLETTE_MODULE)
+    if module is None:
+        return None
+    cls = getattr(module, "CorrelationMiddleware", None)
+    if not isinstance(cls, type):
+        return None
+    return cls
+
+
+def shutdown(handle: Any | None) -> None:
+    """Best-effort shutdown of an arcade-telemetry handle."""
+    if handle is None:
+        return
+    shutdown_fn = getattr(handle, "shutdown", None)
+    if callable(shutdown_fn):
+        shutdown_fn()

--- a/libs/arcade-serve/arcade_serve/fastapi/_arcade_telemetry.py
+++ b/libs/arcade-serve/arcade_serve/fastapi/_arcade_telemetry.py
@@ -38,7 +38,6 @@ def init_providers(
     environment: str,
     version: str,
     log_level: int,
-    log_format: str = "json",
 ) -> Any | None:
     """Initialize global OTel providers via arcade-telemetry, and wire the
     loguru → OTLP bridge if ``arcade_telemetry.loguru`` is importable.
@@ -48,6 +47,11 @@ def init_providers(
     the OTELHandler in-house setup instead". The return type is intentionally
     ``Any`` so this module doesn't pull arcade-telemetry types into the
     public arcade-serve API.
+
+    ``log_format``/``max_bytes``/``destination`` are intentionally not
+    threaded through — ``install_loguru_integration`` reads each from
+    ``Config.from_env()`` when omitted, so ``ARCADE_TELEMETRY_LOG_FORMAT``
+    etc. flow through without arcade-serve duplicating the env binding.
     """
     module = _try_import(_TELEMETRY_MODULE)
     if module is None:
@@ -64,7 +68,6 @@ def init_providers(
             service=service_name,
             environment=environment,
             version=version,
-            log_format=log_format,
             log_level=log_level,
         )
     return tel

--- a/libs/arcade-serve/arcade_serve/fastapi/_arcade_telemetry.py
+++ b/libs/arcade-serve/arcade_serve/fastapi/_arcade_telemetry.py
@@ -47,11 +47,6 @@ def init_providers(
     the OTELHandler in-house setup instead". The return type is intentionally
     ``Any`` so this module doesn't pull arcade-telemetry types into the
     public arcade-serve API.
-
-    ``log_format``/``max_bytes``/``destination`` are intentionally not
-    threaded through — ``install_loguru_integration`` reads each from
-    ``Config.from_env()`` when omitted, so ``ARCADE_TELEMETRY_LOG_FORMAT``
-    etc. flow through without arcade-serve duplicating the env binding.
     """
     module = _try_import(_TELEMETRY_MODULE)
     if module is None:

--- a/libs/arcade-serve/arcade_serve/fastapi/_arcade_telemetry.py
+++ b/libs/arcade-serve/arcade_serve/fastapi/_arcade_telemetry.py
@@ -38,8 +38,10 @@ def init_providers(
     environment: str,
     version: str,
     log_level: int,
+    log_format: str = "json",
 ) -> Any | None:
-    """Initialize global OTel providers via arcade-telemetry.
+    """Initialize global OTel providers via arcade-telemetry, and wire the
+    loguru → OTLP bridge if ``arcade_telemetry.loguru`` is importable.
 
     Returns the arcade-telemetry ``Telemetry`` handle on success, or ``None``
     if arcade-telemetry is not installed. Callers should treat ``None`` as "do
@@ -50,42 +52,22 @@ def init_providers(
     module = _try_import(_TELEMETRY_MODULE)
     if module is None:
         return None
-    return module.new_telemetry(
+    tel = module.new_telemetry(
         service_name=service_name,
         environment=environment,
         version=version,
         log_level=log_level,
     )
-
-
-def install_loguru_integration(
-    *,
-    service_name: str,
-    environment: str,
-    version: str,
-    log_format: str = "json",
-    log_level: str | int = "INFO",
-) -> bool:
-    """Thin wrapper around ``arcade_telemetry.loguru.install_loguru_integration``.
-
-    Returns True if arcade-telemetry (with its ``loguru`` extra) is installed
-    and the integration was wired; False if either is absent, in which case
-    arcade-serve leaves loguru on its default ANSI stdout sink.
-    """
-    module = _try_import(f"{_TELEMETRY_MODULE}.loguru")
-    if module is None:
-        return False
-    fn = getattr(module, "install_loguru_integration", None)
-    if fn is None:
-        return False
-    fn(
-        service=service_name,
-        environment=environment,
-        version=version,
-        log_format=log_format,
-        log_level=log_level,
-    )
-    return True
+    loguru_module = _try_import(f"{_TELEMETRY_MODULE}.loguru")
+    if loguru_module is not None:
+        loguru_module.install_loguru_integration(
+            service=service_name,
+            environment=environment,
+            version=version,
+            log_format=log_format,
+            log_level=log_level,
+        )
+    return tel
 
 
 def correlation_middleware_cls() -> type | None:

--- a/libs/arcade-serve/arcade_serve/fastapi/telemetry.py
+++ b/libs/arcade-serve/arcade_serve/fastapi/telemetry.py
@@ -2,7 +2,7 @@ import logging
 import os
 import urllib.parse
 import warnings
-from typing import Literal, Optional
+from typing import Any, Literal, Optional
 
 # requests scans the environment for chardet at import time and emits a
 # RequestsDependencyWarning when chardet>=6 is present (e.g. pulled in by tox).
@@ -34,6 +34,8 @@ from opentelemetry.sdk.trace.export import BatchSpanProcessor
 from opentelemetry.semconv._incubating.attributes import deployment_attributes
 from opentelemetry.semconv.attributes import service_attributes
 
+from arcade_serve.fastapi import _arcade_telemetry
+
 EXCLUDED_URLS = "/worker/health"
 EXCLUDED_SPANS: list[Literal["send", "receive"]] = ["send", "receive"]
 
@@ -43,9 +45,18 @@ class ShutdownError(Exception):
 
 
 class OTELHandler:
-    def __init__(self, enable: bool = True, log_level: int = logging.INFO):
+    def __init__(
+        self,
+        enable: bool = True,
+        log_level: int = logging.INFO,
+        *,
+        service_name: str = "worker",
+        service_version: str = "",
+    ):
         self.enable = enable
         self.log_level = log_level
+        self.service_name = service_name
+        self.service_version = service_version
         self._tracer_provider: Optional[TracerProvider] = None
         self._tracer_span_exporter: Optional[OTLPSpanExporter] = None
         self._meter_provider: Optional[MeterProvider] = None
@@ -53,29 +64,52 @@ class OTELHandler:
         self._otlp_metric_exporter: Optional[OTLPMetricExporter] = None
         self._logger_provider: Optional[LoggerProvider] = None
         self._log_processor: Optional[BatchLogRecordProcessor] = None
+        self._arcade_telemetry_handle: Optional[Any] = None
         self.environment = os.environ.get("ARCADE_ENVIRONMENT", "local")
 
     def instrument_app(self, app: FastAPI) -> None:
-        if self.enable:
-            logging.info(
-                "🔎 Initializing OpenTelemetry. Use environment variables to configure the connection"
-            )
-            self.resource = Resource(
-                attributes={
-                    service_attributes.SERVICE_NAME: "worker",
-                    deployment_attributes.DEPLOYMENT_ENVIRONMENT_NAME: self.environment,
-                }
-            )
+        if not self.enable:
+            return
 
-            self._init_tracer()
-            self._init_metrics()
-            self._init_logging(self.log_level)
+        if _arcade_telemetry.is_available():
+            logging.info(
+                "🔎 Initializing OpenTelemetry via arcade-telemetry (Sentry + request correlation)"
+            )
+            self._arcade_telemetry_handle = _arcade_telemetry.init_providers(
+                service_name=self.service_name,
+                environment=self.environment,
+                version=self.service_version,
+                log_level=self.log_level,
+            )
             FastAPIInstrumentor().instrument_app(
                 app, excluded_urls=EXCLUDED_URLS, exclude_spans=EXCLUDED_SPANS
             )
-            HTTPXClientInstrumentor()._instrument(tracer_provider=self._tracer_provider)
-            AioHttpClientInstrumentor()._instrument(tracer_provider=self._tracer_provider)
-            RequestsInstrumentor()._instrument(tracer_provider=self._tracer_provider)
+            # Pass tracer_provider=None so instrumentors pick up the global
+            # provider set by arcade-telemetry.
+            HTTPXClientInstrumentor()._instrument(tracer_provider=None)
+            AioHttpClientInstrumentor()._instrument(tracer_provider=None)
+            RequestsInstrumentor()._instrument(tracer_provider=None)
+            return
+
+        logging.info(
+            "🔎 Initializing OpenTelemetry. Use environment variables to configure the connection"
+        )
+        self.resource = Resource(
+            attributes={
+                service_attributes.SERVICE_NAME: self.service_name,
+                deployment_attributes.DEPLOYMENT_ENVIRONMENT_NAME: self.environment,
+            }
+        )
+
+        self._init_tracer()
+        self._init_metrics()
+        self._init_logging(self.log_level)
+        FastAPIInstrumentor().instrument_app(
+            app, excluded_urls=EXCLUDED_URLS, exclude_spans=EXCLUDED_SPANS
+        )
+        HTTPXClientInstrumentor()._instrument(tracer_provider=self._tracer_provider)
+        AioHttpClientInstrumentor()._instrument(tracer_provider=self._tracer_provider)
+        RequestsInstrumentor()._instrument(tracer_provider=self._tracer_provider)
 
     def _init_tracer(self) -> None:
         self._tracer_provider = TracerProvider(resource=self.resource)
@@ -152,6 +186,10 @@ class OTELHandler:
         self._logger_provider.shutdown()
 
     def shutdown(self) -> None:
+        if self._arcade_telemetry_handle is not None:
+            _arcade_telemetry.shutdown(self._arcade_telemetry_handle)
+            self._arcade_telemetry_handle = None
+            return
         self._shutdown_tracer()
         self._shutdown_metrics()
         self._shutdown_logging()

--- a/libs/arcade-serve/arcade_serve/fastapi/telemetry.py
+++ b/libs/arcade-serve/arcade_serve/fastapi/telemetry.py
@@ -72,9 +72,7 @@ class OTELHandler:
             return
 
         if _arcade_telemetry.is_available():
-            logging.info(
-                "🔎 Initializing OpenTelemetry via arcade-telemetry (Sentry + request correlation)"
-            )
+            logging.info("🔎 Initializing OpenTelemetry via arcade-telemetry")
             self._arcade_telemetry_handle = _arcade_telemetry.init_providers(
                 service_name=self.service_name,
                 environment=self.environment,

--- a/libs/arcade-serve/arcade_serve/fastapi/telemetry.py
+++ b/libs/arcade-serve/arcade_serve/fastapi/telemetry.py
@@ -80,16 +80,8 @@ class OTELHandler:
                 environment=self.environment,
                 version=self.service_version,
                 log_level=self.log_level,
+                log_format=os.environ.get("ARCADE_TELEMETRY_LOG_FORMAT", "json"),
             )
-            log_format = os.environ.get("ARCADE_TELEMETRY_LOG_FORMAT", "json")
-            if _arcade_telemetry.install_loguru_integration(
-                service_name=self.service_name,
-                environment=self.environment,
-                version=self.service_version,
-                log_format=log_format,
-                log_level=self.log_level,
-            ):
-                logging.info("🔎 arcade-telemetry loguru sink installed (format=%s)", log_format)
             FastAPIInstrumentor().instrument_app(
                 app, excluded_urls=EXCLUDED_URLS, exclude_spans=EXCLUDED_SPANS
             )

--- a/libs/arcade-serve/arcade_serve/fastapi/telemetry.py
+++ b/libs/arcade-serve/arcade_serve/fastapi/telemetry.py
@@ -94,12 +94,13 @@ class OTELHandler:
         logging.info(
             "🔎 Initializing OpenTelemetry. Use environment variables to configure the connection"
         )
-        self.resource = Resource(
-            attributes={
-                service_attributes.SERVICE_NAME: self.service_name,
-                deployment_attributes.DEPLOYMENT_ENVIRONMENT_NAME: self.environment,
-            }
-        )
+        resource_attrs: dict[str, str] = {
+            service_attributes.SERVICE_NAME: self.service_name,
+            deployment_attributes.DEPLOYMENT_ENVIRONMENT_NAME: self.environment,
+        }
+        if self.service_version:
+            resource_attrs[service_attributes.SERVICE_VERSION] = self.service_version
+        self.resource = Resource(attributes=resource_attrs)
 
         self._init_tracer()
         self._init_metrics()

--- a/libs/arcade-serve/arcade_serve/fastapi/telemetry.py
+++ b/libs/arcade-serve/arcade_serve/fastapi/telemetry.py
@@ -81,6 +81,15 @@ class OTELHandler:
                 version=self.service_version,
                 log_level=self.log_level,
             )
+            log_format = os.environ.get("ARCADE_TELEMETRY_LOG_FORMAT", "json")
+            if _arcade_telemetry.install_loguru_integration(
+                service_name=self.service_name,
+                environment=self.environment,
+                version=self.service_version,
+                log_format=log_format,
+                log_level=self.log_level,
+            ):
+                logging.info("🔎 arcade-telemetry loguru sink installed (format=%s)", log_format)
             FastAPIInstrumentor().instrument_app(
                 app, excluded_urls=EXCLUDED_URLS, exclude_spans=EXCLUDED_SPANS
             )

--- a/libs/arcade-serve/arcade_serve/fastapi/telemetry.py
+++ b/libs/arcade-serve/arcade_serve/fastapi/telemetry.py
@@ -80,7 +80,6 @@ class OTELHandler:
                 environment=self.environment,
                 version=self.service_version,
                 log_level=self.log_level,
-                log_format=os.environ.get("ARCADE_TELEMETRY_LOG_FORMAT", "json"),
             )
             FastAPIInstrumentor().instrument_app(
                 app, excluded_urls=EXCLUDED_URLS, exclude_spans=EXCLUDED_SPANS

--- a/libs/arcade-serve/arcade_serve/fastapi/telemetry.py
+++ b/libs/arcade-serve/arcade_serve/fastapi/telemetry.py
@@ -73,21 +73,26 @@ class OTELHandler:
 
         if _arcade_telemetry.is_available():
             logging.info("🔎 Initializing OpenTelemetry via arcade-telemetry")
-            self._arcade_telemetry_handle = _arcade_telemetry.init_providers(
+            handle = _arcade_telemetry.init_providers(
                 service_name=self.service_name,
                 environment=self.environment,
                 version=self.service_version,
                 log_level=self.log_level,
             )
-            FastAPIInstrumentor().instrument_app(
-                app, excluded_urls=EXCLUDED_URLS, exclude_spans=EXCLUDED_SPANS
-            )
-            # Pass tracer_provider=None so instrumentors pick up the global
-            # provider set by arcade-telemetry.
-            HTTPXClientInstrumentor()._instrument(tracer_provider=None)
-            AioHttpClientInstrumentor()._instrument(tracer_provider=None)
-            RequestsInstrumentor()._instrument(tracer_provider=None)
-            return
+            if handle is not None:
+                self._arcade_telemetry_handle = handle
+                FastAPIInstrumentor().instrument_app(
+                    app, excluded_urls=EXCLUDED_URLS, exclude_spans=EXCLUDED_SPANS
+                )
+                # Pass tracer_provider=None so instrumentors pick up the global
+                # provider set by arcade-telemetry.
+                HTTPXClientInstrumentor()._instrument(tracer_provider=None)
+                AioHttpClientInstrumentor()._instrument(tracer_provider=None)
+                RequestsInstrumentor()._instrument(tracer_provider=None)
+                return
+            # init_providers returned None (arcade-telemetry import race or
+            # internal opt-out) — fall through to the in-house OTLP setup so
+            # shutdown() has something to tear down.
 
         logging.info(
             "🔎 Initializing OpenTelemetry. Use environment variables to configure the connection"

--- a/libs/arcade-serve/pyproject.toml
+++ b/libs/arcade-serve/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "arcade-serve"
-version = "3.3.1"
+version = "3.2.6"
 description = "Arcade Serve - Serving infrastructure for Arcade tools and workers"
 readme = "README.md"
 license = {text = "MIT"}

--- a/libs/arcade-serve/pyproject.toml
+++ b/libs/arcade-serve/pyproject.toml
@@ -42,10 +42,6 @@ dev = [
     "pytest-asyncio>=0.23.7",
 ]
 
-# Optional: if `arcade-telemetry` is importable at runtime, OTELHandler
-# delegates provider setup to it and create_arcade_mcp() registers its
-# CorrelationMiddleware. Detected via importlib; no declaration needed.
-
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/libs/arcade-serve/pyproject.toml
+++ b/libs/arcade-serve/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "arcade-serve"
-version = "3.2.5"
+version = "3.3.0"
 description = "Arcade Serve - Serving infrastructure for Arcade tools and workers"
 readme = "README.md"
 license = {text = "MIT"}
@@ -41,6 +41,10 @@ dev = [
     "pre-commit>=3.4.0",
     "pytest-asyncio>=0.23.7",
 ]
+
+# Optional: if `arcade-telemetry` is importable at runtime, OTELHandler
+# delegates provider setup to it and create_arcade_mcp() registers its
+# CorrelationMiddleware. Detected via importlib; no declaration needed.
 
 [build-system]
 requires = ["hatchling"]

--- a/libs/arcade-serve/pyproject.toml
+++ b/libs/arcade-serve/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "arcade-serve"
-version = "3.2.6"
+version = "3.3.0"
 description = "Arcade Serve - Serving infrastructure for Arcade tools and workers"
 readme = "README.md"
 license = {text = "MIT"}

--- a/libs/arcade-serve/pyproject.toml
+++ b/libs/arcade-serve/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "arcade-serve"
-version = "3.2.6"
+version = "3.3.1"
 description = "Arcade Serve - Serving infrastructure for Arcade tools and workers"
 readme = "README.md"
 license = {text = "MIT"}

--- a/libs/arcade-serve/pyproject.toml
+++ b/libs/arcade-serve/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "arcade-serve"
-version = "3.3.0"
+version = "3.2.6"
 description = "Arcade Serve - Serving infrastructure for Arcade tools and workers"
 readme = "README.md"
 license = {text = "MIT"}

--- a/libs/tests/worker/test_arcade_telemetry_bridge.py
+++ b/libs/tests/worker/test_arcade_telemetry_bridge.py
@@ -1,0 +1,229 @@
+"""Tests for the optional arcade-telemetry bridge in arcade-serve.
+
+Covers both paths:
+- arcade_telemetry NOT importable — OTELHandler runs its built-in OTLP setup.
+- arcade_telemetry importable (simulated via sys.modules monkeypatch) —
+  OTELHandler delegates provider setup and skips OTLP exporter init.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+from arcade_serve.fastapi import _arcade_telemetry
+from arcade_serve.fastapi.telemetry import OTELHandler
+from fastapi import FastAPI
+
+
+@pytest.fixture
+def app() -> FastAPI:
+    return FastAPI()
+
+
+@pytest.fixture
+def fake_arcade_telemetry(monkeypatch: pytest.MonkeyPatch):
+    """Install a fake `arcade_telemetry` package into sys.modules.
+
+    Yields a SimpleNamespace with the mocks the test can assert against.
+    """
+    telemetry_handle = MagicMock(name="Telemetry")
+    new_telemetry = MagicMock(name="new_telemetry", return_value=telemetry_handle)
+
+    fake_root = types.ModuleType("arcade_telemetry")
+    fake_root.new_telemetry = new_telemetry  # type: ignore[attr-defined]
+
+    class _FakeCorrelationMiddleware:
+        def __init__(self, app):
+            self.app = app
+
+        async def __call__(self, scope, receive, send):
+            await self.app(scope, receive, send)
+
+    fake_starlette = types.ModuleType("arcade_telemetry.starlette")
+    fake_starlette.CorrelationMiddleware = _FakeCorrelationMiddleware  # type: ignore[attr-defined]
+
+    monkeypatch.setitem(sys.modules, "arcade_telemetry", fake_root)
+    monkeypatch.setitem(sys.modules, "arcade_telemetry.starlette", fake_starlette)
+
+    return types.SimpleNamespace(
+        new_telemetry=new_telemetry,
+        telemetry_handle=telemetry_handle,
+        correlation_middleware_cls=_FakeCorrelationMiddleware,
+    )
+
+
+def test_bridge_unavailable_when_not_installed(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Make sure no stray import landed in sys.modules from a prior test.
+    monkeypatch.delitem(sys.modules, "arcade_telemetry", raising=False)
+    monkeypatch.delitem(sys.modules, "arcade_telemetry.starlette", raising=False)
+
+    assert _arcade_telemetry.is_available() is False
+    assert (
+        _arcade_telemetry.init_providers(
+            service_name="worker", environment="local", version="1.0.0", log_level=20
+        )
+        is None
+    )
+    assert _arcade_telemetry.correlation_middleware_cls() is None
+    # Shutdown of None is a no-op.
+    _arcade_telemetry.shutdown(None)
+
+
+def test_bridge_available_when_installed(fake_arcade_telemetry) -> None:
+    assert _arcade_telemetry.is_available() is True
+
+    handle = _arcade_telemetry.init_providers(
+        service_name="worker", environment="prod", version="2.3.4", log_level=10
+    )
+    assert handle is fake_arcade_telemetry.telemetry_handle
+    fake_arcade_telemetry.new_telemetry.assert_called_once_with(
+        service_name="worker", environment="prod", version="2.3.4", log_level=10
+    )
+
+    assert (
+        _arcade_telemetry.correlation_middleware_cls()
+        is fake_arcade_telemetry.correlation_middleware_cls
+    )
+
+
+def test_shutdown_calls_handle_shutdown(fake_arcade_telemetry) -> None:
+    handle = _arcade_telemetry.init_providers(
+        service_name="worker", environment="prod", version="1.0.0", log_level=20
+    )
+    _arcade_telemetry.shutdown(handle)
+    fake_arcade_telemetry.telemetry_handle.shutdown.assert_called_once()
+
+
+@patch("arcade_serve.fastapi.telemetry.RequestsInstrumentor")
+@patch("arcade_serve.fastapi.telemetry.AioHttpClientInstrumentor")
+@patch("arcade_serve.fastapi.telemetry.HTTPXClientInstrumentor")
+@patch("arcade_serve.fastapi.telemetry.FastAPIInstrumentor")
+@patch("arcade_serve.fastapi.telemetry.OTLPLogExporter")
+@patch("arcade_serve.fastapi.telemetry.OTLPMetricExporter")
+@patch("arcade_serve.fastapi.telemetry.OTLPSpanExporter")
+def test_otel_handler_delegates_when_arcade_telemetry_present(
+    mock_span_exporter,
+    mock_metric_exporter,
+    mock_log_exporter,
+    mock_fastapi_instrumentor,
+    mock_httpx,
+    mock_aiohttp,
+    mock_requests,
+    fake_arcade_telemetry,
+    app: FastAPI,
+) -> None:
+    handler = OTELHandler(enable=True, service_name="worker", service_version="9.9.9")
+    handler.instrument_app(app)
+
+    # arcade-telemetry handled provider setup — OTELHandler's OTLP exporters
+    # must NOT have been constructed.
+    mock_span_exporter.assert_not_called()
+    mock_metric_exporter.assert_not_called()
+    mock_log_exporter.assert_not_called()
+    assert handler._tracer_provider is None
+    assert handler._meter_provider is None
+    assert handler._logger_provider is None
+
+    # arcade-telemetry's new_telemetry() was called with the handler's values.
+    fake_arcade_telemetry.new_telemetry.assert_called_once()
+    kwargs = fake_arcade_telemetry.new_telemetry.call_args.kwargs
+    assert kwargs["service_name"] == "worker"
+    assert kwargs["version"] == "9.9.9"
+
+    # FastAPI / HTTPX / aiohttp / Requests instrumentors still run, but with
+    # tracer_provider=None so they pick up arcade-telemetry's globals.
+    mock_fastapi_instrumentor.return_value.instrument_app.assert_called_once_with(
+        app, excluded_urls="/worker/health", exclude_spans=["send", "receive"]
+    )
+    mock_httpx.return_value._instrument.assert_called_once_with(tracer_provider=None)
+    mock_aiohttp.return_value._instrument.assert_called_once_with(tracer_provider=None)
+    mock_requests.return_value._instrument.assert_called_once_with(tracer_provider=None)
+
+    # Shutdown delegates to the arcade-telemetry handle and does NOT touch the
+    # OTLP exporter shutdown path (which would crash since exporters were never
+    # initialized).
+    handler.shutdown()
+    fake_arcade_telemetry.telemetry_handle.shutdown.assert_called_once()
+    assert handler._arcade_telemetry_handle is None
+
+
+def test_create_arcade_mcp_registers_correlation_middleware(
+    fake_arcade_telemetry, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When arcade-telemetry is available, create_arcade_mcp adds its
+    CorrelationMiddleware to the FastAPI app."""
+    monkeypatch.setenv("MCP_SERVER_NAME", "test-mcp")
+    monkeypatch.setenv("MCP_SERVER_VERSION", "0.1.0")
+
+    from arcade_core import ToolCatalog
+    from arcade_mcp_server.settings import MCPSettings
+    from arcade_mcp_server.worker import create_arcade_mcp
+
+    catalog = ToolCatalog()
+    mcp_settings = MCPSettings.from_env()
+    app = create_arcade_mcp(catalog, mcp_settings=mcp_settings)
+
+    middleware_classes = [m.cls for m in app.user_middleware]
+    assert fake_arcade_telemetry.correlation_middleware_cls in middleware_classes
+
+
+def test_create_arcade_mcp_skips_middleware_without_arcade_telemetry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without arcade-telemetry installed, no CorrelationMiddleware is added."""
+    monkeypatch.delitem(sys.modules, "arcade_telemetry", raising=False)
+    monkeypatch.delitem(sys.modules, "arcade_telemetry.starlette", raising=False)
+    monkeypatch.setenv("MCP_SERVER_NAME", "test-mcp")
+    monkeypatch.setenv("MCP_SERVER_VERSION", "0.1.0")
+
+    from arcade_core import ToolCatalog
+    from arcade_mcp_server.settings import MCPSettings
+    from arcade_mcp_server.worker import create_arcade_mcp
+
+    catalog = ToolCatalog()
+    mcp_settings = MCPSettings.from_env()
+    app = create_arcade_mcp(catalog, mcp_settings=mcp_settings)
+
+    middleware_classes = [m.cls.__name__ for m in app.user_middleware]
+    assert "CorrelationMiddleware" not in middleware_classes
+
+
+@patch("arcade_serve.fastapi.telemetry.RequestsInstrumentor")
+@patch("arcade_serve.fastapi.telemetry.AioHttpClientInstrumentor")
+@patch("arcade_serve.fastapi.telemetry.HTTPXClientInstrumentor")
+@patch("arcade_serve.fastapi.telemetry.FastAPIInstrumentor")
+@patch("arcade_serve.fastapi.telemetry.OTLPLogExporter")
+@patch("arcade_serve.fastapi.telemetry.OTLPMetricExporter")
+@patch("arcade_serve.fastapi.telemetry.OTLPSpanExporter")
+def test_otel_handler_uses_builtin_when_arcade_telemetry_absent(
+    mock_span_exporter,
+    mock_metric_exporter,
+    mock_log_exporter,
+    mock_fastapi_instrumentor,
+    mock_httpx,
+    mock_aiohttp,
+    mock_requests,
+    monkeypatch: pytest.MonkeyPatch,
+    app: FastAPI,
+) -> None:
+    monkeypatch.delitem(sys.modules, "arcade_telemetry", raising=False)
+    monkeypatch.delitem(sys.modules, "arcade_telemetry.starlette", raising=False)
+
+    mock_span_exporter.return_value.shutdown = MagicMock()
+    mock_metric_exporter.return_value.shutdown = MagicMock()
+    mock_log_exporter.return_value.shutdown = MagicMock()
+
+    handler = OTELHandler(enable=True)
+    handler.instrument_app(app)
+
+    # Built-in path constructed its own providers.
+    mock_span_exporter.assert_called()
+    mock_metric_exporter.assert_called()
+    mock_log_exporter.assert_called()
+    assert handler._tracer_provider is not None
+    assert handler._meter_provider is not None
+    assert handler._logger_provider is not None
+    assert handler._arcade_telemetry_handle is None

--- a/libs/tests/worker/test_arcade_telemetry_bridge.py
+++ b/libs/tests/worker/test_arcade_telemetry_bridge.py
@@ -153,8 +153,8 @@ def test_otel_handler_delegates_when_arcade_telemetry_present(
 def test_create_arcade_mcp_registers_correlation_middleware(
     fake_arcade_telemetry, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """When arcade-telemetry is available, create_arcade_mcp adds its
-    CorrelationMiddleware to the FastAPI app."""
+    """With arcade-telemetry available AND otel_enable=True, create_arcade_mcp
+    adds CorrelationMiddleware to the FastAPI app."""
     monkeypatch.setenv("MCP_SERVER_NAME", "test-mcp")
     monkeypatch.setenv("MCP_SERVER_VERSION", "0.1.0")
 
@@ -164,16 +164,38 @@ def test_create_arcade_mcp_registers_correlation_middleware(
 
     catalog = ToolCatalog()
     mcp_settings = MCPSettings.from_env()
-    app = create_arcade_mcp(catalog, mcp_settings=mcp_settings)
+    app = create_arcade_mcp(catalog, mcp_settings=mcp_settings, otel_enable=True)
 
     middleware_classes = [m.cls for m in app.user_middleware]
     assert fake_arcade_telemetry.correlation_middleware_cls in middleware_classes
 
 
+def test_create_arcade_mcp_skips_middleware_when_otel_disabled(
+    fake_arcade_telemetry, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Even with arcade-telemetry available, otel_enable=False must NOT add
+    CorrelationMiddleware. Matches the documented behavior table — when OTel
+    is off, the middleware stack must not change."""
+    monkeypatch.setenv("MCP_SERVER_NAME", "test-mcp")
+    monkeypatch.setenv("MCP_SERVER_VERSION", "0.1.0")
+
+    from arcade_core import ToolCatalog
+    from arcade_mcp_server.settings import MCPSettings
+    from arcade_mcp_server.worker import create_arcade_mcp
+
+    catalog = ToolCatalog()
+    mcp_settings = MCPSettings.from_env()
+    app = create_arcade_mcp(catalog, mcp_settings=mcp_settings, otel_enable=False)
+
+    middleware_classes = [m.cls for m in app.user_middleware]
+    assert fake_arcade_telemetry.correlation_middleware_cls not in middleware_classes
+
+
 def test_create_arcade_mcp_skips_middleware_without_arcade_telemetry(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Without arcade-telemetry installed, no CorrelationMiddleware is added."""
+    """Without arcade-telemetry installed, no CorrelationMiddleware is added
+    regardless of the otel_enable flag."""
     monkeypatch.delitem(sys.modules, "arcade_telemetry", raising=False)
     monkeypatch.delitem(sys.modules, "arcade_telemetry.starlette", raising=False)
     monkeypatch.setenv("MCP_SERVER_NAME", "test-mcp")


### PR DESCRIPTION
## Summary

Adds an opt-in integration with a pluggable telemetry library so deployments that need richer observability (Sentry, request correlation, structured logging) can swap it in without forking `arcade-serve`. When the library isn't installed, behavior is identical to today.

- New bridge module `libs/arcade-serve/arcade_serve/fastapi/_arcade_telemetry.py` — guarded `importlib` check, no new declared dependency.
- `OTELHandler.instrument_app()` delegates global OTel tracer/meter/logger provider setup to the optional library when available, then still attaches the FastAPI / HTTPX / aiohttp / Requests auto-instrumentors against whatever providers are set. Falls back to the built-in OTLP exporter path otherwise.
- `OTELHandler.__init__` accepts `service_name` / `service_version` so the resource identity matches the MCP server's configured name/version instead of the hard-coded `"worker"`.
- `create_arcade_mcp()` registers the library's `CorrelationMiddleware` when present, so `X-Request-Id` is propagated through the request lifecycle.
- `arcade-serve` patch → minor version bump (3.2.5 → 3.3.0).

## Why

`OTELHandler` is currently a hard-coded OTLP exporter setup. Anyone who wants Sentry, request correlation, or non-OTLP destinations either monkey-patches it or runs a fork. This makes that integration a one-line install: drop a wheel into the venv and `OTELHandler` defers to it transparently. Nothing changes for the default install.

## Behavior

| Scenario | Provider setup | Auto-instrumentation | Middleware |
|---|---|---|---|
| Default install (no telemetry lib) | `OTELHandler`'s built-in OTLP exporters (unchanged) | FastAPI / HTTPX / aiohttp / Requests | None added |
| Telemetry lib installed | Library's `new_telemetry(...)` | FastAPI / HTTPX / aiohttp / Requests (against global providers) | Library's `CorrelationMiddleware` |
| `otel_enable=False` | Nothing initializes | Nothing | None added |

The two providers can't coexist (both set global OTel providers — last-writer-wins), so when the optional library is present it fully owns provider setup.

## Test plan

- [x] `uv run pytest libs/tests/worker/` — 14 tests pass, including 7 new ones covering both code paths (library absent + simulated-present via `sys.modules` monkeypatch).
- [x] `uv run pytest libs/tests/worker/ libs/tests/arcade_mcp_server/` — full sweep: 1429 passing.
- [x] `mypy arcade_serve` clean.
- [x] `mypy arcade_mcp_server` clean.
- [x] `pre-commit` (ruff + ruff-format + guards) clean.

## Notes for reviewers

- The bridge module is the **only** file that touches `arcade_telemetry`. Every other call site goes through `is_available()` / `init_providers()` / `correlation_middleware_cls()` / `shutdown()`.
- No `optional-dependencies` extra is declared in `pyproject.toml` — the integration is purely runtime-detected. (An extra was attempted but breaks `uv sync` since the target library isn't published to PyPI.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes global OpenTelemetry provider initialization and MCP middleware ordering when OTel and arcade-telemetry are both enabled; default installs are unchanged but observability behavior can shift for deployments that add the optional library.
> 
> **Overview**
> Adds a **runtime-detected** bridge to optional `arcade-telemetry` so richer observability (e.g. Sentry, request correlation) can be enabled by installing a wheel, with **no change** when the library is absent.
> 
> **`OTELHandler`** now accepts **`service_name`** / **`service_version`** (MCP passes configured server identity instead of a hard-coded `"worker"`). When `arcade-telemetry` is importable, global tracer/meter/logger setup goes through **`new_telemetry`** (and optional loguru wiring); FastAPI/HTTPX/aiohttp/Requests instrumentors still attach against whatever global providers are set. If the library is missing or opts out (`None` handle), behavior stays on the **built-in OTLP exporter** path; **`shutdown`** routes to the telemetry handle when delegation was used.
> 
> **`create_arcade_mcp`** registers **`CorrelationMiddleware`** from arcade-telemetry when OTel is enabled and the class is available, added **last** so `X-Request-Id` context is set before other middleware runs.
> 
> New **`_arcade_telemetry`** module isolates all `importlib` touches; **`arcade-serve`** bumps **3.2.5 → 3.3.0**. Tests cover delegate vs built-in paths and MCP middleware gating.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e753a007e52d0ab298bf96b9e4ccd6176e02295e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->