### PR TITLE
feat(arcade-core): add OBSERVABILITY ServiceDomain

### DIFF
--- a/libs/arcade-core/arcade_core/metadata.py
+++ b/libs/arcade-core/arcade_core/metadata.py
@@ -109,6 +109,9 @@ class ServiceDomain(str, Enum):
     PRODUCT_ANALYTICS = "product_analytics"
     """Product analytics — user behavior tracking, funnels, retention, session replay, and experimentation."""
 
+    OBSERVABILITY = "observability"
+    """Logs, traces, metrics, and APM for application and infrastructure monitoring."""
+
 
 class Operation(str, Enum):
     """

--- a/libs/tests/tool/test_tool_metadata.py
+++ b/libs/tests/tool/test_tool_metadata.py
@@ -86,6 +86,23 @@ class TestToolMetadataValidation:
         )
         assert metadata is not None
 
+    def test_observability_service_domain_validates(self):
+        """A read-only observability tool classifies and validates cleanly."""
+        assert ServiceDomain.OBSERVABILITY.value == "observability"
+        metadata = ToolMetadata(
+            classification=Classification(
+                service_domains=[ServiceDomain.OBSERVABILITY],
+            ),
+            behavior=Behavior(
+                operations=[Operation.READ],
+                read_only=True,
+                destructive=False,
+                idempotent=True,
+                open_world=True,
+            ),
+        )
+        metadata.validate_for_tool()
+
     def test_mutating_operation_with_read_only_raises(self):
         """Mutating operations with read_only=True should raise when validated."""
         metadata = ToolMetadata(


### PR DESCRIPTION
## What

Adds `OBSERVABILITY` to the `ServiceDomain` enum in `arcade_core/metadata.py`:

```python
OBSERVABILITY = "observability"
"""Logs, traces, metrics, and APM for application and infrastructure monitoring."""
```

## Why

The Datadog toolkit interfaces with an observability/monitoring platform (logs, spans, traces, aggregations, facets). No existing `ServiceDomain` fits:

- `INCIDENT_MANAGEMENT` is on-call management and operational alerting (PagerDuty), not log/trace/APM querying.
- `PRODUCT_ANALYTICS` is user-behavior analytics (funnels, retention, session replay).

Per the convention in `.claude/rules/worker/tool-metadata.md`, a recognized market category that no current enum value covers should get a domain added upstream rather than be left unset. `OBSERVABILITY` passes the 10/10 test for Datadog and also covers future Splunk / New Relic / Grafana / Honeycomb toolkits.

## Unblocks

The `classification=Classification(service_domains=[ServiceDomain.OBSERVABILITY])` wiring on the Datadog toolkit, which is gated on this value shipping in a published `arcade-core`.

## Tests

- `libs/tests/tool/test_tool_metadata.py::TestToolMetadataValidation::test_observability_service_domain_validates` (new) verifies the member value and that a read-only observability tool validates cleanly.
- Full `test_tool_metadata.py` + `test_tool_metadata_serialization.py`: 59 passed.
- mypy clean on arcade-core; pre-commit ruff/ruff-format pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive enum and test only; no changes to validation rules or runtime behavior beyond allowing the new classification value.
> 
> **Overview**
> Adds **`ServiceDomain.OBSERVABILITY`** (`"observability"`) to `arcade_core/metadata.py` so tools for logs, traces, metrics, and APM can be classified separately from incident management and product analytics.
> 
> Adds **`test_observability_service_domain_validates`**, which checks the enum string and that a read-only, open-world observability `ToolMetadata` passes **`validate_for_tool()`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 846c5f33e389aed468d3c232fd7acb10c40f4cf9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->