### PR TITLE
[PLT-2528] fix(arcade-serve): move OTel deps to the 1.38 generation

### DIFF
--- a/libs/arcade-serve/arcade_serve/fastapi/telemetry.py
+++ b/libs/arcade-serve/arcade_serve/fastapi/telemetry.py
@@ -29,7 +29,7 @@ from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
 from opentelemetry.sdk.metrics import MeterProvider
 from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
 from opentelemetry.sdk.resources import Resource
-from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace import ReadableSpan, TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
 from opentelemetry.semconv._incubating.attributes import deployment_attributes
 from opentelemetry.semconv.attributes import service_attributes
@@ -84,12 +84,11 @@ class OTELHandler:
                 FastAPIInstrumentor().instrument_app(
                     app, excluded_urls=EXCLUDED_URLS, exclude_spans=EXCLUDED_SPANS
                 )
-                # Pass tracer_provider=None so instrumentors pick up the global
-                # provider set by arcade-telemetry.
-                HTTPXClientInstrumentor()._instrument(tracer_provider=None)
-                # aiohttp's instrumentor stub types tracer_provider as non-optional.
-                AioHttpClientInstrumentor()._instrument(tracer_provider=None)  # type: ignore[arg-type]
-                RequestsInstrumentor()._instrument(tracer_provider=None)
+                # Omit tracer_provider so the instrumentors resolve the global
+                # provider set by arcade-telemetry (the API's documented default).
+                HTTPXClientInstrumentor()._instrument()
+                AioHttpClientInstrumentor()._instrument()
+                RequestsInstrumentor()._instrument()
                 return
             # init_providers returned None (arcade-telemetry import race or
             # internal opt-out) — fall through to the in-house OTLP setup so
@@ -112,11 +111,14 @@ class OTELHandler:
         FastAPIInstrumentor().instrument_app(
             app, excluded_urls=EXCLUDED_URLS, exclude_spans=EXCLUDED_SPANS
         )
-        HTTPXClientInstrumentor()._instrument(tracer_provider=self._tracer_provider)
-        # aiohttp's instrumentor stub wants a non-optional api TracerProvider; the SDK
-        # provider set just above is compatible at runtime.
-        AioHttpClientInstrumentor()._instrument(tracer_provider=self._tracer_provider)  # type: ignore[arg-type]
-        RequestsInstrumentor()._instrument(tracer_provider=self._tracer_provider)
+        # _init_tracer set this just above; narrow away the Optional so the typed
+        # aiohttp instrumentor kwargs accept it.
+        tracer_provider = self._tracer_provider
+        if tracer_provider is None:
+            raise RuntimeError("tracer provider was not initialized")
+        HTTPXClientInstrumentor()._instrument(tracer_provider=tracer_provider)
+        AioHttpClientInstrumentor()._instrument(tracer_provider=tracer_provider)
+        RequestsInstrumentor()._instrument(tracer_provider=tracer_provider)
 
     def _init_tracer(self) -> None:
         self._tracer_provider = TracerProvider(resource=self.resource)
@@ -125,10 +127,13 @@ class OTELHandler:
         # Create an OTLP exporter
         self._tracer_span_exporter = OTLPSpanExporter()
 
+        # An SDK tracer provider is active (set just above), so start_span returns an
+        # SDK span; narrow to the ReadableSpan the exporter consumes.
+        ping_span = trace.get_tracer(__name__).start_span("ping")
+        if not isinstance(ping_span, ReadableSpan):
+            raise TypeError("expected an SDK ReadableSpan for the connectivity probe")
         try:
-            # start_span is typed as the API Span; at runtime it is an SDK span, which is
-            # the ReadableSpan the exporter consumes.
-            self._tracer_span_exporter.export([trace.get_tracer(__name__).start_span("ping")])  # type: ignore[list-item]
+            self._tracer_span_exporter.export([ping_span])
         except Exception as e:
             raise ConnectionError(
                 f"Could not connect to OpenTelemetry Tracer endpoint. Check OpenTelemetry configuration or disable: {e}"

--- a/libs/arcade-serve/arcade_serve/fastapi/telemetry.py
+++ b/libs/arcade-serve/arcade_serve/fastapi/telemetry.py
@@ -87,7 +87,8 @@ class OTELHandler:
                 # Pass tracer_provider=None so instrumentors pick up the global
                 # provider set by arcade-telemetry.
                 HTTPXClientInstrumentor()._instrument(tracer_provider=None)
-                AioHttpClientInstrumentor()._instrument(tracer_provider=None)
+                # aiohttp's instrumentor stub types tracer_provider as non-optional.
+                AioHttpClientInstrumentor()._instrument(tracer_provider=None)  # type: ignore[arg-type]
                 RequestsInstrumentor()._instrument(tracer_provider=None)
                 return
             # init_providers returned None (arcade-telemetry import race or
@@ -112,7 +113,9 @@ class OTELHandler:
             app, excluded_urls=EXCLUDED_URLS, exclude_spans=EXCLUDED_SPANS
         )
         HTTPXClientInstrumentor()._instrument(tracer_provider=self._tracer_provider)
