### PR TITLE
chore(arcade-mcp-server): require arcade-core>=4.10.0

### DIFF
--- a/libs/arcade-mcp-server/pyproject.toml
+++ b/libs/arcade-mcp-server/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "arcade-mcp-server"
-version = "1.23.0"
+version = "1.24.0"
 description = "Model Context Protocol (MCP) server framework for Arcade.dev"
 readme = "README.md"
 authors = [{ name = "Arcade.dev" }]
@@ -21,7 +21,7 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "arcade-core>=4.9.0,<5.0.0",
+    "arcade-core>=4.10.0,<5.0.0",
     "arcade-serve>=3.3.0,<4.0.0",
     "arcade-tdk>=3.9.0,<4.0.0",
     "arcadepy>=1.5.0",


### PR DESCRIPTION
## Summary

Bumps `arcade-mcp-server`'s `arcade-core` floor from `>=4.9.0` to `>=4.10.0` (version `1.23.0` → `1.24.0`).

arcade-core 4.10.0 (#880) added the `SURVEY` ServiceDomain. Toolkits that classify tools as `SURVEY` (first up: the Google Forms toolkit in ArcadeAI/monorepo#939) need that value. Bumping the floor here lets those toolkits get arcade-core 4.10.0 **transitively** via arcade-mcp-server — keeping `arcade-core` a transitive dependency, which is the convention across toolkits — rather than each toolkit declaring a direct `arcade-core>=4.10.0` dependency.

## Why

Per review feedback on #939: the toolkit shouldn't carry a direct arcade-core dependency just to reach a new ServiceDomain; the floor belongs on arcade-mcp-server so it stays transitive.

## Change

- `libs/arcade-mcp-server/pyproject.toml`: `arcade-core>=4.9.0,<5.0.0` → `arcade-core>=4.10.0,<5.0.0`; version `1.23.0` → `1.24.0`.

No code change. Minor bump because it tightens a dependency requirement.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging-only dependency floor bump with no code changes; may require environments still pinned to arcade-core 4.9.x to upgrade.
> 
> **Overview**
> **`arcade-mcp-server` 1.24.0** raises the minimum **`arcade-core`** dependency from **`>=4.9.0`** to **`>=4.10.0`**, so consumers that depend on this package get **`arcade-core` 4.10+ transitively** (including the new **`SURVEY`** `ServiceDomain`) without each toolkit declaring a direct **`arcade-core`** floor.
> 
> No runtime or library code changes—only **`libs/arcade-mcp-server/pyproject.toml`** version and dependency pins.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd1f1ecb220fe6cdc5210b1f9373cf4cd5e9273f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->