### PR TITLE
fix(arcade-mcp-server): derive engine URL from arcade login coordinator

### DIFF
--- a/libs/arcade-mcp-server/arcade_mcp_server/server.py
+++ b/libs/arcade-mcp-server/arcade_mcp_server/server.py
@@ -23,6 +23,7 @@ from urllib.parse import quote, urlparse, urlunparse
 
 from arcade_core.auth_tokens import get_valid_access_token
 from arcade_core.catalog import MaterializedTool, ToolCatalog
+from arcade_core.constants import PROD_COORDINATOR_HOST, PROD_ENGINE_HOST
 from arcade_core.errors import ErrorKind, ToolInputError
 from arcade_core.executor import ToolExecutor
 from arcade_core.log_extras import build_tool_error_log_extra, build_tool_error_span_attributes
@@ -189,6 +190,41 @@ def _extract_scopes(claims: dict[str, Any]) -> set[str]:
     return set()
 
 
+def _engine_url_from_coordinator(coordinator_url: str | None) -> str | None:
+    """Map an Arcade coordinator URL to its paired engine (API) URL.
+
+    Arcade environments pair a ``cloud.<domain>`` coordinator (used for login)
+    with an ``api.<domain>`` engine (used for tool authorization): production is
+    ``cloud.arcade.dev`` / ``api.arcade.dev``. Given the coordinator URL recorded
+    by ``arcade login``, swap the leading host label to produce the matching
+    engine URL, preserving scheme and port.
+
+    Returns ``None`` when the host does not follow the recognized ``cloud.*``
+    convention (e.g. ``localhost`` or a custom single-host deployment) so callers
+    fall back to their default rather than targeting a guessed URL.
+    """
+    if not coordinator_url:
+        return None
+
+    coordinator_label = PROD_COORDINATOR_HOST.split(".", 1)[0]  # "cloud"
+    engine_label = PROD_ENGINE_HOST.split(".", 1)[0]  # "api"
+
+    parsed = urlparse(coordinator_url)
+    host = parsed.hostname
+    if not host:
+        return None
+
+    labels = host.split(".")
+    if labels[0] != coordinator_label:
+        return None
+
+    labels[0] = engine_label
+    engine_host = ".".join(labels)
+    netloc = f"{engine_host}:{parsed.port}" if parsed.port else engine_host
+    scheme = parsed.scheme or "https"
+    return f"{scheme}://{netloc}"
+
+
 # Methods that require a specific negotiated sub-capability. The dotted
 # notation matches the nested capability structure.
 CAPABILITY_GATED_METHODS: dict[str, str] = {
@@ -294,10 +330,24 @@ class MCPServer:
         self.auth_disabled = auth_disabled or self.settings.arcade.auth_disabled
 
         # Initialize Arcade client
-        # Fallback to API key in ~/.arcade/credentials.yaml if not provided
+        # Fallback to API key in ~/.arcade/credentials.yaml if not provided.
+        # Pass the API URL only when it was explicitly configured (constructor
+        # arg, ARCADE_API_URL, or a non-default settings value); a bare default
+        # is treated as "unset" so the engine URL can be derived from the login
+        # environment when the credentials come from `arcade login`.
+        default_api_url = type(self.settings.arcade).model_fields["api_url"].default
+        configured_api_url = (
+            arcade_api_url
+            or os.environ.get("ARCADE_API_URL")
+            or (
+                self.settings.arcade.api_url
+                if self.settings.arcade.api_url != default_api_url
+                else None
+            )
+        )
         self._init_arcade_client(
             arcade_api_key or self.settings.arcade.api_key,
-            arcade_api_url or self.settings.arcade.api_url,
+            configured_api_url,
         )
 
         # Component managers (passive)
@@ -396,19 +446,63 @@ class MCPServer:
             logger.debug(f"Could not load org/project context from config: {e}")
         return None
 
+    def _coordinator_url_from_config(self) -> str | None:
+        """Return the coordinator URL recorded by ``arcade login``, if any."""
+        try:
+            from arcade_core.config import config
+
+            coordinator_url = config.coordinator_url
+        except Exception as e:
+            logger.debug(f"Could not load coordinator_url from config: {e}")
+            return None
+        return coordinator_url
+
+    def _resolve_arcade_api_url(
+        self, configured_url: str | None, *, credentials_from_login: bool
+    ) -> str:
+        """Resolve the Arcade engine base URL used for runtime authorization.
+
+        An explicitly configured URL always wins. Otherwise, when the credentials
+        were loaded from ``arcade login``, target the engine that pairs with the
+        coordinator the user logged into, so a non-production login (e.g. a
+        staging domain) does not send its token to the production engine and get
+        a 401. Falls back to the production engine when no coordinator is
+        recorded or its host is not a recognized ``cloud.*`` host.
+        """
+        if configured_url:
+            return configured_url
+
+        default_url = f"https://{PROD_ENGINE_HOST}"
+
+        if credentials_from_login:
+            derived = _engine_url_from_coordinator(self._coordinator_url_from_config())
+            if derived:
+                if derived != default_url:
+                    logger.info(
+                        "Derived Arcade engine URL %s from the coordinator recorded by "
+                        "'arcade login'. Set ARCADE_API_URL to override.",
+                        derived,
+                    )
+                return derived
+
+        return default_url
+
     def _init_arcade_client(self, api_key: str | None, api_url: str | None) -> None:
         """Initialize Arcade client for runtime authorization."""
         self.arcade: AsyncArcade | None = None
 
-        if not api_url:
-            api_url = os.environ.get("ARCADE_API_URL", "https://api.arcade.dev")
-
         final_api_key = api_key
+        credentials_from_login = False
 
-        # If no API key provided, try to load from credentials file
+        # If no API key was configured, fall back to the token from `arcade login`.
         if not final_api_key:
             config_api_key, _ = self._load_config_values()
             final_api_key = config_api_key
+            credentials_from_login = final_api_key is not None
+
+        api_url = self._resolve_arcade_api_url(
+            api_url, credentials_from_login=credentials_from_login
+        )
 
         if final_api_key:
             logger.info(f"Using Arcade client with API URL: {api_url}")

--- a/libs/arcade-mcp-server/arcade_mcp_server/server.py
+++ b/libs/arcade-mcp-server/arcade_mcp_server/server.py
@@ -220,7 +220,13 @@ def _engine_url_from_coordinator(coordinator_url: str | None) -> str | None:
 
     labels[0] = engine_label
     engine_host = ".".join(labels)
-    netloc = f"{engine_host}:{parsed.port}" if parsed.port else engine_host
+    try:
+        port = parsed.port
+    except ValueError:
+        # A malformed port (e.g. a hand-edited or corrupt coordinator URL) is a
+        # configuration problem, not a fatal one: fall back to the default.
+        return None
+    netloc = f"{engine_host}:{port}" if port else engine_host
     scheme = parsed.scheme or "https"
     return f"{scheme}://{netloc}"
 

--- a/libs/arcade-mcp-server/pyproject.toml
+++ b/libs/arcade-mcp-server/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "arcade-mcp-server"
-version = "1.25.0"
+version = "1.25.1"
 description = "Model Context Protocol (MCP) server framework for Arcade.dev"
 readme = "README.md"
 authors = [{ name = "Arcade.dev" }]

--- a/libs/tests/arcade_mcp_server/test_arcade_client_url.py
+++ b/libs/tests/arcade_mcp_server/test_arcade_client_url.py
@@ -1,0 +1,173 @@
+"""Tests for how MCPServer resolves the Arcade engine URL for tool authorization.
+
+When credentials come from ``arcade login``, the engine URL must follow the
+environment the user logged into (the coordinator) instead of defaulting to the
+production engine. Otherwise a non-production login sends its token to the
+production engine and authorization fails with a 401.
+"""
+
+import sys
+import types
+from unittest.mock import patch
+
+import pytest
+from arcade_core.catalog import ToolCatalog
+from arcade_mcp_server.server import MCPServer, _engine_url_from_coordinator
+from arcade_mcp_server.settings import MCPSettings
+
+PROD_ENGINE_URL = "https://api.arcade.dev"
+
+
+@pytest.fixture(autouse=True)
+def _clear_arcade_env(monkeypatch):
+    """Ensure the server does not pick up ambient Arcade credentials/URLs."""
+    monkeypatch.delenv("ARCADE_API_KEY", raising=False)
+    monkeypatch.delenv("ARCADE_API_URL", raising=False)
+
+
+def _fake_config_module(coordinator_url: str | None) -> types.ModuleType:
+    """A stand-in for ``arcade_core.config`` exposing a ``config.coordinator_url``.
+
+    Injecting this via ``sys.modules`` lets the real ``_coordinator_url_from_config``
+    run without depending on a real ``~/.arcade/credentials.yaml`` (importing the
+    genuine module raises when logged out).
+    """
+    module = types.ModuleType("arcade_core.config")
+    module.config = types.SimpleNamespace(coordinator_url=coordinator_url)
+    return module
+
+
+def _build_server(
+    *,
+    coordinator_url: str | None,
+    arcade_api_key: str | None = None,
+    arcade_api_url: str | None = None,
+    org_project: tuple[str, str] | None = None,
+) -> MCPServer:
+    """Construct a server with the login config mocked out.
+
+    ``_load_config_values`` returns a non-``arc_`` value to mimic the OAuth
+    access token that ``arcade login`` stores, so the login-derivation path is
+    exercised. The coordinator is supplied through a fake ``arcade_core.config``
+    module so the real coordinator-to-engine resolution runs.
+    """
+    with (
+        patch.object(
+            MCPServer,
+            "_load_config_values",
+            return_value=("login-access-stub", "user@example.com"),
+        ),
+        patch.object(MCPServer, "_load_org_project_context", return_value=org_project),
+        patch.dict(sys.modules, {"arcade_core.config": _fake_config_module(coordinator_url)}),
+    ):
+        return MCPServer(
+            catalog=ToolCatalog(),
+            settings=MCPSettings(),
+            arcade_api_key=arcade_api_key,
+            arcade_api_url=arcade_api_url,
+        )
+
+
+def _base_url(server: MCPServer) -> str:
+    assert server.arcade is not None
+    return str(server.arcade.base_url).rstrip("/")
+
+
+class TestEngineUrlFromCoordinator:
+    """The pure coordinator -> engine host mapping."""
+
+    @pytest.mark.parametrize(
+        ("coordinator", "expected"),
+        [
+            ("https://cloud.arcade.dev", "https://api.arcade.dev"),
+            ("https://cloud.example.dev", "https://api.example.dev"),
+            ("https://cloud.staging.example.com", "https://api.staging.example.com"),
+            ("https://cloud.example.dev:8443", "https://api.example.dev:8443"),
+        ],
+    )
+    def test_maps_cloud_host_to_api_host(self, coordinator, expected):
+        assert _engine_url_from_coordinator(coordinator) == expected
+
+    @pytest.mark.parametrize(
+        "coordinator",
+        [
+            None,
+            "",
+            "http://localhost:8000",
+            "https://gateway.example.dev",  # first label is not "cloud"
+            "https://",  # truthy but no host
+        ],
+    )
+    def test_returns_none_for_unrecognized_hosts(self, coordinator):
+        assert _engine_url_from_coordinator(coordinator) is None
+
+
+class TestArcadeClientUrlResolution:
+    """End-to-end resolution through MCPServer construction."""
+
+    def test_login_into_non_prod_targets_matching_engine(self):
+        """The reported bug: a non-prod login must not hit the prod engine."""
+        server = _build_server(coordinator_url="https://cloud.example.dev")
+        assert _base_url(server) == "https://api.example.dev"
+
+    def test_prod_login_targets_prod_engine(self):
+        server = _build_server(coordinator_url="https://cloud.arcade.dev")
+        assert _base_url(server) == PROD_ENGINE_URL
+
+    def test_missing_coordinator_falls_back_to_prod(self):
+        server = _build_server(coordinator_url=None)
+        assert _base_url(server) == PROD_ENGINE_URL
+
+    def test_localhost_coordinator_falls_back_to_prod(self):
+        server = _build_server(coordinator_url="http://localhost:8000")
+        assert _base_url(server) == PROD_ENGINE_URL
+
+    def test_explicit_api_url_arg_wins_over_derivation(self):
+        server = _build_server(
+            coordinator_url="https://cloud.example.dev",
+            arcade_api_url="https://api.override.dev",
+        )
+        assert _base_url(server) == "https://api.override.dev"
+
+    def test_env_api_url_wins_over_derivation(self, monkeypatch):
+        monkeypatch.setenv("ARCADE_API_URL", "https://api.fromenv.dev")
+        server = _build_server(coordinator_url="https://cloud.example.dev")
+        assert _base_url(server) == "https://api.fromenv.dev"
+
+    def test_explicit_service_key_does_not_derive_from_login_config(self):
+        """An explicit API key means the caller owns the key/URL pairing.
+
+        A stale login coordinator in the config must not silently redirect a
+        server that was handed its own service key.
+        """
+        server = _build_server(
+            coordinator_url="https://cloud.example.dev",
+            arcade_api_key="arc_service_key",
+        )
+        assert _base_url(server) == PROD_ENGINE_URL
+
+    def test_coordinator_url_read_from_config(self):
+        server = _build_server(coordinator_url="https://cloud.example.dev")
+        with patch.dict(
+            sys.modules,
+            {"arcade_core.config": _fake_config_module("https://cloud.example.dev")},
+        ):
+            assert server._coordinator_url_from_config() == "https://cloud.example.dev"
+
+    def test_coordinator_url_returns_none_when_config_unavailable(self):
+        """A missing/broken config must degrade to ``None``, not raise."""
+        server = _build_server(coordinator_url="https://cloud.example.dev")
+        # A module with no ``config`` attribute makes the import inside the
+        # method raise, which must be swallowed.
+        broken = types.ModuleType("arcade_core.config")
+        with patch.dict(sys.modules, {"arcade_core.config": broken}):
+            assert server._coordinator_url_from_config() is None
+
+    def test_derived_url_applies_with_org_scoped_client(self):
+        """A login token carries org/project context; the org-scoped client
+        rewrites paths but the derived engine host must still be the base URL."""
+        server = _build_server(
+            coordinator_url="https://cloud.example.dev",
+            org_project=("org_1", "project_1"),
+        )
+        assert _base_url(server) == "https://api.example.dev"

--- a/libs/tests/arcade_mcp_server/test_arcade_client_url.py
+++ b/libs/tests/arcade_mcp_server/test_arcade_client_url.py
@@ -88,6 +88,12 @@ class TestEngineUrlFromCoordinator:
     def test_maps_cloud_host_to_api_host(self, coordinator, expected):
         assert _engine_url_from_coordinator(coordinator) == expected
 
+    def test_malformed_port_returns_none(self):
+        """A cloud host with an invalid port must not raise; ``.port`` raises
+        ValueError on a non-numeric/out-of-range port, and that must degrade to
+        the default rather than crashing resolution."""
+        assert _engine_url_from_coordinator("https://cloud.staging.example.com:bad") is None
+
     @pytest.mark.parametrize(
         "coordinator",
         [
@@ -120,6 +126,11 @@ class TestArcadeClientUrlResolution:
 
     def test_localhost_coordinator_falls_back_to_prod(self):
         server = _build_server(coordinator_url="http://localhost:8000")
+        assert _base_url(server) == PROD_ENGINE_URL
+
+    def test_malformed_coordinator_port_falls_back_to_prod(self):
+        """A corrupt coordinator URL in the config must not fail construction."""
+        server = _build_server(coordinator_url="https://cloud.staging.example.com:bad")
         assert _base_url(server) == PROD_ENGINE_URL
 
     def test_explicit_api_url_arg_wins_over_derivation(self):


### PR DESCRIPTION
## Summary

A local server running a tool that requires auth loads its OAuth token from the coordinator recorded by `arcade login`, but the engine `base_url` used for authorization always defaulted to the production `api.arcade.dev`. If you logged into a non-production environment (e.g. a staging domain), the server sent your staging token to the production engine and authorization failed with `401 invalid_authorization` / "Invalid API credentials". Login succeeds (it hits the coordinator, which is staging), so the failure is confusing.

This resolves the engine URL from the stored `coordinator_url` when the credentials come from `arcade login`, so the token and the engine target the same environment.

Resolves: <!-- no ticket -->

## Design decisions

Resolution precedence in `_resolve_arcade_api_url`:

1. An explicitly configured URL wins: `arcade_api_url` constructor arg, `ARCADE_API_URL` env, or a non-default `MCPSettings` value.
2. Otherwise, when the token was loaded from `arcade login`, derive the engine URL from `config.coordinator_url` by swapping the leading host label (`cloud.<domain>` to `api.<domain>`), preserving scheme and port. This mirrors the existing `PROD_COORDINATOR_HOST` / `PROD_ENGINE_HOST` convention.
3. Fall back to the production engine.

Deliberate guardrails:

- **Derivation only fires for `arcade login` credentials.** If an explicit `ARCADE_API_KEY` is set, the caller owns the key/URL pairing and a stale login coordinator must not silently redirect them.
- **Only maps recognized `cloud.*` hosts.** `localhost` and custom single-host deployments return `None` and fall back to the production default rather than targeting a guessed URL.
- **Production is unchanged.** `cloud.arcade.dev` derives `api.arcade.dev`, identical to today's default (and no log line is emitted in that case).

Alternative considered and rejected: deriving the default at the `ArcadeSettings` layer. That would push config-file IO into an import-time settings singleton and affect the HTTP/stdio startup banners; keeping the logic in the runtime auth client localizes it next to where the token and org/project context are already loaded from the same config.

resolves https://linear.app/arcadedev/issue/TOO-1456/auto-detect-non-prod-domain-when-running-local-arcade-mcp-server

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes runtime Arcade client `base_url` selection for login-based local dev; behavior is guarded by explicit URL/key overrides and extensive tests, but mis-derivation could still break auth in edge deployments.
> 
> **Overview**
> Fixes **401 invalid authorization** when running a local MCP server after `arcade login` against a non-production coordinator: the OAuth token came from staging but tool auth always hit production `api.arcade.dev`.
> 
> **Engine URL resolution** now runs in `MCPServer` when credentials are loaded from login (not when an explicit `arc_*` service key is set). Explicit `arcade_api_url`, `ARCADE_API_URL`, or a non-default settings `api_url` still win; otherwise the server reads `config.coordinator_url` and maps `cloud.<domain>` → `api.<domain>` (scheme/port preserved). Unrecognized hosts (`localhost`, non-`cloud.*`) fall back to the production engine. Default settings `api_url` is treated as unset so derivation can apply.
> 
> Adds `_engine_url_from_coordinator`, `_coordinator_url_from_config`, and `_resolve_arcade_api_url`, plus tests in `test_arcade_client_url.py`. Patch release **1.25.1**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6940cd283ae8ff3c3d68c69521df5a06c42b9170. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->