### PR TITLE
feat(metadata): add SURVEY ServiceDomain

### DIFF
--- a/libs/arcade-core/arcade_core/metadata.py
+++ b/libs/arcade-core/arcade_core/metadata.py
@@ -118,6 +118,9 @@ class ServiceDomain(str, Enum):
     SALES_INTELLIGENCE = "sales_intelligence"
     """Sales intelligence and prospecting platforms: B2B contact and company databases, lead enrichment, and buyer intent data."""
 
+    SURVEY = "survey"
+    """Survey, form, and questionnaire builders for collecting and analyzing responses."""
+
 
 class Operation(str, Enum):
     """

--- a/libs/arcade-core/pyproject.toml
+++ b/libs/arcade-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "arcade-core"
-version = "4.9.0"
+version = "4.10.0"
 description = "Arcade Core - Core library for Arcade platform"
 readme = "README.md"
 license = { text = "MIT" }

--- a/libs/tests/tool/test_tool_metadata.py
+++ b/libs/tests/tool/test_tool_metadata.py
@@ -365,6 +365,24 @@ class TestToolDecoratorWithMetadata:
             ServiceDomain.CONTACTS
         ]
 
+    def test_decorator_accepts_survey_domain(self):
+        """SURVEY classifies survey / form-builder services (e.g. Google Forms)."""
+        assert ServiceDomain.SURVEY.value == "survey"
+
+        @tool(
+            desc="List form responses",
+            metadata=ToolMetadata(
+                classification=Classification(service_domains=[ServiceDomain.SURVEY]),
+                behavior=Behavior(operations=[Operation.READ], read_only=True, open_world=True),
+            ),
+        )
+        def list_responses() -> str:
+            return "results"
+
+        assert list_responses.__tool_metadata__.classification.service_domains == [
+            ServiceDomain.SURVEY
+        ]
+
     def test_decorator_without_metadata_is_backward_compatible(self):
         """Decorator should work without metadata (existing tools unchanged)."""
 


### PR DESCRIPTION
## Summary

Adds a `SURVEY` value to the `ServiceDomain` enum in `arcade_core.metadata`.

Survey / form / questionnaire builders (Google Forms, Typeform, SurveyMonkey, Qualtrics, etc.) have no fitting `ServiceDomain` today — none of the existing values passes the 10/10 test for "is this a survey tool?". Per the tool-metadata convention, a missing-but-warranted category should be added upstream (the same path `OBSERVABILITY` took for Datadog) rather than forcing tools into the wrong domain or defaulting to `None`.

```python
SURVEY = "survey"
"""Survey, form, and questionnaire builders for collecting and analyzing responses."""
```

## First consumer

The Google Forms worker toolkit (ArcadeAI/monorepo#939). Its 21 tools currently ship without a `Classification` because no domain fit; once this releases, that toolkit will bump its `arcade-mcp-server` minimum and classify all tools as `SURVEY`.

## Test plan

- Adds `test_decorator_accepts_survey_domain` mirroring the existing per-domain acceptance tests.
- New enum member only; no behavior change to existing domains.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive enum member and version bump only; no changes to validation logic or existing ServiceDomain values.
> 
> **Overview**
> Adds **`ServiceDomain.SURVEY`** (`"survey"`) to `arcade_core.metadata` so survey, form, and questionnaire integrations (e.g. Google Forms) can be classified for discovery and search boosting instead of leaving `Classification` unset or mis-tagging another domain.
> 
> **`arcade-core`** is bumped **4.9.0 → 4.10.0** for the release. A decorator acceptance test **`test_decorator_accepts_survey_domain`** follows the same pattern as other per-domain tests; existing domains and validation rules are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1377fab0ed5700ec092da199c4cf3674a3804e1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->