### PR TITLE
chore(arcade-core): bump to 4.10.0 for CONTACTS service domain (TOO-1322)

### DIFF
--- a/libs/arcade-core/pyproject.toml
+++ b/libs/arcade-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "arcade-core"
-version = "4.9.0"
+version = "4.10.0"
 description = "Arcade Core - Core library for Arcade platform"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
## What

Bumps `arcade-core` `4.9.0` → `4.10.0`.

## Why

#881 added `ServiceDomain.CONTACTS` but was merged **without** a version bump. The prior service-domain addition (#866, `SALES_INTELLIGENCE`) shipped the enum + a minor `arcade-core` bump in the same PR (`4.7.3` → `4.8.0`); #881 missed the bump. This follow-up marks the release that includes `CONTACTS` so downstream consumers can pin it.

## Changes

- `libs/arcade-core/pyproject.toml`: `version = "4.10.0"` (minor — new enum value, backward-compatible).

## Test plan

- [x] No code change; `CONTACTS` already on `main` via #881. Bump only.

Refs: TOO-1322

---

🤖 Generated with [Claude Code](https://claude.com/claude-code); author is accountable for every line.
