### PR TITLE
fix(arcade-mcp-server): drop old key on prompt rename in update_prompt

### DIFF
--- a/libs/arcade-mcp-server/arcade_mcp_server/managers/prompt.py
+++ b/libs/arcade-mcp-server/arcade_mcp_server/managers/prompt.py
@@ -111,9 +111,13 @@ class PromptManager(ComponentManager[str, PromptHandler]):
         prompt: Prompt,
         handler: Callable[[dict[str, str]], list[PromptMessage]] | None = None,
     ) -> Prompt:
-        # Ensure exists
+        # Remove the existing entry (this also verifies it exists). Removing by the
+        # original ``name`` rather than just upserting by ``prompt.name`` ensures a
+        # rename (prompt.name != name) does not leave the old entry orphaned in the
+        # registry. Mirrors ResourceManager.update_resource, which handles URI
+        # changes the same way.
         try:
-            _ = await self.registry.get(name)
+            await self.registry.remove(name)
         except KeyError:
             raise NotFoundError(f"Prompt '{name}' not found")
 

--- a/libs/tests/arcade_mcp_server/test_prompt.py
+++ b/libs/tests/arcade_mcp_server/test_prompt.py
@@ -239,3 +239,30 @@ class TestPromptManager:
 
         with pytest.raises(PromptError):
             await manager.get_prompt("error_prompt", {})
+
+    @pytest.mark.asyncio
+    async def test_update_prompt_rename_does_not_orphan_old_entry(
+        self, prompt_manager, sample_prompt, prompt_function
+    ):
+        """A rename via update_prompt must not leave the old entry orphaned."""
+        await prompt_manager.add_prompt(sample_prompt, prompt_function)
+
+        renamed = sample_prompt.model_copy(update={"name": "greeting_v2"})
+        await prompt_manager.update_prompt(sample_prompt.name, renamed, prompt_function)
+
+        prompts = await prompt_manager.list_prompts()
+        assert len(prompts) == 1
+        assert prompts[0].name == "greeting_v2"
+        with pytest.raises(NotFoundError):
+            await prompt_manager.get_prompt("greeting", {"name": "Bob"})
+        result = await prompt_manager.get_prompt("greeting_v2", {"name": "Bob"})
+        assert isinstance(result, GetPromptResult)
+
+    @pytest.mark.asyncio
+    async def test_update_prompt_missing_raises_not_found(
+        self, prompt_manager, sample_prompt, prompt_function
+    ):
+        """Updating a prompt that does not exist raises NotFoundError."""
+        missing = sample_prompt.model_copy(update={"name": "nope"})
+        with pytest.raises(NotFoundError):
+            await prompt_manager.update_prompt("nope", missing, prompt_function)


### PR DESCRIPTION
## What

`PromptManager.update_prompt` verified that a prompt existed under the input `name`, then upserted the new handler under `prompt.name`. When `prompt.name` differs from `name` — a rename — the entry under the old `name` was never removed, so the registry kept a stale, orphaned prompt. `ResourceManager.update_resource` already does this correctly.

This change mirrors `update_resource`: it removes by the old `name` first (which also serves as the existence check, raising `NotFoundError` when the prompt is missing), then upserts by `prompt.name`.

## Why

Found while reviewing the in-progress TypeScript port, where the same bug had been faithfully reproduced. The TS side has been fixed in parallel; this PR fixes the Python original so the two stay aligned.

## Tests

Added two regression tests in `libs/tests/arcade_mcp_server/test_prompt.py`:
- `test_update_prompt_rename_does_not_orphan_old_entry`
- `test_update_prompt_missing_raises_not_found`

`uv run pytest libs/tests/arcade_mcp_server/test_prompt.py` — 16 passed. `ruff check` / `ruff format --check` clean.

Closes PLT-2067.

🐕 Written by Kyoto, an AI agent, on Pascal's behalf —

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized registry fix with tests; no auth, data, or API surface changes beyond correct prompt rename behavior.
> 
> **Overview**
> Fixes a registry bug where **renaming a prompt** via `update_prompt` left the old name registered alongside the new one.
> 
> `PromptManager.update_prompt` now **removes the entry under the original `name`** before upserting under `prompt.name`, matching how `ResourceManager.update_resource` handles URI changes. Missing prompts still raise `NotFoundError` via the remove step.
> 
> Adds regression tests for rename (single listing, old name not found) and update of a non-existent prompt.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ebdcda15cef003085ebd1c0c496e31ed2b4cd97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->