### PR TITLE
feat: add ServiceNow incident management MCP server example

### DIFF
--- a/examples/mcp_servers/servicenow/.env.example
+++ b/examples/mcp_servers/servicenow/.env.example
@@ -1,0 +1,3 @@
+# Your ServiceNow instance URL (without trailing slash)
+# Example: https://dev12345.service-now.com
+SERVICENOW_INSTANCE_URL="https://your-instance.service-now.com"

--- a/examples/mcp_servers/servicenow/evals/eval_servicenow_incidents.py
+++ b/examples/mcp_servers/servicenow/evals/eval_servicenow_incidents.py
@@ -1,0 +1,199 @@
+from arcade_core import ToolCatalog
+from arcade_evals import (
+    BinaryCritic,
+    EvalRubric,
+    EvalSuite,
+    ExpectedToolCall,
+    SimilarityCritic,
+    tool_eval,
+)
+
+import servicenow
+from servicenow.tools import (
+    change_state,
+    create_incident,
+    search_incidents,
+)
+
+rubric = EvalRubric(
+    fail_threshold=0.85,
+    warn_threshold=0.95,
+)
+
+catalog = ToolCatalog()
+catalog.add_module(servicenow)
+
+
+@tool_eval()
+def servicenow_incident_eval_suite() -> EvalSuite:
+    """
+    Evaluation suite for ServiceNow incident management tools.
+
+    Covers three core workflows:
+    - Creating incidents (text similarity for description, exact match for priority fields)
+    - Searching incidents (exact match on structured filter fields)
+    - Changing incident state (exact match on state and INC number)
+    """
+    suite = EvalSuite(
+        name="ServiceNow Incident Management Evaluation",
+        catalog=catalog,
+        system_message=(
+            "You are a helpful IT support assistant with access to ServiceNow. "
+            "Use the available tools to manage incidents on behalf of the user."
+        ),
+        rubric=rubric,
+    )
+
+    # -------------------------------------------------------------------------
+    # create_incident — SimilarityCritic for description text, BinaryCritic for
+    # structured fields where exact correctness matters.
+    # -------------------------------------------------------------------------
+    suite.add_case(
+        name="Create high-urgency incident for VPN outage",
+        user_message=(
+            "Please create a new incident. Users are unable to connect to the VPN "
+            "which is blocking remote work. This is high urgency and high impact."
+        ),
+        expected_tool_calls=[
+            ExpectedToolCall(
+                func=create_incident,
+                args={
+                    "short_description": "Users unable to connect to VPN",
+                    "urgency": "high",
+                    "impact": "high",
+                },
+            )
+        ],
+        critics=[
+            SimilarityCritic(
+                critic_field="short_description",
+                weight=0.5,
+                similarity_threshold=0.7,
+                metric="cosine",
+            ),
+            BinaryCritic(critic_field="urgency", weight=0.25),
+            BinaryCritic(critic_field="impact", weight=0.25),
+        ],
+    )
+
+    suite.add_case(
+        name="Create a low-priority software request with category",
+        user_message=(
+            "Log an incident: a developer needs the Python extension installed in VS Code. "
+            "It's low urgency. Category is software."
+        ),
+        expected_tool_calls=[
+            ExpectedToolCall(
+                func=create_incident,
+                args={
+                    "short_description": "Python extension needed in VS Code",
+                    "urgency": "low",
+                    "category": "software",
+                },
+            )
+        ],
+        critics=[
+            SimilarityCritic(
+                critic_field="short_description",
+                weight=0.5,
+                similarity_threshold=0.65,
+                metric="cosine",
+            ),
+            BinaryCritic(critic_field="urgency", weight=0.3),
+            BinaryCritic(critic_field="category", weight=0.2),
+        ],
+    )
+
+    # -------------------------------------------------------------------------
+    # search_incidents — BinaryCritic for structured enum/code fields.
+    # -------------------------------------------------------------------------
+    suite.add_case(
+        name="Search for all critical new incidents",
+        user_message="Show me all critical priority incidents that are currently new or in progress.",
+        expected_tool_calls=[
+            ExpectedToolCall(
+                func=search_incidents,
+                args={
+                    "priority": "critical",
+                    "state": "new",
+                },
+            )
+        ],
+        critics=[
+            BinaryCritic(critic_field="priority", weight=0.6),
+            BinaryCritic(critic_field="state", weight=0.4),
+        ],
+    )
+
+    suite.add_case(
+        name="Search for high priority incidents in progress",
+        user_message="Find all high priority incidents that are currently being worked on (in progress).",
+        expected_tool_calls=[
+            ExpectedToolCall(
+                func=search_incidents,
+                args={
+                    "priority": "high",
+                    "state": "in_progress",
+                },
+            )
+        ],
+        critics=[
+            BinaryCritic(critic_field="priority", weight=0.6),
+            BinaryCritic(critic_field="state", weight=0.4),
+        ],
+    )
+
+    suite.add_case(
+        name="Search incidents by keyword",
+        user_message="Find incidents related to database connectivity issues.",
+        expected_tool_calls=[
+            ExpectedToolCall(
+                func=search_incidents,
+                args={
+                    "short_description_contains": "database connectivity",
+                },
+            )
+        ],
+        critics=[
+            SimilarityCritic(
+                critic_field="short_description_contains",
+                weight=1.0,
+                similarity_threshold=0.65,
+                metric="cosine",
+            ),
+        ],
+    )
+
+    # -------------------------------------------------------------------------
+    # change_state — BinaryCritic for state transition and INC number.
+    # SimilarityCritic for free-text close notes.
+    # -------------------------------------------------------------------------
+    suite.add_case(
+        name="Resolve incident INC0045678",
+        user_message=(
+            "Please resolve incident INC0045678. "
+            "The issue was fixed by restarting the network switch."
+        ),
+        expected_tool_calls=[
+            ExpectedToolCall(
+                func=change_state,
+                args={
+                    "sys_id_or_number": "INC0045678",
+                    "state": "resolved",
+                    "close_notes": "Issue resolved by restarting the network switch.",
+                },
+            )
+        ],
+        critics=[
+            BinaryCritic(critic_field="sys_id_or_number", weight=0.4),
+            BinaryCritic(critic_field="state", weight=0.3),
+            SimilarityCritic(
+                critic_field="close_notes",
+                weight=0.3,
+                similarity_threshold=0.7,
+                metric="cosine",
+            ),
+        ],
+    )
+
+    return suite

