### PR TITLE
fix(arcade-mcp): bump authlib to >=1.7.1 for CVE remediation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "arcade-mcp"
-version = "1.14.3"
+version = "1.14.4"
 description = "Arcade.dev - Tool Calling platform for Agents"
 readme = "README.md"
 license = { file = "LICENSE" }
@@ -24,7 +24,7 @@ dependencies = [
     "typer==0.10.0",
     "rich>=14.0.0,<15.0.0",
     "Jinja2==3.1.6",
-    "authlib==1.6.9",
+    "authlib>=1.7.1",
     "arcadepy==1.8.0",
     "tqdm==4.67.1",
     "click==8.1.8",


### PR DESCRIPTION
resolves: https://linear.app/arcadedev/issue/TOO-1052/authlib-medium-cve-2026-41425-41479-44681-appsworkerarcade-mcp-sla-jun

## What

Bumps `authlib` from pinned `==1.6.9` to `>=1.7.1` in the root `pyproject.toml`, and patch-bumps the `arcade-mcp` package version `1.14.3` → `1.14.4`.

After `uv lock`, authlib resolves to **1.7.2**.

## Why

`authlib==1.6.9` sits below the fix for three CVEs flagged against this repo. GHSA-44681 in particular is not fixed until **1.6.12 / 1.7.1**, so the prior pin left it open. Flooring at `>=1.7.1` clears all three.

The Vanta finding labeled this against apps/worker/arcade-mcp, but the worker has no lockfile of its own and pulls authlib transitively through `arcade-mcp-server`. The remediation belongs here in arcade-mcp; the floor now propagates through the workspace. Coordinator is already clear at 1.7.1.

## Notes

- `uv.lock` is gitignored (`*.lock` in `.gitignore`), so it does not appear in this diff. The enforceable constraint is the `pyproject.toml` floor.
- `types-Authlib>=1.3.0` (dev-only stubs) is unaffected and left as-is.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only version floor for a security fix; no changes to OAuth or auth implementation code in this diff.
> 
> **Overview**
> **Security dependency update** for the `arcade-mcp` package: bumps the project version to **1.14.4** and relaxes the `authlib` constraint from a pinned **1.6.9** to **`>=1.7.1`** so installs pick up patched releases (e.g. 1.7.2 after lock refresh).
> 
> That floor addresses CVE findings tied to older `authlib` (including GHSA-44681, which needs **≥1.7.1**). The constraint propagates through the workspace to consumers that pull `authlib` via this package (e.g. worker paths using `arcade-mcp-server`), without changing application OAuth code—only the declared minimum library version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4d75cd75abf2a667b993c38aadadd647fc5be5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->