### PR TITLE
fix: publish arcade-serve _arcade_telemetry module (unbreak arcade-mcp-server 1.24.0)

### DIFF
--- a/libs/arcade-mcp-server/pyproject.toml
+++ b/libs/arcade-mcp-server/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "arcade-mcp-server"
-version = "1.24.0"
+version = "1.24.1"
 description = "Model Context Protocol (MCP) server framework for Arcade.dev"
 readme = "README.md"
 authors = [{ name = "Arcade.dev" }]
@@ -22,7 +22,7 @@ classifiers = [
 requires-python = ">=3.10"
 dependencies = [
     "arcade-core>=4.10.0,<5.0.0",
-    "arcade-serve>=3.3.0,<4.0.0",
+    "arcade-serve>=3.4.0,<4.0.0",
     "arcade-tdk>=3.9.0,<4.0.0",
     "arcadepy>=1.5.0",
     "pydantic>=2.0.0",

--- a/libs/arcade-serve/pyproject.toml
+++ b/libs/arcade-serve/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "arcade-serve"
-version = "3.3.0"
+version = "3.4.0"
 description = "Arcade Serve - Serving infrastructure for Arcade tools and workers"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
## Summary

`arcade-mcp-server` 1.24.0 is broken against every published `arcade-serve`. `import arcade_mcp_server` raises:

```
ImportError: cannot import name '_arcade_telemetry' from 'arcade_serve.fastapi'
```

## Root cause

- #862 added `arcade_serve/fastapi/_arcade_telemetry.py` and `arcade_mcp_server/worker.py` started importing it (`from arcade_serve.fastapi import _arcade_telemetry`).
- But arcade-serve's version stayed at `3.3.0` when that module landed, so the release-on-version-change workflow never cut a new arcade-serve. The **published** `arcade-serve 3.3.0` wheel predates the module and doesn't contain it.
- arcade-mcp-server was then bumped to `1.24.0` (floor `arcade-serve>=3.3.0`) and published — pulling in code that imports a module no published arcade-serve provides.

Net: any consumer that resolves the published packages fails at catalog/framework import. It's latent today only because nothing has adopted 1.24.0 yet.

## Fix

- **arcade-serve `3.3.0` → `3.4.0`** — the module is a new feature; bumping the version lets the release workflow publish the current tree (with `_arcade_telemetry.py`).
- **arcade-mcp-server: floor `arcade-serve>=3.3.0` → `>=3.4.0`, version `1.24.0` → `1.24.1`** — guarantees no resolution can land on the broken stale 3.3.0.

## Verification

Installed the local libs (`arcade-core`, `arcade-serve`, `arcade-mcp-server`) into a clean venv and confirmed `import arcade_mcp_server` and `from arcade_serve.fastapi import _arcade_telemetry` both succeed — i.e. the tree being published here is internally consistent.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-only version and dependency constraint changes; no runtime code in the diff.
> 
> **Overview**
> Repairs a **published package mismatch**: `arcade-mcp-server` 1.24.0 imports `arcade_serve.fastapi._arcade_telemetry`, but the **published** `arcade-serve` 3.3.0 wheel never included that module, so `import arcade_mcp_server` fails with `ImportError`.
> 
> **arcade-serve** is bumped **3.3.0 → 3.4.0** so the release workflow can ship the tree that already contains `_arcade_telemetry`. **arcade-mcp-server** is bumped **1.24.0 → 1.24.1** and its dependency floor is raised from **`arcade-serve>=3.3.0`** to **`>=3.4.0`**, blocking installs that would still resolve the broken 3.3.0 artifact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7e66a7bead49c62be1642443e994196e8beb88c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->