-        AioHttpClientInstrumentor()._instrument(tracer_provider=self._tracer_provider)
+        # aiohttp's instrumentor stub wants a non-optional api TracerProvider; the SDK
+        # provider set just above is compatible at runtime.
+        AioHttpClientInstrumentor()._instrument(tracer_provider=self._tracer_provider)  # type: ignore[arg-type]
         RequestsInstrumentor()._instrument(tracer_provider=self._tracer_provider)
 
     def _init_tracer(self) -> None:
@@ -123,7 +126,9 @@ class OTELHandler:
         self._tracer_span_exporter = OTLPSpanExporter()
 
         try:
-            self._tracer_span_exporter.export([trace.get_tracer(__name__).start_span("ping")])
+            # start_span is typed as the API Span; at runtime it is an SDK span, which is
+            # the ReadableSpan the exporter consumes.
+            self._tracer_span_exporter.export([trace.get_tracer(__name__).start_span("ping")])  # type: ignore[list-item]
         except Exception as e:
             raise ConnectionError(
                 f"Could not connect to OpenTelemetry Tracer endpoint. Check OpenTelemetry configuration or disable: {e}"

--- a/libs/arcade-serve/pyproject.toml
+++ b/libs/arcade-serve/pyproject.toml
@@ -24,12 +24,12 @@ dependencies = [
     "uvicorn>=0.30.0",
     "watchfiles>=1.0.5",
     "sse-starlette>=2.0.0",
-    "opentelemetry-instrumentation-fastapi==0.49b2",
-    "opentelemetry-exporter-otlp-proto-http==1.28.2",
-    "opentelemetry-exporter-otlp-proto-common==1.28.2",
-    "opentelemetry-instrumentation-httpx==0.49b2",
-    "opentelemetry-instrumentation-aiohttp-client==0.49b2",
-    "opentelemetry-instrumentation-requests==0.49b2",
+    "opentelemetry-instrumentation-fastapi>=0.59b0",
+    "opentelemetry-exporter-otlp-proto-http>=1.38.0",
+    "opentelemetry-exporter-otlp-proto-common>=1.38.0",
+    "opentelemetry-instrumentation-httpx>=0.59b0",
+    "opentelemetry-instrumentation-aiohttp-client>=0.59b0",
+    "opentelemetry-instrumentation-requests>=0.59b0",
     "aiohttp>=3.0.0,<4.0.0",
 ]
 

--- a/libs/tests/worker/test_arcade_telemetry_bridge.py
+++ b/libs/tests/worker/test_arcade_telemetry_bridge.py
@@ -133,14 +133,14 @@ def test_otel_handler_delegates_when_arcade_telemetry_present(
     assert kwargs["service_name"] == "worker"
     assert kwargs["version"] == "9.9.9"
 
-    # FastAPI / HTTPX / aiohttp / Requests instrumentors still run, but with
-    # tracer_provider=None so they pick up arcade-telemetry's globals.
+    # FastAPI / HTTPX / aiohttp / Requests instrumentors still run, with
+    # tracer_provider omitted so they pick up arcade-telemetry's global providers.
     mock_fastapi_instrumentor.return_value.instrument_app.assert_called_once_with(
         app, excluded_urls="/worker/health", exclude_spans=["send", "receive"]
     )
-    mock_httpx.return_value._instrument.assert_called_once_with(tracer_provider=None)
-    mock_aiohttp.return_value._instrument.assert_called_once_with(tracer_provider=None)
-    mock_requests.return_value._instrument.assert_called_once_with(tracer_provider=None)
+    mock_httpx.return_value._instrument.assert_called_once_with()
+    mock_aiohttp.return_value._instrument.assert_called_once_with()
+    mock_requests.return_value._instrument.assert_called_once_with()
 
     # Shutdown delegates to the arcade-telemetry handle and does NOT touch the
     # OTLP exporter shutdown path (which would crash since exporters were never


### PR DESCRIPTION
## What

Move `arcade-serve`'s pinned OpenTelemetry dependencies from the **1.28.2 / 0.49b2** generation to **1.38** (`>=1.38.0` exporters, `>=0.59b0` instrumentation).

```diff
-    "opentelemetry-instrumentation-fastapi==0.49b2"
-    "opentelemetry-exporter-otlp-proto-http==1.28.2"
-    "opentelemetry-exporter-otlp-proto-common==1.28.2"
-    "opentelemetry-instrumentation-httpx==0.49b2"
-    "opentelemetry-instrumentation-aiohttp-client==0.49b2"
-    "opentelemetry-instrumentation-requests==0.49b2"
+    "opentelemetry-instrumentation-fastapi>=0.59b0"
+    "opentelemetry-exporter-otlp-proto-http>=1.38.0"
+    "opentelemetry-exporter-otlp-proto-common>=1.38.0"
+    "opentelemetry-instrumentation-httpx>=0.59b0"
+    "opentelemetry-instrumentation-aiohttp-client>=0.59b0"
+    "opentelemetry-instrumentation-requests>=0.59b0"
```

## Why

The exact 1.28.2 pin makes `arcade-serve` **unsatisfiable** in the Arcade worker *supervisor* image (one isolated venv per toolkit version) for two independent reasons — the image cannot build at all:

1. **protobuf CVE floor** — the worker floors `protobuf>=6.31.1` (CVE-2025-4565), but `arcade-serve` → `opentelemetry-proto==1.28.2` → `protobuf>=5.0,<6.0`. Unsatisfiable.
2. **arcade-telemetry** — `arcade-telemetry` (and the Arcade coordinator) require `opentelemetry-exporter-otlp-proto-http>=1.38.0`, installed alongside `arcade_mcp_server` in the supervisor venv.

Both resolve once `arcade-serve` moves to the 1.38 generation (which supports protobuf 6/7 and matches `arcade-telemetry`).

## Safety

Version bump plus **type-only** adjustments in `arcade_serve/fastapi/telemetry.py` — no runtime behavior change (verified against `opentelemetry` 1.43 / instrumentation 0.64b). The newer stubs tightened `AioHttpClientInstrumentor._instrument` (now `**kwargs: Unpack[InstrumentKwargs]`, a `TypedDict`; httpx/requests still use `**kwargs: Any`), which surfaced three pre-existing type mismatches. Each is fixed properly — **no `# type: ignore`**:

- **Omit `tracer_provider`** to use the global provider (the API's documented default when the key is absent; runtime-identical to the previous explicit `None`, which the impl coerced via `kwargs.get(...)`).
- **Narrow the Optional** `self._tracer_provider` with an explicit `None`-check before instrumenting (`_init_tracer` sets it just above).
- **Narrow the ping span** with `isinstance(..., ReadableSpan)` — with the SDK provider active, `start_span` returns an SDK span (verified `True` at runtime), which is what the exporter consumes.

The OTel APIs `arcade-serve` imports are otherwise stable across 1.28→1.38 (`_log_exporter.OTLPLogExporter`, `.metric_exporter`, `.trace_exporter`; `sdk._logs`/`.metrics`/`.trace`/`.resources`; `_logs`, `semconv.*`, `instrumentation.*`). `mypy` + `ruff` clean.

## Validation

Built the full **115-toolkit** Arcade worker supervisor image with this change applied:
- **Builds green** — the supervisor venv resolves (previously failed here), all toolkit venvs build.
- **Boots and serves** — `GET /worker/health → 200`, `GET /worker/tools → 200` under the resolved coordinated set **OpenTelemetry 1.44 / instrumentation 0.64b0 / protobuf 7.x** (protobuf 7 satisfies the CVE floor).
- arcade-serve's telemetry setup imports resolve and run under 1.44.

Tracked in PLT-2528; unblocks the Arcade worker supervisor (PLT-2525).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency floor bump plus typing guards in telemetry setup; behavior is documented as unchanged and validated on a full supervisor image build.
> 
> **Overview**
> **Bumps `arcade-serve` OpenTelemetry packages** from pinned **1.28.2 / 0.49b2** to **`>=1.38.0` exporters** and **`>=0.59b0` instrumentation**, so the library resolves alongside `arcade-telemetry` and protobuf 6+ in the worker supervisor image.
> 
> In `telemetry.py`, **HTTP client instrumentors** on the arcade-telemetry path now call `_instrument()` **without** passing `tracer_provider` (same global-provider behavior as before). On the in-house OTLP path, the code **narrows** `self._tracer_provider` before passing it to instrumentors and **validates** the connectivity-probe span as `ReadableSpan` before export—changes driven by stricter OTel 1.38+ typing, not new behavior.
> 
> Tests expect `_instrument()` with no kwargs when arcade-telemetry is active.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 485e4b89a46587540e0b14a91ad16317ad83ebbc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