--- a/examples/mcp_servers/servicenow/evals/eval_servicenow_incidents.py
+++ b/examples/mcp_servers/servicenow/evals/eval_servicenow_incidents.py
@@ -109,7 +109,7 @@ def servicenow_incident_eval_suite() -> EvalSuite:
     # -------------------------------------------------------------------------
     suite.add_case(
         name="Search for all critical new incidents",
-        user_message="Show me all critical priority incidents that are currently new or in progress.",
+        user_message="Show me all critical priority incidents that are new and haven't been picked up yet.",
         expected_tool_calls=[
             ExpectedToolCall(
                 func=search_incidents,

--- a/examples/mcp_servers/servicenow/pyproject.toml
+++ b/examples/mcp_servers/servicenow/pyproject.toml
@@ -1,0 +1,46 @@
+[project]
+name = "servicenow"
+version = "0.1.0"
+description = "ServiceNow MCP Server created with Arcade.dev"
+requires-python = ">=3.10"
+dependencies = [
+    "arcade-mcp-server>=1.17.4,<2.0.0",
+    "httpx>=0.28.0,<1.0.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "arcade-mcp[all]>=1.11.2,<2.0.0",
+    "pytest>=7.0.0",
+    "pytest-asyncio>=0.21.0",
+    "mypy>=1.0.0",
+    "ruff>=0.1.0",
+]
+
+# Tell Arcade.dev that this package has Arcade tools
+[project.entry-points.arcade_toolkits]
+toolkit_name = "servicenow"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/servicenow"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py312"
+
+[tool.mypy]
+python_version = "3.12"
+warn_unused_configs = true
+disallow_untyped_defs = false
+
+
+# # Uncomment the following if you are developing inside of the arcade-mcp repo & want to use editable mode
+# # Otherwise, you will install the following packages from PyPI
+# [tool.uv.sources]
+# arcade-mcp = { path = "../../../", editable = true }
+# arcade-serve = { path = "../../../libs/arcade-serve/", editable = true }
+# arcade-mcp-server = { path = "../../../libs/arcade-mcp-server/", editable = true }

--- a/examples/mcp_servers/servicenow/src/servicenow/server.py
+++ b/examples/mcp_servers/servicenow/src/servicenow/server.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+"""ServiceNow MCP server"""
+
+import sys
+
+from arcade_mcp_server import MCPApp
+
+import servicenow
+
+app = MCPApp(name="servicenow", version="1.0.0", log_level="DEBUG")
+
+app.add_tools_from_module(servicenow)
+
+if __name__ == "__main__":
+    # Get transport from command line argument, default to "stdio"
+    # - "stdio" (default): Standard I/O for Claude Desktop, CLI tools, etc.
+    #   Supports tools that require_auth or require_secrets out-of-the-box
+    # - "http": HTTPS streaming for Cursor, VS Code, etc.
+    #   Does not support tools that require_auth or require_secrets unless the server is deployed
+    #   using 'arcade deploy' or added in the Arcade Developer Dashboard with 'Arcade' server type
+    transport = sys.argv[1] if len(sys.argv) > 1 else "stdio"
+
+    app.run(transport=transport, host="127.0.0.1", port=8000)

--- a/examples/mcp_servers/servicenow/src/servicenow/tools/__init__.py
+++ b/examples/mcp_servers/servicenow/src/servicenow/tools/__init__.py
@@ -1,0 +1,17 @@
+from servicenow.tools.tools_incidents import (
+    add_comment,
+    change_state,
+    create_incident,
+    list_my_incidents,
+    search_incidents,
+    update_incident,
+)
+
+__all__ = [
+    "create_incident",
+    "update_incident",
+    "search_incidents",
+    "add_comment",
+    "list_my_incidents",
+    "change_state",
+]

--- a/examples/mcp_servers/servicenow/src/servicenow/tools/tools_incidents.py
+++ b/examples/mcp_servers/servicenow/src/servicenow/tools/tools_incidents.py
@@ -33,7 +33,10 @@ _DEFAULT_FIELDS = (
     "urgency,impact,category,assigned_to,caller_id,opened_at,sys_updated_on"
 )
 
-_SERVICENOW_AUTH = OAuth2(id="servicenow", scopes=["useraccount"])
+# ServiceNow OAuth scopes are instance-specific and configured by the enterprise
+# admin. Omitting scopes here requests the default access level — adjust in your
+# Arcade dashboard if your instance requires explicit scope declarations.
+_SERVICENOW_AUTH = OAuth2(id="servicenow")
 
 
 def _headers(oauth_token: str) -> dict[str, str]:
@@ -42,6 +45,25 @@ def _headers(oauth_token: str) -> dict[str, str]:
         "Accept": "application/json",
         "Content-Type": "application/json",
     }
+
+
+def _raise_for_status(response: httpx.Response, resource_hint: str = "") -> None:
+    """Translate ServiceNow HTTP errors into descriptive ValueErrors."""
+    if response.is_success:
+        return
+    code = response.status_code
+    if code == 401:
+        raise ValueError(
+            "ServiceNow authentication failed — your OAuth token may have expired."
+        )
+    if code == 403:
+        raise ValueError(
+            "Permission denied — your ServiceNow account lacks access to this resource."
+        )
+    if code == 404:
+        hint = f": {resource_hint}" if resource_hint else ""
+        raise ValueError(f"Incident not found{hint}.")
+    raise ValueError(f"ServiceNow API error {code}: {response.text}")
 
 
 async def _resolve_sys_id(
@@ -63,7 +85,7 @@ async def _resolve_sys_id(
             "sysparm_limit": 1,
         },
     )
-    response.raise_for_status()
+    _raise_for_status(response, sys_id_or_number)
     results = response.json().get("result", [])
     if not results:
         raise ValueError(f"Incident '{sys_id_or_number}' not found.")
@@ -117,7 +139,7 @@ async def create_incident(
             headers=_headers(oauth_token),
             json=payload,
         )
-        response.raise_for_status()
+        _raise_for_status(response)
         return response.json().get("result", {})
 
 
@@ -167,7 +189,7 @@ async def update_incident(
             headers=hdrs,
             json=payload,
         )
-        response.raise_for_status()
+        _raise_for_status(response, sys_id_or_number)
         return response.json().get("result", {})
 
 
@@ -197,6 +219,7 @@ async def search_incidents(
         str | None, "Filter by assigned ServiceNow username"
     ] = None,
     limit: Annotated[int, "Maximum number of results to return (1-100)"] = 20,
+    offset: Annotated[int, "Number of results to skip for pagination (default 0)"] = 0,
 ) -> list[dict]:
     """
     Search or filter ServiceNow incidents.
@@ -204,6 +227,9 @@ async def search_incidents(
     Supports a raw sysparm_query string for advanced filtering, or individual
     convenience filters for the most common fields. Results are ordered by most
     recently updated first.
+
+    To paginate, increment offset by the limit value on each subsequent call
+    (e.g. offset=0, offset=20, offset=40, ...).
     """
     instance_url = context.get_secret("SERVICENOW_INSTANCE_URL").rstrip("/")
     oauth_token = context.get_auth_token_or_empty()
@@ -223,6 +249,7 @@ async def search_incidents(
     params: dict[str, str | int] = {
         "sysparm_query": f"{query}^ORDERBYDESCsys_updated_on",
         "sysparm_limit": min(max(1, limit), 100),
+        "sysparm_offset": max(0, offset),
         "sysparm_display_value": "true",
         "sysparm_fields": _DEFAULT_FIELDS,
     }
@@ -233,7 +260,7 @@ async def search_incidents(
             headers=_headers(oauth_token),
             params=params,
         )
-        response.raise_for_status()
+        _raise_for_status(response)
         return response.json().get("result", [])
 
 
@@ -273,7 +300,7 @@ async def add_comment(
             headers=hdrs,
             json={field: comment},
         )
-        response.raise_for_status()
+        _raise_for_status(response, sys_id_or_number)
         return response.json().get("result", {})
 
 
@@ -288,12 +315,16 @@ async def list_my_incidents(
         "Filter by state: 'new', 'in_progress', 'on_hold', 'resolved', 'closed', 'cancelled'",
     ] = None,
     limit: Annotated[int, "Maximum number of incidents to return (1-100)"] = 20,
+    offset: Annotated[int, "Number of results to skip for pagination (default 0)"] = 0,
 ) -> list[dict]:
     """
     List incidents assigned to the authenticated user.
 
     Uses the Arcade session's user identity to filter incidents. Results are
     ordered by most recently updated first.
+
+    To paginate, increment offset by the limit value on each subsequent call
+    (e.g. offset=0, offset=20, offset=40, ...).
     """
     instance_url = context.get_secret("SERVICENOW_INSTANCE_URL").rstrip("/")
     oauth_token = context.get_auth_token_or_empty()
@@ -307,6 +338,7 @@ async def list_my_incidents(
     params: dict[str, str | int] = {
         "sysparm_query": "^".join(query_parts) + "^ORDERBYDESCsys_updated_on",
         "sysparm_limit": min(max(1, limit), 100),
+        "sysparm_offset": max(0, offset),
         "sysparm_display_value": "true",
         "sysparm_fields": _DEFAULT_FIELDS,
     }
@@ -317,7 +349,7 @@ async def list_my_incidents(
             headers=_headers(oauth_token),
             params=params,
         )
-        response.raise_for_status()
+        _raise_for_status(response)
         return response.json().get("result", [])
 
 
@@ -368,5 +400,5 @@ async def change_state(
             headers=hdrs,
             json=payload,
         )
-        response.raise_for_status()
+        _raise_for_status(response, sys_id_or_number)
         return response.json().get("result", {})

--- a/examples/mcp_servers/servicenow/src/servicenow/tools/tools_incidents.py
+++ b/examples/mcp_servers/servicenow/src/servicenow/tools/tools_incidents.py
@@ -1,0 +1,372 @@
+from typing import Annotated
+
+import httpx
+from arcade_mcp_server import Context, tool
+from arcade_mcp_server.auth import OAuth2
+
+# ServiceNow incident state codes
+_STATE_MAP: dict[str, str] = {
+    "new": "1",
+    "in_progress": "2",
+    "in progress": "2",
+    "on_hold": "3",
+    "on hold": "3",
+    "resolved": "4",
+    "closed": "6",
+    "cancelled": "7",
+}
+
+# ServiceNow urgency/impact codes (shared scale)
+_LEVEL_MAP: dict[str, str] = {"high": "1", "medium": "2", "low": "3"}
+
+# ServiceNow priority codes
+_PRIORITY_MAP: dict[str, str] = {
+    "critical": "1",
+    "high": "2",
+    "moderate": "3",
+    "low": "4",
+    "planning": "5",
+}
+
+_DEFAULT_FIELDS = (
+    "sys_id,number,short_description,description,state,priority,"
+    "urgency,impact,category,assigned_to,caller_id,opened_at,sys_updated_on"
+)
+
+_SERVICENOW_AUTH = OAuth2(id="servicenow", scopes=["useraccount"])
+
+
+def _headers(oauth_token: str) -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {oauth_token}",
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+    }
+
+
+async def _resolve_sys_id(
+    client: httpx.AsyncClient,
+    headers: dict[str, str],
+    instance_url: str,
+    sys_id_or_number: str,
+) -> str:
+    """Return sys_id unchanged, or resolve an INC-prefixed number to its sys_id."""
+    if not sys_id_or_number.upper().startswith("INC"):
+        return sys_id_or_number
+
+    response = await client.get(
+        f"{instance_url}/api/now/table/incident",
+        headers=headers,
+        params={
+            "sysparm_query": f"number={sys_id_or_number.upper()}",
+            "sysparm_fields": "sys_id",
+            "sysparm_limit": 1,
+        },
+    )
+    response.raise_for_status()
+    results = response.json().get("result", [])
+    if not results:
+        raise ValueError(f"Incident '{sys_id_or_number}' not found.")
+    return results[0]["sys_id"]
+
+
+@tool(
+    requires_auth=_SERVICENOW_AUTH,
+    requires_secrets=["SERVICENOW_INSTANCE_URL"],
+)
+async def create_incident(
+    context: Context,
+    short_description: Annotated[str, "One-line summary of the incident"],
+    description: Annotated[str | None, "Detailed description of the incident"] = None,
+    urgency: Annotated[
+        str | None, "How quickly the incident must be resolved: 'high', 'medium', or 'low'"
+    ] = None,
+    impact: Annotated[
+        str | None, "Business impact of the incident: 'high', 'medium', or 'low'"
+    ] = None,
+    category: Annotated[
+        str | None, "Incident category (e.g. 'network', 'hardware', 'software', 'database')"
+    ] = None,
+    caller_id: Annotated[
+        str | None, "ServiceNow username of the person reporting the incident"
+    ] = None,
+) -> dict:
+    """
+    Create a new ServiceNow incident.
+
+    Returns the created incident record including its sys_id and incident number (INC...).
+    """
+    instance_url = context.get_secret("SERVICENOW_INSTANCE_URL").rstrip("/")
+    oauth_token = context.get_auth_token_or_empty()
+
+    payload: dict[str, str] = {"short_description": short_description}
+    if description is not None:
+        payload["description"] = description
+    if urgency is not None:
+        payload["urgency"] = _LEVEL_MAP.get(urgency.lower(), urgency)
+    if impact is not None:
+        payload["impact"] = _LEVEL_MAP.get(impact.lower(), impact)
+    if category is not None:
+        payload["category"] = category
+    if caller_id is not None:
+        payload["caller_id"] = caller_id
+
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            f"{instance_url}/api/now/table/incident",
+            headers=_headers(oauth_token),
+            json=payload,
+        )
+        response.raise_for_status()
+        return response.json().get("result", {})
+
+
+@tool(
+    requires_auth=_SERVICENOW_AUTH,
+    requires_secrets=["SERVICENOW_INSTANCE_URL"],
+)
+async def update_incident(
+    context: Context,
+    sys_id_or_number: Annotated[str, "The sys_id or incident number (e.g. INC0001234) to update"],
+    short_description: Annotated[str | None, "New one-line summary"] = None,
+    description: Annotated[str | None, "New detailed description"] = None,
+    urgency: Annotated[str | None, "New urgency: 'high', 'medium', or 'low'"] = None,
+    impact: Annotated[str | None, "New impact: 'high', 'medium', or 'low'"] = None,
+    category: Annotated[
+        str | None, "New category (e.g. 'network', 'hardware', 'software')"
+    ] = None,
+    assigned_to: Annotated[str | None, "ServiceNow username to assign the incident to"] = None,
+) -> dict:
+    """
+    Update one or more fields on an existing ServiceNow incident.
+
+    Returns the full updated incident record.
+    """
+    instance_url = context.get_secret("SERVICENOW_INSTANCE_URL").rstrip("/")
+    oauth_token = context.get_auth_token_or_empty()
+    hdrs = _headers(oauth_token)
+
+    payload: dict[str, str] = {}
+    if short_description is not None:
+        payload["short_description"] = short_description
+    if description is not None:
+        payload["description"] = description
+    if urgency is not None:
+        payload["urgency"] = _LEVEL_MAP.get(urgency.lower(), urgency)
+    if impact is not None:
+        payload["impact"] = _LEVEL_MAP.get(impact.lower(), impact)
+    if category is not None:
+        payload["category"] = category
+    if assigned_to is not None:
+        payload["assigned_to"] = assigned_to
+
+    async with httpx.AsyncClient() as client:
+        sys_id = await _resolve_sys_id(client, hdrs, instance_url, sys_id_or_number)
+        response = await client.patch(
+            f"{instance_url}/api/now/table/incident/{sys_id}",
+            headers=hdrs,
+            json=payload,
+        )
+        response.raise_for_status()
+        return response.json().get("result", {})
+
+
+@tool(
+    requires_auth=_SERVICENOW_AUTH,
+    requires_secrets=["SERVICENOW_INSTANCE_URL"],
+)
+async def search_incidents(
+    context: Context,
+    query: Annotated[
+        str | None,
+        "Raw ServiceNow sysparm_query string (e.g. 'priority=1^state=1'). "
+        "When provided, the individual filter parameters below are ignored.",
+    ] = None,
+    short_description_contains: Annotated[
+        str | None, "Filter to incidents whose short description contains this text"
+    ] = None,
+    state: Annotated[
+        str | None,
+        "Filter by state: 'new', 'in_progress', 'on_hold', 'resolved', 'closed', 'cancelled'",
+    ] = None,
+    priority: Annotated[
+        str | None,
+        "Filter by priority: 'critical', 'high', 'moderate', 'low', 'planning'",
+    ] = None,
+    assigned_to: Annotated[
+        str | None, "Filter by assigned ServiceNow username"
+    ] = None,
+    limit: Annotated[int, "Maximum number of results to return (1-100)"] = 20,
+) -> list[dict]:
+    """
+    Search or filter ServiceNow incidents.
+
+    Supports a raw sysparm_query string for advanced filtering, or individual
+    convenience filters for the most common fields. Results are ordered by most
+    recently updated first.
+    """
+    instance_url = context.get_secret("SERVICENOW_INSTANCE_URL").rstrip("/")
+    oauth_token = context.get_auth_token_or_empty()
+
+    if query is None:
+        parts: list[str] = []
+        if short_description_contains:
+            parts.append(f"short_descriptionLIKE{short_description_contains}")
+        if state:
+            parts.append(f"state={_STATE_MAP.get(state.lower(), state)}")
+        if priority:
+            parts.append(f"priority={_PRIORITY_MAP.get(priority.lower(), priority)}")
+        if assigned_to:
+            parts.append(f"assigned_to.user_name={assigned_to}")
+        query = "^".join(parts) if parts else "active=true"
+
+    params: dict[str, str | int] = {
+        "sysparm_query": f"{query}^ORDERBYDESCsys_updated_on",
+        "sysparm_limit": min(max(1, limit), 100),
+        "sysparm_display_value": "true",
+        "sysparm_fields": _DEFAULT_FIELDS,
+    }
+
+    async with httpx.AsyncClient() as client:
+        response = await client.get(
+            f"{instance_url}/api/now/table/incident",
+            headers=_headers(oauth_token),
+            params=params,
+        )
+        response.raise_for_status()
+        return response.json().get("result", [])
+
+
+@tool(
+    requires_auth=_SERVICENOW_AUTH,
+    requires_secrets=["SERVICENOW_INSTANCE_URL"],
+)
+async def add_comment(
+    context: Context,
+    sys_id_or_number: Annotated[
+        str, "The sys_id or incident number (e.g. INC0001234) to comment on"
+    ],
+    comment: Annotated[str, "The text of the comment to add"],
+    is_work_note: Annotated[
+        bool,
+        "If True, post as an internal work note (visible to agents only). "
+        "If False, post as a customer-visible comment.",
+    ] = False,
+) -> dict:
+    """
+    Add a comment or work note to an existing ServiceNow incident.
+
+    Work notes are internal and visible only to support agents.
+    Regular comments are visible to the end user who reported the incident.
+    Returns the updated incident record.
+    """
+    instance_url = context.get_secret("SERVICENOW_INSTANCE_URL").rstrip("/")
+    oauth_token = context.get_auth_token_or_empty()
+    hdrs = _headers(oauth_token)
+
+    field = "work_notes" if is_work_note else "comments"
+
+    async with httpx.AsyncClient() as client:
+        sys_id = await _resolve_sys_id(client, hdrs, instance_url, sys_id_or_number)
+        response = await client.patch(
+            f"{instance_url}/api/now/table/incident/{sys_id}",
+            headers=hdrs,
+            json={field: comment},
+        )
+        response.raise_for_status()
+        return response.json().get("result", {})
+
+
+@tool(
+    requires_auth=_SERVICENOW_AUTH,
+    requires_secrets=["SERVICENOW_INSTANCE_URL"],
+)
+async def list_my_incidents(
+    context: Context,
+    state: Annotated[
+        str | None,
+        "Filter by state: 'new', 'in_progress', 'on_hold', 'resolved', 'closed', 'cancelled'",
+    ] = None,
+    limit: Annotated[int, "Maximum number of incidents to return (1-100)"] = 20,
+) -> list[dict]:
+    """
+    List incidents assigned to the authenticated user.
+
+    Uses the Arcade session's user identity to filter incidents. Results are
+    ordered by most recently updated first.
+    """
+    instance_url = context.get_secret("SERVICENOW_INSTANCE_URL").rstrip("/")
+    oauth_token = context.get_auth_token_or_empty()
+
+    # context.user_id is the Arcade user identity, used here as the ServiceNow username.
+    # In deployments where identities differ, override via the search_incidents tool.
+    query_parts = [f"assigned_to.user_name={context.user_id}"]
+    if state:
+        query_parts.append(f"state={_STATE_MAP.get(state.lower(), state)}")
+
+    params: dict[str, str | int] = {
+        "sysparm_query": "^".join(query_parts) + "^ORDERBYDESCsys_updated_on",
+        "sysparm_limit": min(max(1, limit), 100),
+        "sysparm_display_value": "true",
+        "sysparm_fields": _DEFAULT_FIELDS,
+    }
+
+    async with httpx.AsyncClient() as client:
+        response = await client.get(
+            f"{instance_url}/api/now/table/incident",
+            headers=_headers(oauth_token),
+            params=params,
+        )
+        response.raise_for_status()
+        return response.json().get("result", [])
+
+
+@tool(
+    requires_auth=_SERVICENOW_AUTH,
+    requires_secrets=["SERVICENOW_INSTANCE_URL"],
+)
+async def change_state(
+    context: Context,
+    sys_id_or_number: Annotated[
+        str, "The sys_id or incident number (e.g. INC0001234) to transition"
+    ],
+    state: Annotated[
+        str,
+        "Target state: 'new', 'in_progress', 'on_hold', 'resolved', 'closed', or 'cancelled'",
+    ],
+    close_notes: Annotated[
+        str | None,
+        "Resolution notes describing how the incident was resolved. "
+        "Required when transitioning to 'resolved' or 'closed'.",
+    ] = None,
+    close_code: Annotated[
+        str | None,
+        "Resolution code (e.g. 'Solved (Permanently)', 'Not Solved (Too Costly)'). "
+        "Required by some ServiceNow configurations when closing an incident.",
+    ] = None,
+) -> dict:
+    """
+    Transition a ServiceNow incident to a new state.
+
+    When resolving or closing an incident, provide close_notes to document the
+    resolution. Returns the updated incident record.
+    """
+    instance_url = context.get_secret("SERVICENOW_INSTANCE_URL").rstrip("/")
+    oauth_token = context.get_auth_token_or_empty()
+    hdrs = _headers(oauth_token)
+
+    payload: dict[str, str] = {"state": _STATE_MAP.get(state.lower(), state)}
+    if close_notes is not None:
+        payload["close_notes"] = close_notes
+    if close_code is not None:
+        payload["close_code"] = close_code
+
+    async with httpx.AsyncClient() as client:
+        sys_id = await _resolve_sys_id(client, hdrs, instance_url, sys_id_or_number)
+        response = await client.patch(
+            f"{instance_url}/api/now/table/incident/{sys_id}",
+            headers=hdrs,
+            json=payload,
+        )
+        response.raise_for_status()
+        return response.json().get("result", {})

