### PR TITLE
feat(arcade-core): add CONTACTS service domain (TOO-1322)

### DIFF
--- a/libs/arcade-core/arcade_core/metadata.py
+++ b/libs/arcade-core/arcade_core/metadata.py
@@ -40,6 +40,9 @@ class ServiceDomain(str, Enum):
     CRM = "crm"
     """Customer relationship management - contacts, deals, pipelines, sales activities."""
 
+    CONTACTS = "contacts"
+    """Address books and people directories — managing personal or organizational contact records."""
+
     EMAIL = "email"
     """Email services for sending, receiving, and managing messages."""
 

--- a/libs/tests/tool/test_tool_metadata.py
+++ b/libs/tests/tool/test_tool_metadata.py
@@ -347,6 +347,24 @@ class TestToolDecoratorWithMetadata:
             ServiceDomain.SALES_INTELLIGENCE
         ]
 
+    def test_decorator_accepts_contacts_domain(self):
+        """CONTACTS classifies address-book / people-directory services (e.g. Google Contacts)."""
+        assert ServiceDomain.CONTACTS.value == "contacts"
+
+        @tool(
+            desc="Search the organization directory",
+            metadata=ToolMetadata(
+                classification=Classification(service_domains=[ServiceDomain.CONTACTS]),
+                behavior=Behavior(operations=[Operation.READ], read_only=True, open_world=True),
+            ),
+        )
+        def search_directory() -> str:
+            return "results"
+
+        assert search_directory.__tool_metadata__.classification.service_domains == [
+            ServiceDomain.CONTACTS
+        ]
+
     def test_decorator_without_metadata_is_backward_compatible(self):
         """Decorator should work without metadata (existing tools unchanged)."""
 


### PR DESCRIPTION
## What

Adds a `CONTACTS` member to `ServiceDomain` (`arcade_core.metadata`, re-exported via `arcade_mcp_server.metadata`):

```
CONTACTS = "contacts"
"""Address books and people directories — managing personal or organizational contact records."""
```

## Why

The `google_contacts` toolkit is the only Google toolkit in the monorepo with **no** `ServiceDomain` — every sibling sets one (gmail→EMAIL, calendar→CALENDAR, docs→DOCUMENTS, drive→CLOUD_STORAGE, sheets→SPREADSHEETS, slides→PRESENTATIONS). No existing value fits an address book:

- `CRM` fails the 10/10 test — Google Contacts is a personal/org address book, not a sales-pipeline CRM (Salesforce/HubSpot/Attio).
- `SALES_INTELLIGENCE` is prospecting/lead databases (Apollo), not a personal/org directory.

Per the metadata convention (the `Datadog → OBSERVABILITY` / `Apollo → SALES_INTELLIGENCE` precedent), when no `ServiceDomain` fits a recognized external service, add one upstream rather than force a wrong category.

## Changes

- `ServiceDomain.CONTACTS = "contacts"` with a docstring, placed next to `CRM` so the distinction is explicit.
- A test asserting the enum value and a classified-tool round-trip (mirrors `test_decorator_accepts_sales_intelligence_domain`).

No version bump (consistent with the prior service-domain additions; handled at release).

## Test plan

- [x] `uv run pytest -W ignore libs/tests/tool/test_tool_metadata.py libs/tests/arcade_mcp_server/test_tool_metadata_serialization.py` — 61 passed (incl. new `test_decorator_accepts_contacts_domain`)

## Downstream

Unblocks **TOO-1322** in the monorepo: once released, bump `arcade-mcp-server` in `google_contacts` and classify its 5 tools with `ServiceDomain.CONTACTS`.

Refs: TOO-1322

---

🤖 Generated with [Claude Code](https://claude.com/claude-code); author is accountable for every line.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive enum and test only; no changes to auth, runtime behavior, or existing tool metadata rules.
> 
> **Overview**
> Adds **`ServiceDomain.CONTACTS`** (`"contacts"`) to `arcade_core.metadata`, positioned next to **`CRM`**, for address books and people directories (e.g. Google Contacts) rather than sales CRM or prospecting tools.
> 
> A new decorator test checks the enum value and that tools can classify with **`CONTACTS`** end-to-end, matching the existing **`SALES_INTELLIGENCE`** pattern. No validation or serialization logic changes beyond the new enum member.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54171279a3b5d8b4457e8972026b26ddfda3ba82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->