### PR TITLE
fix(examples): bump uv base image to patched 0.11.21-python3.11-trixie-slim

### DIFF
--- a/examples/docker-template/docker/Dockerfile
+++ b/examples/docker-template/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/astral-sh/uv:python3.11-bookworm-slim
+FROM ghcr.io/astral-sh/uv:0.11.21-python3.11-trixie-slim
 
 # Create non-root user
 RUN useradd -m -u 1000 appuser

--- a/examples/mcp_servers/authorization/docker/Dockerfile
+++ b/examples/mcp_servers/authorization/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/astral-sh/uv:python3.11-bookworm-slim
+FROM ghcr.io/astral-sh/uv:0.11.21-python3.11-trixie-slim
 
 # Create non-root user
 RUN useradd -m -u 1000 appuser

--- a/examples/mcp_servers/logging/docker/Dockerfile
+++ b/examples/mcp_servers/logging/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/astral-sh/uv:python3.11-bookworm-slim
+FROM ghcr.io/astral-sh/uv:0.11.21-python3.11-trixie-slim
 
 # Create non-root user
 RUN useradd -m -u 1000 appuser

--- a/examples/mcp_servers/pctx_code_mode/docker/Dockerfile
+++ b/examples/mcp_servers/pctx_code_mode/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/astral-sh/uv:python3.11-bookworm-slim
+FROM ghcr.io/astral-sh/uv:0.11.21-python3.11-trixie-slim
 
 RUN useradd -m -u 1000 appuser
 


### PR DESCRIPTION
## What

Bumps the uv base image in the four example Dockerfiles from the floating `ghcr.io/astral-sh/uv:python3.11-bookworm-slim` tag to the pinned `ghcr.io/astral-sh/uv:0.11.21-python3.11-trixie-slim`.

- `examples/docker-template/docker/Dockerfile`
- `examples/mcp_servers/authorization/docker/Dockerfile`
- `examples/mcp_servers/logging/docker/Dockerfile`
- `examples/mcp_servers/pctx_code_mode/docker/Dockerfile`

## Why

The `uv` binary is written in Rust and statically vendors `rustls-webpki`, so container scanners report that crate as a package present in any image built on a uv base.

The floating `python3.11-bookworm-slim` tag is **frozen at uv 0.9.30**, whose `uv` binary vendors **rustls-webpki 0.103.8**, which is vulnerable to **GHSA-82j2-j2ch-gfr8** (HIGH: DoS via panic on a malformed CRL BIT STRING, fixed in 0.103.13). uv **0.11.21** vendors **rustls-webpki 0.103.13**, so pinning to it clears the advisory.

Newer uv releases moved the Python + Debian bundled image from `bookworm-slim` (Debian 12) to `trixie-slim` (Debian 13); the old `*-bookworm-slim` tags stopped updating at 0.9.30. `python3.11-trixie-slim` is the maintained successor, so the bump also moves the example OS layer to current Debian stable.

## Verification

- `uv` 0.11.21 `Cargo.lock` pins `rustls-webpki 0.103.13` (vs 0.103.8 in 0.9.30, the frozen floating tag).
- GHSA-82j2-j2ch-gfr8 first patched version is `0.103.13` (confirmed via the GitHub advisory API).
- `ghcr.io/astral-sh/uv:0.11.21-python3.11-trixie-slim` exists and is multi-arch (`linux/amd64` + `linux/arm64`); index digest `sha256:64bf733d19003ab1de5d88a3f4494937637e737452bc980083cb67655419e932`.
- No tests or other repo files reference the base-image tag; the four `build:`-based compose files inherit the change automatically.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Examples-only base-image tag changes with no application or runtime logic edits; main caveat is Debian 12→13 in the image layer for local/example builds.
> 
> **Overview**
> Updates the **`FROM`** line in four example Dockerfiles from the floating **`ghcr.io/astral-sh/uv:python3.11-bookworm-slim`** tag to the pinned **`ghcr.io/astral-sh/uv:0.11.21-python3.11-trixie-slim`**.
> 
> That pins a newer **`uv`** build (with patched **`rustls-webpki`**) and shifts the bundled OS from **bookworm** to **trixie** on the maintained image line. Affected paths: **`examples/docker-template/docker/Dockerfile`** and the three **`examples/mcp_servers/*/docker/Dockerfile`** copies; no other Dockerfile steps change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5eea1bf29f12d48c8c340138f2f20170a1deed03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->