### PR TITLE
feat(arcade-cli): deploy Cloudflare Python (Pyodide) workers (PLT-2154)

### DIFF
--- a/libs/arcade-cli/arcade_cli/deploy.py
+++ b/libs/arcade-cli/arcade_cli/deploy.py
@@ -7,6 +7,7 @@ import random
 import subprocess
 import tarfile
 import time
+import zipfile
 from collections import deque
 from pathlib import Path
 from typing import cast
@@ -94,6 +95,11 @@ class CreateDeploymentRequest(BaseModel):
     name: str
     description: str
     toolkits: DeploymentToolkits
+    # Optional deployment target. Sent only when set (model_dump(exclude_none=True))
+    # so the default path is byte-for-byte unchanged. The engine routes by these:
+    # host="cloudflare" + runtime="python" selects the Cloudflare Pyodide path.
+    host: str | None = None
+    runtime: str | None = None
 
 
 class UpdateDeploymentRequest(BaseModel):
@@ -353,6 +359,23 @@ def update_deployment(
         client.close()
 
 
+def _is_excluded_archive_path(parts: tuple[str, ...]) -> bool:
+    """Return True if any path component should be excluded from a deployment
+    archive: hidden files/dirs, __pycache__, .egg-info, dist/build, .lock files.
+    Shared by the tar.gz and zip packagers so they exclude the same things.
+    """
+    for part in parts:
+        if (
+            part.startswith(".")
+            or part == "__pycache__"
+            or part.endswith(".egg-info")
+            or part in ["dist", "build"]
+            or part.endswith(".lock")
+        ):
+            return True
+    return False
+
+
 def create_package_archive(package_dir: Path) -> str:
     """
     Create a tar.gz archive of the package directory.
@@ -373,29 +396,8 @@ def create_package_archive(package_dir: Path) -> str:
         raise ValueError(f"Package path must be a directory: {package_dir}")
 
     def exclude_filter(tarinfo: tarfile.TarInfo) -> tarfile.TarInfo | None:
-        """Filter for files/directories to exclude from the archive.
-
-        Filters out:
-        - Hidden files and directories
-        - __pycache__ directories
-        - .egg-info directories
-        - dist and build directories
-        - files ending with .lock
-        """
-        name = tarinfo.name
-
-        parts = Path(name).parts
-
-        for part in parts:
-            if (
-                part.startswith(".")
-                or part == "__pycache__"
-                or part.endswith(".egg-info")
-                or part in ["dist", "build"]
-                or part.endswith(".lock")
-            ):
-                return None
-
+        if _is_excluded_archive_path(Path(tarinfo.name).parts):
+            return None
         return tarinfo
 
     # Create tar.gz archive in memory
@@ -409,6 +411,46 @@ def create_package_archive(package_dir: Path) -> str:
     package_bytes_b64 = base64.b64encode(package_bytes).decode("utf-8")
 
     return package_bytes_b64
+
+
+def create_zip_archive(package_dir: Path) -> str:
+    """
+    Create a zip archive of the package directory, base64-encoded.
+
+    Used for Cloudflare Python (Pyodide) workers: the engine detects a Python
+    worker by the zip container, then uploads each file in it as a separate
+    Worker module. Unlike create_package_archive (tar.gz, used by the
+    JavaScript/Porter paths), entries are stored *relative to package_dir* with
+    no top-level directory, so a worker entrypoint like "src/worker.py" resolves
+    inside the archive. The same exclusion rules apply.
+
+    Args:
+        package_dir: Path to the worker directory to archive
+
+    Returns:
+        Base64-encoded string of the zip archive bytes
+
+    Raises:
+        ValueError: If package_dir doesn't exist or is not a directory
+    """
+    if not package_dir.exists():
+        raise ValueError(f"Package directory not found: {package_dir}")
+
+    if not package_dir.is_dir():
+        raise ValueError(f"Package path must be a directory: {package_dir}")
+
+    byte_stream = io.BytesIO()
+    with zipfile.ZipFile(byte_stream, mode="w", compression=zipfile.ZIP_DEFLATED) as zf:
+        for path in sorted(package_dir.rglob("*")):
+            if not path.is_file():
+                continue
+            rel = path.relative_to(package_dir)
+            if _is_excluded_archive_path(rel.parts):
+                continue
+            zf.write(path, arcname=rel.as_posix())
+
+    byte_stream.seek(0)
+    return base64.b64encode(byte_stream.read()).decode("utf-8")
 
 
 def _resolve_server_process_stdio(debug: bool) -> tuple[int | None, int | None]:
@@ -819,6 +861,7 @@ def deploy_server_logic(
     force_tls: bool,
     force_no_tls: bool,
     debug: bool,
+    runtime: str = "auto",
 ) -> None:
     """
     Main logic for deploying an MCP server to Arcade Engine.
@@ -873,17 +916,28 @@ def deploy_server_logic(
     else:
         console.print("[!] No .env file found in current or parent directories", style="yellow")
 
-    # Step 4: Verify server and extract metadata (or skip if --skip-validate)
+    # A Cloudflare Python (Pyodide) worker is deployed as a zip archive and runs
+    # on the Workers runtime, so it can't be started locally under CPython for
+    # validation — skip that step (main.py requires an explicit name/version).
+    is_cloudflare_python = runtime == "python"
+
+    # Step 4: Verify server and extract metadata (or skip)
     required_secrets_from_validation: set[str] = set()
 
-    if skip_validate:
-        console.print("\n[!] Skipping server validation (--skip-validate set)", style="yellow")
-        # Use the provided server_name and server_version
-        # These are guaranteed to be set due to validation in main.py
+    if skip_validate or is_cloudflare_python:
+        if is_cloudflare_python:
+            console.print(
+                "\n[!] Cloudflare Python worker: skipping local validation "
+                "(a Pyodide worker can't run under plain CPython)",
+                style="yellow",
+            )
+        else:
+            console.print("\n[!] Skipping server validation (--skip-validate set)", style="yellow")
+        # server_name/version are guaranteed set by validation in main.py.
         if server_name is None:
-            raise ValueError("server_name must be provided when skip_validate is True")
+            raise ValueError("server_name must be provided when skipping validation")
         if server_version is None:
-            raise ValueError("server_version must be provided when skip_validate is True")
+            raise ValueError("server_version must be provided when skipping validation")
 
         console.print(f"✓ Using server name: {server_name}", style="green")
         console.print(f"✓ Using server version: {server_version}", style="green")
@@ -926,10 +980,15 @@ def deploy_server_logic(
         else:
             console.print("\n✓ No required secrets found", style="green")
 
-    # Step 6: Create tar.gz archive of current directory
+    # Step 6: Package the current directory. Cloudflare Python workers ship as a
+    # zip (the engine detects Python by the zip container); the default path ships
+    # a tar.gz.
     console.print("\nCreating deployment package...", style="dim")
     try:
-        archive_base64 = create_package_archive(current_dir)
+        if is_cloudflare_python:
+            archive_base64 = create_zip_archive(current_dir)
+        else:
+            archive_base64 = create_package_archive(current_dir)
         archive_size_kb = len(archive_base64) * 3 / 4 / 1024  # base64 is ~4/3 larger
         console.print(f"✓ Package created ({archive_size_kb:.1f} KB)", style="green")
     except Exception as e:
@@ -959,8 +1018,13 @@ def deploy_server_logic(
                 name=server_name,
                 description="MCP Server deployed via CLI",
                 toolkits=deployment_toolkits,
+                # A Cloudflare Python worker must target the Cloudflare host
+                # explicitly — runtime-only Python routing goes to Porter.
+                host="cloudflare" if is_cloudflare_python else None,
+                runtime="python" if is_cloudflare_python else None,
             )
-            deploy_server_to_engine(engine_url, create_request.model_dump(), debug)
+            # exclude_none keeps the default (auto) payload byte-for-byte unchanged.
+            deploy_server_to_engine(engine_url, create_request.model_dump(exclude_none=True), debug)
     except Exception as e:
         raise ValueError(f"Deployment failed: {e}") from e
 

--- a/libs/arcade-cli/arcade_cli/main.py
+++ b/libs/arcade-cli/arcade_cli/main.py
@@ -946,6 +946,21 @@ def deploy(
         rich_help_panel="Advanced",
         click_type=click.Choice(["auto", "all", "skip"], case_sensitive=False),
     ),
+    runtime: str = typer.Option(
+        "auto",
+        "--runtime",
+        "-r",
+        help=(
+            "Worker runtime / deployment target:\n"
+            "  `auto` (default): a standard MCP server; packaged as tar.gz and validated locally.\n"
+            "  `python`: a Cloudflare Python (Pyodide) worker; packaged as a zip and deployed to "
+            "Cloudflare. Local validation is skipped (a Pyodide worker can't run under CPython), so "
+            "`--server-name` and `--server-version` are required, and `--entrypoint` must be the `.py` "
+            "main module (e.g. `src/worker.py`)."
+        ),
+        show_choices=True,
+        click_type=click.Choice(["auto", "python"], case_sensitive=False),
+    ),
     host: str = typer.Option(
         PROD_ENGINE_HOST,
         "--host",
@@ -988,12 +1003,17 @@ def deploy(
     """
     from arcade_cli.deploy import deploy_server_logic
 
-    if skip_validate and not (server_name and server_version):
+    # A Cloudflare Python worker can't be validated locally (it runs on Pyodide),
+    # so it skips validation and therefore needs an explicit name and version,
+    # exactly like --skip-validate.
+    needs_explicit_metadata = skip_validate or runtime == "python"
+    if needs_explicit_metadata and not (server_name and server_version):
+        flag = "--runtime python" if runtime == "python" else "--skip-validate"
         handle_cli_error(
-            "When --skip-validate is set, you must provide --server-name and --server-version.",
+            f"When {flag} is set, you must provide --server-name and --server-version.",
             should_exit=True,
         )
-    if skip_validate and secrets == "auto":
+    if needs_explicit_metadata and secrets == "auto":
         secrets = "skip"
 
     try:
@@ -1008,6 +1028,7 @@ def deploy(
             force_tls=force_tls,
             force_no_tls=force_no_tls,
             debug=debug,
+            runtime=runtime,
         )
     except Exception as e:
         handle_cli_error("Failed to deploy server", e, debug)

--- a/libs/tests/cli/deploy/test_deploy.py
+++ b/libs/tests/cli/deploy/test_deploy.py
@@ -3,6 +3,7 @@ import io
 import socket
 import subprocess
 import tarfile
+import zipfile
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -10,7 +11,12 @@ import httpx
 import pytest
 from arcade_cli.deploy import (
     DEPLOY_TIMEOUT_SECONDS,
+    CreateDeploymentRequest,
+    DeploymentToolkits,
+    ToolkitBundle,
     create_package_archive,
+    create_zip_archive,
+    deploy_server_logic,
     deploy_server_to_engine,
     get_required_secrets,
     get_server_info,
@@ -160,6 +166,161 @@ def test_create_package_archive_excludes_files(tmp_path: Path) -> None:
         # Verify included files are present
         assert any("main.py" in name for name in filenames)
         assert any("pyproject.toml" in name for name in filenames)
+
+
+# Tests for create_zip_archive (Cloudflare Python worker packaging)
+
+
+def test_create_zip_archive_uses_relative_paths(tmp_path: Path) -> None:
+    """Entries are stored relative to the package dir (no top-level dir), so a
+    'src/worker.py' entrypoint resolves inside the archive."""
+    worker = tmp_path / "worker"
+    (worker / "src").mkdir(parents=True)
+    (worker / "src" / "worker.py").write_text("main", encoding="utf-8")
+    (worker / "python_modules").mkdir()
+    (worker / "python_modules" / "six.py").write_text("x = 1", encoding="utf-8")
+    (worker / "pyproject.toml").write_text("project", encoding="utf-8")
+
+    archive_base64 = create_zip_archive(worker)
+    names = zipfile.ZipFile(io.BytesIO(base64.b64decode(archive_base64))).namelist()
+
+    assert "src/worker.py" in names
+    assert "python_modules/six.py" in names
+    assert "pyproject.toml" in names
+    # No top-level directory prefix (unlike the tar.gz packager).
+    assert not any(name.startswith("worker/") for name in names)
+
+
+def test_create_zip_archive_excludes_files(tmp_path: Path) -> None:
+    """The same exclusions as the tar.gz packager apply."""
+    worker = tmp_path / "worker"
+    worker.mkdir()
+    (worker / "worker.py").write_text("main", encoding="utf-8")
+    (worker / ".venv-workers").mkdir()
+    (worker / ".venv-workers" / "x").write_text("v", encoding="utf-8")
+    (worker / "__pycache__").mkdir()
+    (worker / "__pycache__" / "c.pyc").write_text("c", encoding="utf-8")
+    (worker / "uv.lock").write_text("lock", encoding="utf-8")
+
+    names = zipfile.ZipFile(io.BytesIO(base64.b64decode(create_zip_archive(worker)))).namelist()
+
+    assert "worker.py" in names
+    assert not any(".venv-workers" in n for n in names)
+    assert not any("__pycache__" in n for n in names)
+    assert not any(n.endswith(".lock") for n in names)
+
+
+def test_create_zip_archive_nonexistent_dir(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="Package directory not found"):
+        create_zip_archive(tmp_path / "nope")
+
+
+def test_create_zip_archive_produces_valid_zip(tmp_path: Path) -> None:
+    """The output must start with the zip magic so the engine detects Python."""
+    worker = tmp_path / "worker"
+    worker.mkdir()
+    (worker / "worker.py").write_text("main", encoding="utf-8")
+    raw = base64.b64decode(create_zip_archive(worker))
+    assert raw[:2] == b"PK"
+
+
+# Tests for CreateDeploymentRequest host/runtime
+
+
+def test_create_deployment_request_omits_host_runtime_when_unset() -> None:
+    """The default path must not send host/runtime, keeping the payload unchanged."""
+    req = CreateDeploymentRequest(
+        name="s",
+        description="d",
+        toolkits=DeploymentToolkits(
+            bundles=[ToolkitBundle(name="s", version="1", bytes="x", entrypoint="server.py")]
+        ),
+    )
+    dumped = req.model_dump(exclude_none=True)
+    assert "host" not in dumped
+    assert "runtime" not in dumped
+
+
+def test_create_deployment_request_includes_cloudflare_target() -> None:
+    req = CreateDeploymentRequest(
+        name="s",
+        description="d",
+        toolkits=DeploymentToolkits(
+            bundles=[ToolkitBundle(name="s", version="1", bytes="x", entrypoint="worker.py")]
+        ),
+        host="cloudflare",
+        runtime="python",
+    )
+    dumped = req.model_dump(exclude_none=True)
+    assert dumped["host"] == "cloudflare"
+    assert dumped["runtime"] == "python"
+
+
+# Tests for the Cloudflare Python deploy path
+
+
+@patch("arcade_cli.deploy._monitor_deployment_with_logs", return_value=("running", []))
+@patch("arcade_cli.deploy.deploy_server_to_engine")
+@patch("arcade_cli.deploy.server_already_exists", return_value=False)
+@patch("arcade_cli.deploy.find_env_file", return_value=None)
+@patch("arcade_cli.deploy.compute_base_url", return_value="https://engine.example.com")
+@patch("arcade_cli.deploy.verify_server_and_get_metadata")
+@patch("arcade_cli.deploy.validate_and_get_config")
+def test_deploy_server_logic_cloudflare_python(
+    mock_config: MagicMock,
+    mock_verify: MagicMock,
+    mock_base_url: MagicMock,
+    mock_find_env: MagicMock,
+    mock_exists: MagicMock,
+    mock_deploy: MagicMock,
+    mock_monitor: MagicMock,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`runtime=python` zips the worker, skips local validation, and sends
+    host=cloudflare + runtime=python with the .py entrypoint."""
+    mock_config.return_value = MagicMock(user=MagicMock(email="dev@example.com"))
+
+    worker = tmp_path / "worker"
+    (worker / "src").mkdir(parents=True)
+    (worker / "pyproject.toml").write_text("[project]\nname='w'\n", encoding="utf-8")
+    (worker / "src" / "worker.py").write_text(
+        "from workers import WorkerEntrypoint", encoding="utf-8"
+    )
+    (worker / "python_modules").mkdir()
+    (worker / "python_modules" / "six.py").write_text("x = 1", encoding="utf-8")
+    monkeypatch.chdir(worker)
+
+    deploy_server_logic(
+        entrypoint="src/worker.py",
+        skip_validate=False,
+        server_name="my-cf-worker",
+        server_version="1.0.0",
+        secrets="skip",
+        host="api.arcade.dev",
+        port=None,
+        force_tls=False,
+        force_no_tls=False,
+        debug=False,
+        runtime="python",
+    )
+
+    # Local validation must be skipped for a Pyodide worker.
+    mock_verify.assert_not_called()
+
+    # The request must target Cloudflare with a Python runtime and a zip bundle.
+    assert mock_deploy.call_count == 1
+    payload = mock_deploy.call_args.args[1]
+    assert payload["host"] == "cloudflare"
+    assert payload["runtime"] == "python"
+    bundle = payload["toolkits"]["bundles"][0]
+    assert bundle["entrypoint"] == "src/worker.py"
+
+    raw = base64.b64decode(bundle["bytes"])
+    assert raw[:2] == b"PK", "Cloudflare Python worker must be a zip"
+    names = zipfile.ZipFile(io.BytesIO(raw)).namelist()
+    assert "src/worker.py" in names
+    assert "python_modules/six.py" in names
 
 
 # Tests for wait_for_health

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "arcade-mcp"
-version = "1.15.0"
+version = "1.16.0"
 description = "Arcade.dev - Tool Calling platform for Agents"
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
Adds the client side of Cloudflare Python (Pyodide) worker deployment. Tracked by PLT-2154.

## What's here

A new `--runtime python` path on `arcade deploy`:

- **Packages the worker directory as a zip** (`create_zip_archive`) instead of tar.gz. Entries are stored relative to the project root (no top-level dir), so a `--entrypoint src/worker.py` resolves inside the archive. The engine detects a Python worker by the zip container and uploads each file as its own Worker module.
- **Sends `host=cloudflare` + `runtime=python`** on `CreateDeploymentRequest`, with the bundle `entrypoint` set to the `.py` main module.
- **Skips local validation.** A Pyodide `worker.py` (`from workers import WorkerEntrypoint`) can't run under plain CPython, so the usual "start the server and hit `/worker/health`" step would always fail. `--runtime python` therefore requires `--server-name`/`--server-version`, like `--skip-validate`.

The default (`--runtime auto`) is unchanged: tar.gz + local validation + the existing Porter path. `host`/`runtime` are sent only via `model_dump(exclude_none=True)`, so the default payload is byte-for-byte identical.

```bash
# From a Cloudflare Python worker dir (after `pywrangler sync` vendors python_modules/):
arcade deploy --runtime python -e src/worker.py --server-name my-worker --server-version 1.0.0
```

## Why no engine change here

The engine's JSON `/deployments` create path already routes by `host`/`runtime` and detects Python from the bundle's `.py` entrypoint (PLT-2153), so the CLI only needs to produce the right request + zip.

## Testing

`ruff format`/`ruff check`/`mypy` clean; `libs/tests/cli/deploy/test_deploy.py` passes (30 tests). New tests cover the zip archive (relative paths, exclusions, zip magic), the request model (host/runtime omitted by default, included for Cloudflare), and the end-to-end `deploy_server_logic` Python path (zips, skips validation, sends `host=cloudflare`/`runtime=python` with the `.py` entrypoint). Bumped `arcade-mcp` to 1.16.0.

## Out of scope / follow-ups

- Auto-detecting Cloudflare from a `wrangler.jsonc` (explicit `--runtime python` for now).
- Vendoring `python_modules` (the user runs `pywrangler sync` first; the CLI zips what's present).
- A real end-to-end deploy through a live engine + Cloudflare account.

🐕 Written by Kyoto, an AI agent, on Pascal's behalf —

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New deploy routing and packaging path affects engine integration; default deploy behavior is preserved via exclude_none, but misconfigured Cloudflare deploys could fail at runtime without local validation catching issues.
> 
> **Overview**
> Adds **`arcade deploy --runtime python`** for Cloudflare Python (Pyodide) workers, alongside the unchanged default **`auto`** path (tar.gz + local validation).
> 
> For **`python`**, the CLI **builds a zip** with flat paths (via new **`create_zip_archive`**), **skips local health/metadata validation**, and on **create** sends **`host=cloudflare`** and **`runtime=python`** using **`model_dump(exclude_none=True)`** so default deploy payloads stay the same. Tar.gz packaging now shares exclusion logic through **`_is_excluded_archive_path`**.
> 
> **`main.py`** requires **`--server-name`** / **`--server-version`** when using **`--runtime python`** (same as **`--skip-validate`**) and treats **`secrets auto`** as **`skip`** in that case. Tests cover zip packaging, request fields, and the end-to-end Cloudflare deploy path; **`arcade-mcp`** is bumped to **1.16.0**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b11820b91b264e4a6bc366f56b9bec44ff2c0fa5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->