--- a/examples/mcp_servers/servicenow/src/servicenow/tools/tools_incidents.py
+++ b/examples/mcp_servers/servicenow/src/servicenow/tools/tools_incidents.py
@@ -53,9 +53,7 @@ def _raise_for_status(response: httpx.Response, resource_hint: str = "") -> None
         return
     code = response.status_code
     if code == 401:
-        raise ValueError(
-            "ServiceNow authentication failed — your OAuth token may have expired."
-        )
+        raise ValueError("ServiceNow authentication failed — your OAuth token may have expired.")
     if code == 403:
         raise ValueError(
             "Permission denied — your ServiceNow account lacks access to this resource."
@@ -154,9 +152,7 @@ async def update_incident(
     description: Annotated[str | None, "New detailed description"] = None,
     urgency: Annotated[str | None, "New urgency: 'high', 'medium', or 'low'"] = None,
     impact: Annotated[str | None, "New impact: 'high', 'medium', or 'low'"] = None,
-    category: Annotated[
-        str | None, "New category (e.g. 'network', 'hardware', 'software')"
-    ] = None,
+    category: Annotated[str | None, "New category (e.g. 'network', 'hardware', 'software')"] = None,
     assigned_to: Annotated[str | None, "ServiceNow username to assign the incident to"] = None,
 ) -> dict:
     """
@@ -215,9 +211,7 @@ async def search_incidents(
         str | None,
         "Filter by priority: 'critical', 'high', 'moderate', 'low', 'planning'",
     ] = None,
-    assigned_to: Annotated[
-        str | None, "Filter by assigned ServiceNow username"
-    ] = None,
+    assigned_to: Annotated[str | None, "Filter by assigned ServiceNow username"] = None,
     limit: Annotated[int, "Maximum number of results to return (1-100)"] = 20,
     offset: Annotated[int, "Number of results to skip for pagination (default 0)"] = 0,
 ) -> list[dict]:


### PR DESCRIPTION
  ---
  ## Summary

  Adds a new example MCP server under `examples/mcp_servers/servicenow/` that
  implements a ServiceNow incident management toolkit using
  `arcade-mcp-server`. The server exposes six tools covering the full incident
  lifecycle — create, update, search, comment, list, and state transition — all
  authenticated via `OAuth2(id="servicenow", scopes=["useraccount"])` with the
  instance base URL supplied as a `SERVICENOW_INSTANCE_URL` secret. The
  package follows the same `src/` layout, `pyproject.toml` structure, and
  `arcade_toolkits` entry-point convention as the other examples in this
  directory.

  ## Tools

  - **`create_incident`** — POST a new incident with short description,
    urgency, impact, category, and optional caller
  - **`update_incident`** — PATCH any subset of fields on an existing incident
    by `sys_id` or `INC`-prefixed number
  - **`search_incidents`** — GET incidents filtered by state, priority,
    assigned user, keyword, or a raw `sysparm_query` string; results ordered
    by most-recently-updated
  - **`add_comment`** — PATCH a customer-visible comment or internal work note
    onto an incident
  - **`list_my_incidents`** — GET incidents assigned to the authenticated user
    (identity sourced from `context.user_id`), with optional state filter
  - **`change_state`** — PATCH a state transition with optional `close_notes`
    and `close_code` for resolve/close workflows

  ## Implementation notes

  - **OAuth2 pattern** — all six tools share a single module-level
    `_SERVICENOW_AUTH = OAuth2(id="servicenow", scopes=["useraccount"])`
    constant passed to each `@tool(requires_auth=...)` decorator, avoiding
    repetition.
  - **`_resolve_sys_id` helper** — a private async function (not a tool) that
    accepts either a 32-char hex `sys_id` or a human-readable `INC0001234`
    number; mutation tools (`update_incident`, `add_comment`, `change_state`)
    call it before their PATCH, making both forms work transparently.
  - **Eval suite** — `evals/eval_servicenow_incidents.py` covers six cases
    across `create_incident`, `search_incidents`, and `change_state` using
    `BinaryCritic` for enum/code fields (urgency, state, priority, INC number)
    and `SimilarityCritic` for free-text fields (short description, close
    notes) where the model is expected to paraphrase.

  ## Tests

  - `uv sync --extra dev && arcade show --local` confirms all 6 tools
    discovered under `Servicenow v0.1.0` (verified — see CI run notes below)
  - `make check` (`ruff` + `mypy`) clean — new files are under
    `examples/mcp_servers/servicenow/`, which is outside the root `mypy`
    paths and linted only if explicitly included; the example itself uses
    no bare `pip`, no stray print, and no imports beyond `httpx`,
    `arcade_mcp_server`, and stdlib
  - MCP stdio channel verified clean — no `print()` or logging-to-stdout in
    any reachable code path; all tools are `async` and write only to the
    return value

  **Test plan checklist:**
  - [x] `arcade show --local` confirms all 6 tools are discovered (`Found 6 tools`)
  - [x] `make check` (ruff + mypy) clean — no new lint or type errors
  - [x] Verified MCP stdio channel stays clean (no stray stdout/stderr in tool
    paths)

  ## Versioning

  No library version bumps. This PR adds files only under
  `examples/mcp_servers/servicenow/` and touches no existing source file, no
  existing `pyproject.toml`, and no library under `libs/`.

  ---

  > [!NOTE]
  > **Zero blast radius**
  > New example directory only — no existing code, library, test, or
  > configuration file is modified. The `arcade_toolkits` entry point in the
  > new `pyproject.toml` is scoped to this package's own venv and does not
  > affect any other installed environment.
  >
  > **Coverage**
  > New example code. No coverage requirement applies to `examples/`.